### PR TITLE
Disable tracing when making calls to tcollector

### DIFF
--- a/context_builder.go
+++ b/context_builder.go
@@ -38,6 +38,9 @@ type ContextBuilder struct {
 	// CallOptions are TChannel call options for the specific call.
 	CallOptions *CallOptions
 
+	// TracingDisabled disables trace reporting for calls using this context.
+	TracingDisabled bool
+
 	// Hidden fields: we do not want users outside of tchannel to set these.
 	incomingCall IncomingCall
 	span         *Span
@@ -91,6 +94,12 @@ func (cb *ContextBuilder) SetFormat(f Format) *ContextBuilder {
 	return cb
 }
 
+// DisableTracing disables tracing.
+func (cb *ContextBuilder) DisableTracing() *ContextBuilder {
+	cb.TracingDisabled = true
+	return cb
+}
+
 // SetIncomingCallForTest sets an IncomingCall in the context.
 // This should only be used in unit tests.
 func (cb *ContextBuilder) SetIncomingCallForTest(call IncomingCall) *ContextBuilder {
@@ -118,6 +127,10 @@ func (cb *ContextBuilder) Build() (ContextWithHeaders, context.CancelFunc) {
 	timeout := cb.Timeout
 	if timeout == 0 {
 		timeout = defaultTimeout
+	}
+
+	if cb.TracingDisabled {
+		cb.span.EnableTracing(false)
 	}
 
 	params := &tchannelCtxParams{

--- a/context_builder.go
+++ b/context_builder.go
@@ -47,6 +47,7 @@ type ContextBuilder struct {
 func NewContextBuilder(timeout time.Duration) *ContextBuilder {
 	return &ContextBuilder{
 		Timeout: timeout,
+		span:    NewRootSpan(),
 	}
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -47,6 +47,15 @@ func TestNewContextBuilderHasSpan(t *testing.T) {
 	defer cancel()
 
 	assert.NotNil(t, CurrentSpan(ctx), "NewContext should contain span")
+	assert.True(t, CurrentSpan(ctx).TracingEnabled(), "Tracing should be enabled")
+}
+
+func TestNewContextBuilderDisableTracing(t *testing.T) {
+	ctx, cancel := NewContextBuilder(time.Second).
+		DisableTracing().Build()
+	defer cancel()
+
+	assert.False(t, CurrentSpan(ctx).TracingEnabled(), "Tracing should be disabled")
 }
 
 func TestShardKeyPropagates(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -42,6 +42,13 @@ func TestWrapContextForTest(t *testing.T) {
 	assert.Equal(t, call, CurrentCall(actual), "Incorrect call object returned.")
 }
 
+func TestNewContextBuilderHasSpan(t *testing.T) {
+	ctx, cancel := NewContextBuilder(time.Second).Build()
+	defer cancel()
+
+	assert.NotNil(t, CurrentSpan(ctx), "NewContext should contain span")
+}
+
 func TestShardKeyPropagates(t *testing.T) {
 	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		peerInfo := ch.PeerInfo()

--- a/trace/zipkin_tracereporter.go
+++ b/trace/zipkin_tracereporter.go
@@ -89,6 +89,7 @@ func (r *ZipkinTraceReporter) Report(
 
 func (r *ZipkinTraceReporter) zipkinReport(data *zipkinData) error {
 	ctx, cancel := tc.NewContextBuilder(time.Second).
+		DisableTracing().
 		SetShardKey(base64Encode(data.Span.TraceID())).Build()
 	defer cancel()
 

--- a/tracereporter.go
+++ b/tracereporter.go
@@ -105,6 +105,7 @@ type Annotations struct {
 	binaryAnnotations []BinaryAnnotation
 }
 
+// SetOperation sets the operation being called.
 func (as *Annotations) SetOperation(operation string) {
 	as.endpoint.Operation = operation
 }


### PR DESCRIPTION
Add methods to ContextBuilder to disable tracing, and use those in the ZipKin trace reporter.

r @junchaowu 