### PR TITLE
Fix thrift client/servers when service A extends a base service

### DIFF
--- a/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
+++ b/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
@@ -32,24 +32,26 @@ type TChanBaseService interface {
 type tchanAdminClient struct {
 	tchanBaseServiceClient
 
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanAdminClient(client thrift.TChanClient) *tchanAdminClient {
+func newTChanAdminClient(thriftService string, client thrift.TChanClient) *tchanAdminClient {
 	return &tchanAdminClient{
-		*newTChanBaseServiceClient(client),
+		*newTChanBaseServiceClient(thriftService, client),
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanAdminClient(client thrift.TChanClient) TChanAdmin {
-	return newTChanAdminClient(client)
+	return newTChanAdminClient("Admin", client)
 }
 
 func (c *tchanAdminClient) ClearAll(ctx thrift.Context) error {
 	var resp AdminClearAllResult
 	args := AdminClearAllArgs{}
-	success, err := c.client.Call(ctx, "Admin", "clearAll", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "clearAll", &args, &resp)
 	if err == nil && !success {
 		if e := resp.NotAuthorized; e != nil {
 			err = e
@@ -92,6 +94,10 @@ func (s *tchanAdminServer) Handle(ctx thrift.Context, methodName string, protoco
 	switch methodName {
 	case "clearAll":
 		return s.handleClearAll(ctx, protocol)
+
+	case "HealthCheck":
+		return s.handleHealthCheck(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}
@@ -124,18 +130,20 @@ func (s *tchanAdminServer) handleClearAll(ctx thrift.Context, protocol athrift.T
 type tchanKeyValueClient struct {
 	tchanBaseServiceClient
 
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanKeyValueClient(client thrift.TChanClient) *tchanKeyValueClient {
+func newTChanKeyValueClient(thriftService string, client thrift.TChanClient) *tchanKeyValueClient {
 	return &tchanKeyValueClient{
-		*newTChanBaseServiceClient(client),
+		*newTChanBaseServiceClient(thriftService, client),
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanKeyValueClient(client thrift.TChanClient) TChanKeyValue {
-	return newTChanKeyValueClient(client)
+	return newTChanKeyValueClient("KeyValue", client)
 }
 
 func (c *tchanKeyValueClient) Get(ctx thrift.Context, key string) (string, error) {
@@ -143,7 +151,7 @@ func (c *tchanKeyValueClient) Get(ctx thrift.Context, key string) (string, error
 	args := KeyValueGetArgs{
 		Key: key,
 	}
-	success, err := c.client.Call(ctx, "KeyValue", "Get", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Get", &args, &resp)
 	if err == nil && !success {
 		if e := resp.NotFound; e != nil {
 			err = e
@@ -162,7 +170,7 @@ func (c *tchanKeyValueClient) Set(ctx thrift.Context, key string, value string) 
 		Key:   key,
 		Value: value,
 	}
-	success, err := c.client.Call(ctx, "KeyValue", "Set", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Set", &args, &resp)
 	if err == nil && !success {
 		if e := resp.InvalidKey; e != nil {
 			err = e
@@ -208,6 +216,10 @@ func (s *tchanKeyValueServer) Handle(ctx thrift.Context, methodName string, prot
 		return s.handleGet(ctx, protocol)
 	case "Set":
 		return s.handleSet(ctx, protocol)
+
+	case "HealthCheck":
+		return s.handleHealthCheck(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}
@@ -265,23 +277,25 @@ func (s *tchanKeyValueServer) handleSet(ctx thrift.Context, protocol athrift.TPr
 }
 
 type tchanBaseServiceClient struct {
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanBaseServiceClient(client thrift.TChanClient) *tchanBaseServiceClient {
+func newTChanBaseServiceClient(thriftService string, client thrift.TChanClient) *tchanBaseServiceClient {
 	return &tchanBaseServiceClient{
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanBaseServiceClient(client thrift.TChanClient) TChanBaseService {
-	return newTChanBaseServiceClient(client)
+	return newTChanBaseServiceClient("baseService", client)
 }
 
 func (c *tchanBaseServiceClient) HealthCheck(ctx thrift.Context) (string, error) {
 	var resp BaseServiceHealthCheckResult
 	args := BaseServiceHealthCheckArgs{}
-	success, err := c.client.Call(ctx, "baseService", "HealthCheck", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "HealthCheck", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -316,6 +330,7 @@ func (s *tchanBaseServiceServer) Handle(ctx thrift.Context, methodName string, p
 	switch methodName {
 	case "HealthCheck":
 		return s.handleHealthCheck(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}

--- a/examples/thrift/gen-go/test/base.go
+++ b/examples/thrift/gen-go/test/base.go
@@ -14,11 +14,11 @@ var _ = thrift.ZERO
 var _ = fmt.Printf
 var _ = bytes.Equal
 
-type Second interface {
-	Test() (err error)
+type Base interface {
+	BaseCall() (err error)
 }
 
-type SecondClient struct {
+type BaseClient struct {
 	Transport       thrift.TTransport
 	ProtocolFactory thrift.TProtocolFactory
 	InputProtocol   thrift.TProtocol
@@ -26,8 +26,8 @@ type SecondClient struct {
 	SeqId           int32
 }
 
-func NewSecondClientFactory(t thrift.TTransport, f thrift.TProtocolFactory) *SecondClient {
-	return &SecondClient{Transport: t,
+func NewBaseClientFactory(t thrift.TTransport, f thrift.TProtocolFactory) *BaseClient {
+	return &BaseClient{Transport: t,
 		ProtocolFactory: f,
 		InputProtocol:   f.GetProtocol(t),
 		OutputProtocol:  f.GetProtocol(t),
@@ -35,8 +35,8 @@ func NewSecondClientFactory(t thrift.TTransport, f thrift.TProtocolFactory) *Sec
 	}
 }
 
-func NewSecondClientProtocol(t thrift.TTransport, iprot thrift.TProtocol, oprot thrift.TProtocol) *SecondClient {
-	return &SecondClient{Transport: t,
+func NewBaseClientProtocol(t thrift.TTransport, iprot thrift.TProtocol, oprot thrift.TProtocol) *BaseClient {
+	return &BaseClient{Transport: t,
 		ProtocolFactory: nil,
 		InputProtocol:   iprot,
 		OutputProtocol:  oprot,
@@ -44,24 +44,24 @@ func NewSecondClientProtocol(t thrift.TTransport, iprot thrift.TProtocol, oprot 
 	}
 }
 
-func (p *SecondClient) Test() (err error) {
-	if err = p.sendTest(); err != nil {
+func (p *BaseClient) BaseCall() (err error) {
+	if err = p.sendBaseCall(); err != nil {
 		return
 	}
-	return p.recvTest()
+	return p.recvBaseCall()
 }
 
-func (p *SecondClient) sendTest() (err error) {
+func (p *BaseClient) sendBaseCall() (err error) {
 	oprot := p.OutputProtocol
 	if oprot == nil {
 		oprot = p.ProtocolFactory.GetProtocol(p.Transport)
 		p.OutputProtocol = oprot
 	}
 	p.SeqId++
-	if err = oprot.WriteMessageBegin("Test", thrift.CALL, p.SeqId); err != nil {
+	if err = oprot.WriteMessageBegin("BaseCall", thrift.CALL, p.SeqId); err != nil {
 		return
 	}
-	args := SecondTestArgs{}
+	args := BaseBaseCallArgs{}
 	if err = args.Write(oprot); err != nil {
 		return
 	}
@@ -71,7 +71,7 @@ func (p *SecondClient) sendTest() (err error) {
 	return oprot.Flush()
 }
 
-func (p *SecondClient) recvTest() (err error) {
+func (p *BaseClient) recvBaseCall() (err error) {
 	iprot := p.InputProtocol
 	if iprot == nil {
 		iprot = p.ProtocolFactory.GetProtocol(p.Transport)
@@ -81,32 +81,32 @@ func (p *SecondClient) recvTest() (err error) {
 	if err != nil {
 		return
 	}
-	if method != "Test" {
-		err = thrift.NewTApplicationException(thrift.WRONG_METHOD_NAME, "Test failed: wrong method name")
+	if method != "BaseCall" {
+		err = thrift.NewTApplicationException(thrift.WRONG_METHOD_NAME, "BaseCall failed: wrong method name")
 		return
 	}
 	if p.SeqId != seqId {
-		err = thrift.NewTApplicationException(thrift.BAD_SEQUENCE_ID, "Test failed: out of sequence response")
+		err = thrift.NewTApplicationException(thrift.BAD_SEQUENCE_ID, "BaseCall failed: out of sequence response")
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error12 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error13 error
-		error13, err = error12.Read(iprot)
+		error0 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error1 error
+		error1, err = error0.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error13
+		err = error1
 		return
 	}
 	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(thrift.INVALID_MESSAGE_TYPE_EXCEPTION, "Test failed: invalid message type")
+		err = thrift.NewTApplicationException(thrift.INVALID_MESSAGE_TYPE_EXCEPTION, "BaseCall failed: invalid message type")
 		return
 	}
-	result := SecondTestResult{}
+	result := BaseBaseCallResult{}
 	if err = result.Read(iprot); err != nil {
 		return
 	}
@@ -116,32 +116,32 @@ func (p *SecondClient) recvTest() (err error) {
 	return
 }
 
-type SecondProcessor struct {
+type BaseProcessor struct {
 	processorMap map[string]thrift.TProcessorFunction
-	handler      Second
+	handler      Base
 }
 
-func (p *SecondProcessor) AddToProcessorMap(key string, processor thrift.TProcessorFunction) {
+func (p *BaseProcessor) AddToProcessorMap(key string, processor thrift.TProcessorFunction) {
 	p.processorMap[key] = processor
 }
 
-func (p *SecondProcessor) GetProcessorFunction(key string) (processor thrift.TProcessorFunction, ok bool) {
+func (p *BaseProcessor) GetProcessorFunction(key string) (processor thrift.TProcessorFunction, ok bool) {
 	processor, ok = p.processorMap[key]
 	return processor, ok
 }
 
-func (p *SecondProcessor) ProcessorMap() map[string]thrift.TProcessorFunction {
+func (p *BaseProcessor) ProcessorMap() map[string]thrift.TProcessorFunction {
 	return p.processorMap
 }
 
-func NewSecondProcessor(handler Second) *SecondProcessor {
+func NewBaseProcessor(handler Base) *BaseProcessor {
 
-	self14 := &SecondProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self14.processorMap["Test"] = &secondProcessorTest{handler: handler}
-	return self14
+	self2 := &BaseProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
+	self2.processorMap["BaseCall"] = &baseProcessorBaseCall{handler: handler}
+	return self2
 }
 
-func (p *SecondProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+func (p *BaseProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
 	name, _, seqId, err := iprot.ReadMessageBegin()
 	if err != nil {
 		return false, err
@@ -151,25 +151,25 @@ func (p *SecondProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, 
 	}
 	iprot.Skip(thrift.STRUCT)
 	iprot.ReadMessageEnd()
-	x15 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
+	x3 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
 	oprot.WriteMessageBegin(name, thrift.EXCEPTION, seqId)
-	x15.Write(oprot)
+	x3.Write(oprot)
 	oprot.WriteMessageEnd()
 	oprot.Flush()
-	return false, x15
+	return false, x3
 
 }
 
-type secondProcessorTest struct {
-	handler Second
+type baseProcessorBaseCall struct {
+	handler Base
 }
 
-func (p *secondProcessorTest) Process(seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
-	args := SecondTestArgs{}
+func (p *baseProcessorBaseCall) Process(seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+	args := BaseBaseCallArgs{}
 	if err = args.Read(iprot); err != nil {
 		iprot.ReadMessageEnd()
 		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
-		oprot.WriteMessageBegin("Test", thrift.EXCEPTION, seqId)
+		oprot.WriteMessageBegin("BaseCall", thrift.EXCEPTION, seqId)
 		x.Write(oprot)
 		oprot.WriteMessageEnd()
 		oprot.Flush()
@@ -177,17 +177,17 @@ func (p *secondProcessorTest) Process(seqId int32, iprot, oprot thrift.TProtocol
 	}
 
 	iprot.ReadMessageEnd()
-	result := SecondTestResult{}
+	result := BaseBaseCallResult{}
 	var err2 error
-	if err2 = p.handler.Test(); err2 != nil {
-		x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing Test: "+err2.Error())
-		oprot.WriteMessageBegin("Test", thrift.EXCEPTION, seqId)
+	if err2 = p.handler.BaseCall(); err2 != nil {
+		x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing BaseCall: "+err2.Error())
+		oprot.WriteMessageBegin("BaseCall", thrift.EXCEPTION, seqId)
 		x.Write(oprot)
 		oprot.WriteMessageEnd()
 		oprot.Flush()
 		return true, err2
 	}
-	if err2 = oprot.WriteMessageBegin("Test", thrift.REPLY, seqId); err2 != nil {
+	if err2 = oprot.WriteMessageBegin("BaseCall", thrift.REPLY, seqId); err2 != nil {
 		err = err2
 	}
 	if err2 = result.Write(oprot); err == nil && err2 != nil {
@@ -207,14 +207,14 @@ func (p *secondProcessorTest) Process(seqId int32, iprot, oprot thrift.TProtocol
 
 // HELPER FUNCTIONS AND STRUCTURES
 
-type SecondTestArgs struct {
+type BaseBaseCallArgs struct {
 }
 
-func NewSecondTestArgs() *SecondTestArgs {
-	return &SecondTestArgs{}
+func NewBaseBaseCallArgs() *BaseBaseCallArgs {
+	return &BaseBaseCallArgs{}
 }
 
-func (p *SecondTestArgs) Read(iprot thrift.TProtocol) error {
+func (p *BaseBaseCallArgs) Read(iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
 	}
@@ -240,8 +240,8 @@ func (p *SecondTestArgs) Read(iprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p *SecondTestArgs) Write(oprot thrift.TProtocol) error {
-	if err := oprot.WriteStructBegin("Test_args"); err != nil {
+func (p *BaseBaseCallArgs) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("BaseCall_args"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -253,21 +253,21 @@ func (p *SecondTestArgs) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p *SecondTestArgs) String() string {
+func (p *BaseBaseCallArgs) String() string {
 	if p == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("SecondTestArgs(%+v)", *p)
+	return fmt.Sprintf("BaseBaseCallArgs(%+v)", *p)
 }
 
-type SecondTestResult struct {
+type BaseBaseCallResult struct {
 }
 
-func NewSecondTestResult() *SecondTestResult {
-	return &SecondTestResult{}
+func NewBaseBaseCallResult() *BaseBaseCallResult {
+	return &BaseBaseCallResult{}
 }
 
-func (p *SecondTestResult) Read(iprot thrift.TProtocol) error {
+func (p *BaseBaseCallResult) Read(iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
 	}
@@ -293,8 +293,8 @@ func (p *SecondTestResult) Read(iprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p *SecondTestResult) Write(oprot thrift.TProtocol) error {
-	if err := oprot.WriteStructBegin("Test_result"); err != nil {
+func (p *BaseBaseCallResult) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("BaseCall_result"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -306,9 +306,9 @@ func (p *SecondTestResult) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p *SecondTestResult) String() string {
+func (p *BaseBaseCallResult) String() string {
 	if p == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("SecondTestResult(%+v)", *p)
+	return fmt.Sprintf("BaseBaseCallResult(%+v)", *p)
 }

--- a/examples/thrift/gen-go/test/first.go
+++ b/examples/thrift/gen-go/test/first.go
@@ -15,6 +15,8 @@ var _ = fmt.Printf
 var _ = bytes.Equal
 
 type First interface {
+	Base
+
 	// Parameters:
 	//  - Msg
 	Echo(msg string) (r string, err error)
@@ -23,29 +25,15 @@ type First interface {
 }
 
 type FirstClient struct {
-	Transport       thrift.TTransport
-	ProtocolFactory thrift.TProtocolFactory
-	InputProtocol   thrift.TProtocol
-	OutputProtocol  thrift.TProtocol
-	SeqId           int32
+	*BaseClient
 }
 
 func NewFirstClientFactory(t thrift.TTransport, f thrift.TProtocolFactory) *FirstClient {
-	return &FirstClient{Transport: t,
-		ProtocolFactory: f,
-		InputProtocol:   f.GetProtocol(t),
-		OutputProtocol:  f.GetProtocol(t),
-		SeqId:           0,
-	}
+	return &FirstClient{BaseClient: NewBaseClientFactory(t, f)}
 }
 
 func NewFirstClientProtocol(t thrift.TTransport, iprot thrift.TProtocol, oprot thrift.TProtocol) *FirstClient {
-	return &FirstClient{Transport: t,
-		ProtocolFactory: nil,
-		InputProtocol:   iprot,
-		OutputProtocol:  oprot,
-		SeqId:           0,
-	}
+	return &FirstClient{BaseClient: NewBaseClientProtocol(t, iprot, oprot)}
 }
 
 // Parameters:
@@ -98,16 +86,16 @@ func (p *FirstClient) recvEcho() (value string, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error1 error
-		error1, err = error0.Read(iprot)
+		error4 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error5 error
+		error5, err = error4.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error1
+		err = error5
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -171,16 +159,16 @@ func (p *FirstClient) recvHealthcheck() (value *HealthCheckRes, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error2 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error3 error
-		error3, err = error2.Read(iprot)
+		error6 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error7 error
+		error7, err = error6.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error3
+		err = error7
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -244,16 +232,16 @@ func (p *FirstClient) recvAppError() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error4 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error5 error
-		error5, err = error4.Read(iprot)
+		error8 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error9 error
+		error9, err = error8.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error5
+		err = error9
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -271,49 +259,15 @@ func (p *FirstClient) recvAppError() (err error) {
 }
 
 type FirstProcessor struct {
-	processorMap map[string]thrift.TProcessorFunction
-	handler      First
-}
-
-func (p *FirstProcessor) AddToProcessorMap(key string, processor thrift.TProcessorFunction) {
-	p.processorMap[key] = processor
-}
-
-func (p *FirstProcessor) GetProcessorFunction(key string) (processor thrift.TProcessorFunction, ok bool) {
-	processor, ok = p.processorMap[key]
-	return processor, ok
-}
-
-func (p *FirstProcessor) ProcessorMap() map[string]thrift.TProcessorFunction {
-	return p.processorMap
+	*BaseProcessor
 }
 
 func NewFirstProcessor(handler First) *FirstProcessor {
-
-	self6 := &FirstProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self6.processorMap["Echo"] = &firstProcessorEcho{handler: handler}
-	self6.processorMap["Healthcheck"] = &firstProcessorHealthcheck{handler: handler}
-	self6.processorMap["AppError"] = &firstProcessorAppError{handler: handler}
-	return self6
-}
-
-func (p *FirstProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
-	name, _, seqId, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return false, err
-	}
-	if processor, ok := p.GetProcessorFunction(name); ok {
-		return processor.Process(seqId, iprot, oprot)
-	}
-	iprot.Skip(thrift.STRUCT)
-	iprot.ReadMessageEnd()
-	x7 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
-	oprot.WriteMessageBegin(name, thrift.EXCEPTION, seqId)
-	x7.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return false, x7
-
+	self10 := &FirstProcessor{NewBaseProcessor(handler)}
+	self10.AddToProcessorMap("Echo", &firstProcessorEcho{handler: handler})
+	self10.AddToProcessorMap("Healthcheck", &firstProcessorHealthcheck{handler: handler})
+	self10.AddToProcessorMap("AppError", &firstProcessorAppError{handler: handler})
+	return self10
 }
 
 type firstProcessorEcho struct {

--- a/examples/thrift/gen-go/test/tchan-test.go
+++ b/examples/thrift/gen-go/test/tchan-test.go
@@ -10,7 +10,13 @@ import (
 
 // Interfaces for the service and client for the services defined in the IDL.
 
+type TChanBase interface {
+	BaseCall(ctx thrift.Context) error
+}
+
 type TChanFirst interface {
+	TChanBase
+
 	AppError(ctx thrift.Context) error
 	Echo(ctx thrift.Context, msg string) (string, error)
 	Healthcheck(ctx thrift.Context) (*HealthCheckRes, error)
@@ -22,24 +28,108 @@ type TChanSecond interface {
 
 // Implementation of a client and service handler.
 
-type tchanFirstClient struct {
-	client thrift.TChanClient
+type tchanBaseClient struct {
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanFirstClient(client thrift.TChanClient) *tchanFirstClient {
+func newTChanBaseClient(thriftService string, client thrift.TChanClient) *tchanBaseClient {
+	return &tchanBaseClient{
+		thriftService,
+		client,
+	}
+}
+
+func NewTChanBaseClient(client thrift.TChanClient) TChanBase {
+	return newTChanBaseClient("Base", client)
+}
+
+func (c *tchanBaseClient) BaseCall(ctx thrift.Context) error {
+	var resp BaseBaseCallResult
+	args := BaseBaseCallArgs{}
+	success, err := c.client.Call(ctx, c.thriftService, "BaseCall", &args, &resp)
+	if err == nil && !success {
+	}
+
+	return err
+}
+
+type tchanBaseServer struct {
+	handler TChanBase
+}
+
+func newTChanBaseServer(handler TChanBase) *tchanBaseServer {
+	return &tchanBaseServer{
+		handler,
+	}
+}
+
+func NewTChanBaseServer(handler TChanBase) thrift.TChanServer {
+	return newTChanBaseServer(handler)
+}
+
+func (s *tchanBaseServer) Service() string {
+	return "Base"
+}
+
+func (s *tchanBaseServer) Methods() []string {
+	return []string{
+		"BaseCall",
+	}
+}
+
+func (s *tchanBaseServer) Handle(ctx thrift.Context, methodName string, protocol athrift.TProtocol) (bool, athrift.TStruct, error) {
+	switch methodName {
+	case "BaseCall":
+		return s.handleBaseCall(ctx, protocol)
+
+	default:
+		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
+	}
+}
+
+func (s *tchanBaseServer) handleBaseCall(ctx thrift.Context, protocol athrift.TProtocol) (bool, athrift.TStruct, error) {
+	var req BaseBaseCallArgs
+	var res BaseBaseCallResult
+
+	if err := req.Read(protocol); err != nil {
+		return false, nil, err
+	}
+
+	err :=
+		s.handler.BaseCall(ctx)
+
+	if err != nil {
+		return false, nil, err
+	} else {
+	}
+
+	return err == nil, &res, nil
+}
+
+type tchanFirstClient struct {
+	tchanBaseClient
+
+	thriftService string
+	client        thrift.TChanClient
+}
+
+func newTChanFirstClient(thriftService string, client thrift.TChanClient) *tchanFirstClient {
 	return &tchanFirstClient{
+		*newTChanBaseClient(thriftService, client),
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanFirstClient(client thrift.TChanClient) TChanFirst {
-	return newTChanFirstClient(client)
+	return newTChanFirstClient("First", client)
 }
 
 func (c *tchanFirstClient) AppError(ctx thrift.Context) error {
 	var resp FirstAppErrorResult
 	args := FirstAppErrorArgs{}
-	success, err := c.client.Call(ctx, "First", "AppError", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "AppError", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -51,7 +141,7 @@ func (c *tchanFirstClient) Echo(ctx thrift.Context, msg string) (string, error) 
 	args := FirstEchoArgs{
 		Msg: msg,
 	}
-	success, err := c.client.Call(ctx, "First", "Echo", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Echo", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -61,7 +151,7 @@ func (c *tchanFirstClient) Echo(ctx thrift.Context, msg string) (string, error) 
 func (c *tchanFirstClient) Healthcheck(ctx thrift.Context) (*HealthCheckRes, error) {
 	var resp FirstHealthcheckResult
 	args := FirstHealthcheckArgs{}
-	success, err := c.client.Call(ctx, "First", "Healthcheck", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Healthcheck", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -69,11 +159,14 @@ func (c *tchanFirstClient) Healthcheck(ctx thrift.Context) (*HealthCheckRes, err
 }
 
 type tchanFirstServer struct {
+	tchanBaseServer
+
 	handler TChanFirst
 }
 
 func newTChanFirstServer(handler TChanFirst) *tchanFirstServer {
 	return &tchanFirstServer{
+		*newTChanBaseServer(handler),
 		handler,
 	}
 }
@@ -91,6 +184,8 @@ func (s *tchanFirstServer) Methods() []string {
 		"AppError",
 		"Echo",
 		"Healthcheck",
+
+		"BaseCall",
 	}
 }
 
@@ -102,6 +197,10 @@ func (s *tchanFirstServer) Handle(ctx thrift.Context, methodName string, protoco
 		return s.handleEcho(ctx, protocol)
 	case "Healthcheck":
 		return s.handleHealthcheck(ctx, protocol)
+
+	case "BaseCall":
+		return s.handleBaseCall(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}
@@ -167,23 +266,25 @@ func (s *tchanFirstServer) handleHealthcheck(ctx thrift.Context, protocol athrif
 }
 
 type tchanSecondClient struct {
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanSecondClient(client thrift.TChanClient) *tchanSecondClient {
+func newTChanSecondClient(thriftService string, client thrift.TChanClient) *tchanSecondClient {
 	return &tchanSecondClient{
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanSecondClient(client thrift.TChanClient) TChanSecond {
-	return newTChanSecondClient(client)
+	return newTChanSecondClient("Second", client)
 }
 
 func (c *tchanSecondClient) Test(ctx thrift.Context) error {
 	var resp SecondTestResult
 	args := SecondTestArgs{}
-	success, err := c.client.Call(ctx, "Second", "Test", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Test", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -218,6 +319,7 @@ func (s *tchanSecondServer) Handle(ctx thrift.Context, methodName string, protoc
 	switch methodName {
 	case "Test":
 		return s.handleTest(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}

--- a/examples/thrift/main.go
+++ b/examples/thrift/main.go
@@ -94,7 +94,8 @@ func runClient1(hyperbahnService string, addr net.Addr) error {
 			ctx, cancel := thrift.NewContext(time.Second)
 			res, err := client.Echo(ctx, "Hi")
 			log.Println("Echo(Hi) = ", res, ", err: ", err)
-			log.Println("AppError = ", client.AppError(ctx))
+			log.Println("AppError() = ", client.AppError(ctx))
+			log.Println("BaseCall() = ", client.BaseCall(ctx))
 			cancel()
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -148,6 +149,11 @@ func (h *firstHandler) Healthcheck(ctx thrift.Context) (*gen.HealthCheckRes, err
 	return &gen.HealthCheckRes{
 		Healthy: true,
 		Msg:     "OK"}, nil
+}
+
+func (h *firstHandler) BaseCall(ctx thrift.Context) error {
+	log.Printf("first: BaseCall()\n")
+	return nil
 }
 
 func (h *firstHandler) Echo(ctx thrift.Context, msg string) (r string, err error) {

--- a/examples/thrift/main.go
+++ b/examples/thrift/main.go
@@ -175,6 +175,6 @@ func (h *secondHandler) Test(ctx thrift.Context) error {
 func optsFor(processName string) *tchannel.ChannelOptions {
 	return &tchannel.ChannelOptions{
 		ProcessName: processName,
-		Logger:      tchannel.SimpleLogger,
+		Logger:      tchannel.NewLevelLogger(tchannel.SimpleLogger, tchannel.LogLevelWarn),
 	}
 }

--- a/examples/thrift/test.thrift
+++ b/examples/thrift/test.thrift
@@ -3,12 +3,16 @@ struct HealthCheckRes {
   2: string msg,
 }
 
-service First {
-    string Echo(1:string msg)
-    HealthCheckRes Healthcheck()
-    void AppError()
+service Base {
+  void BaseCall()
+}
+
+service First extends Base {
+  string Echo(1:string msg)
+  HealthCheckRes Healthcheck()
+  void AppError()
 }
 
 service Second {
-    void Test()
+  void Test()
 }

--- a/thrift/gen-go/test/tchan-test.go
+++ b/thrift/gen-go/test/tchan-test.go
@@ -22,17 +22,19 @@ type TChanSimpleService interface {
 // Implementation of a client and service handler.
 
 type tchanSecondServiceClient struct {
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanSecondServiceClient(client thrift.TChanClient) *tchanSecondServiceClient {
+func newTChanSecondServiceClient(thriftService string, client thrift.TChanClient) *tchanSecondServiceClient {
 	return &tchanSecondServiceClient{
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanSecondServiceClient(client thrift.TChanClient) TChanSecondService {
-	return newTChanSecondServiceClient(client)
+	return newTChanSecondServiceClient("SecondService", client)
 }
 
 func (c *tchanSecondServiceClient) Echo(ctx thrift.Context, arg string) (string, error) {
@@ -40,7 +42,7 @@ func (c *tchanSecondServiceClient) Echo(ctx thrift.Context, arg string) (string,
 	args := SecondServiceEchoArgs{
 		Arg: arg,
 	}
-	success, err := c.client.Call(ctx, "SecondService", "Echo", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Echo", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -75,6 +77,7 @@ func (s *tchanSecondServiceServer) Handle(ctx thrift.Context, methodName string,
 	switch methodName {
 	case "Echo":
 		return s.handleEcho(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}
@@ -101,17 +104,19 @@ func (s *tchanSecondServiceServer) handleEcho(ctx thrift.Context, protocol athri
 }
 
 type tchanSimpleServiceClient struct {
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanSimpleServiceClient(client thrift.TChanClient) *tchanSimpleServiceClient {
+func newTChanSimpleServiceClient(thriftService string, client thrift.TChanClient) *tchanSimpleServiceClient {
 	return &tchanSimpleServiceClient{
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanSimpleServiceClient(client thrift.TChanClient) TChanSimpleService {
-	return newTChanSimpleServiceClient(client)
+	return newTChanSimpleServiceClient("SimpleService", client)
 }
 
 func (c *tchanSimpleServiceClient) Call(ctx thrift.Context, arg *Data) (*Data, error) {
@@ -119,7 +124,7 @@ func (c *tchanSimpleServiceClient) Call(ctx thrift.Context, arg *Data) (*Data, e
 	args := SimpleServiceCallArgs{
 		Arg: arg,
 	}
-	success, err := c.client.Call(ctx, "SimpleService", "Call", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Call", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -129,7 +134,7 @@ func (c *tchanSimpleServiceClient) Call(ctx thrift.Context, arg *Data) (*Data, e
 func (c *tchanSimpleServiceClient) Simple(ctx thrift.Context) error {
 	var resp SimpleServiceSimpleResult
 	args := SimpleServiceSimpleArgs{}
-	success, err := c.client.Call(ctx, "SimpleService", "Simple", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "Simple", &args, &resp)
 	if err == nil && !success {
 		if e := resp.SimpleErr; e != nil {
 			err = e
@@ -170,6 +175,7 @@ func (s *tchanSimpleServiceServer) Handle(ctx thrift.Context, methodName string,
 		return s.handleCall(ctx, protocol)
 	case "Simple":
 		return s.handleSimple(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}

--- a/thrift/thrift-gen/template.go
+++ b/thrift/thrift-gen/template.go
@@ -34,21 +34,23 @@ type {{ .ClientStruct }} struct {
 		{{ .ExtendsService.ClientStruct }}
 
 	{{ end }}
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
 
-func {{ .InternalClientConstructor }}(client thrift.TChanClient) *{{ .ClientStruct }} {
+func {{ .InternalClientConstructor }}(thriftService string, client thrift.TChanClient) *{{ .ClientStruct }} {
 	return &{{ .ClientStruct }}{
 		{{ if .HasExtends }}
-			*{{ .ExtendsService.InternalClientConstructor }}(client),
+			*{{ .ExtendsService.InternalClientConstructor }}(thriftService, client),
 		{{ end }}
+		thriftService,
 		client,
 	}
 }
 
 func {{ .ClientConstructor }}(client thrift.TChanClient) {{ .Interface }} {
-	return {{ .InternalClientConstructor }}(client)
+	return {{ .InternalClientConstructor }}("{{ .ThriftName }}", client)
 }
 
 {{ range .Methods }}
@@ -59,7 +61,7 @@ func {{ .ClientConstructor }}(client thrift.TChanClient) {{ .Interface }} {
 				{{ .ArgStructName }}: {{ .Name }},
 			{{ end }}
 		}
-		success, err := c.client.Call(ctx, "{{ $svc.ThriftName }}", "{{ .ThriftName }}", &args, &resp)
+		success, err := c.client.Call(ctx, c.thriftService, "{{ .ThriftName }}", &args, &resp)
 		if err == nil && !success {
 			{{ range .Exceptions }}
 				if e := resp.{{ .ArgStructName }}; e != nil {
@@ -119,6 +121,12 @@ func (s *{{ .ServerStruct }}) Handle(ctx {{ contextType }}, methodName string, p
 		{{ range .Methods }}
 			case "{{ .ThriftName }}":
 				return s.{{ .HandleFunc }}(ctx, protocol)
+		{{ end }}
+		{{ if .HasExtends }}
+			{{ range .ExtendsService.Methods }}
+				case "{{ .ThriftName }}":
+					return s.{{ .HandleFunc }}(ctx, protocol)
+			{{ end }}
 		{{ end }}
 		default:
 			return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())

--- a/trace/thrift/gen-go/tcollector/tchan-tcollector.go
+++ b/trace/thrift/gen-go/tcollector/tchan-tcollector.go
@@ -18,17 +18,19 @@ type TChanTCollector interface {
 // Implementation of a client and service handler.
 
 type tchanTCollectorClient struct {
-	client thrift.TChanClient
+	thriftService string
+	client        thrift.TChanClient
 }
 
-func newTChanTCollectorClient(client thrift.TChanClient) *tchanTCollectorClient {
+func newTChanTCollectorClient(thriftService string, client thrift.TChanClient) *tchanTCollectorClient {
 	return &tchanTCollectorClient{
+		thriftService,
 		client,
 	}
 }
 
 func NewTChanTCollectorClient(client thrift.TChanClient) TChanTCollector {
-	return newTChanTCollectorClient(client)
+	return newTChanTCollectorClient("TCollector", client)
 }
 
 func (c *tchanTCollectorClient) MultiSubmit(ctx thrift.Context, spans []*Span) ([]*Response, error) {
@@ -36,7 +38,7 @@ func (c *tchanTCollectorClient) MultiSubmit(ctx thrift.Context, spans []*Span) (
 	args := TCollectorMultiSubmitArgs{
 		Spans: spans,
 	}
-	success, err := c.client.Call(ctx, "TCollector", "multi_submit", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "multi_submit", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -48,7 +50,7 @@ func (c *tchanTCollectorClient) Submit(ctx thrift.Context, span *Span) (*Respons
 	args := TCollectorSubmitArgs{
 		Span: span,
 	}
-	success, err := c.client.Call(ctx, "TCollector", "submit", &args, &resp)
+	success, err := c.client.Call(ctx, c.thriftService, "submit", &args, &resp)
 	if err == nil && !success {
 	}
 
@@ -86,6 +88,7 @@ func (s *tchanTCollectorServer) Handle(ctx thrift.Context, methodName string, pr
 		return s.handleMultiSubmit(ctx, protocol)
 	case "submit":
 		return s.handleSubmit(ctx, protocol)
+
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
 	}


### PR DESCRIPTION
Fixes a couple of issues:
 - clients were using the wrong service name when calling the base method
 - servers were not handling calls for any base methods

cc @danqing 