### PR TITLE
Fix errExpectedMoreArguments when benchmarking with large requests

### DIFF
--- a/fragmentation_test.go
+++ b/fragmentation_test.go
@@ -250,8 +250,8 @@ func TestFragmentationReaderErrors(t *testing.T) {
 func TestFragmentationChecksumTypeErrors(t *testing.T) {
 	sendCh := make(fragmentChannel, 10)
 	recvCh := make(fragmentChannel, 10)
-	w := newFragmentingWriter(sendCh, ChecksumTypeCrc32.New())
-	r := newFragmentingReader(recvCh)
+	w := newFragmentingWriter(NullLogger, sendCh, ChecksumTypeCrc32.New())
+	r := newFragmentingReader(NullLogger, recvCh)
 
 	// Write two fragments out
 	writer, err := w.ArgWriter(true /* last */)
@@ -277,8 +277,8 @@ func TestFragmentationChecksumTypeErrors(t *testing.T) {
 func TestFragmentationChecksumMismatch(t *testing.T) {
 	sendCh := make(fragmentChannel, 10)
 	recvCh := make(fragmentChannel, 10)
-	w := newFragmentingWriter(sendCh, ChecksumTypeCrc32.New())
-	r := newFragmentingReader(recvCh)
+	w := newFragmentingWriter(NullLogger, sendCh, ChecksumTypeCrc32.New())
+	r := newFragmentingReader(NullLogger, recvCh)
 
 	// Write two fragments out
 	writer, err := w.ArgWriter(true /* last */)
@@ -303,8 +303,8 @@ func TestFragmentationChecksumMismatch(t *testing.T) {
 
 func runFragmentationErrorTest(f func(w *fragmentingWriter, r *fragmentingReader)) {
 	ch := make(fragmentChannel, 10)
-	w := newFragmentingWriter(ch, ChecksumTypeCrc32.New())
-	r := newFragmentingReader(ch)
+	w := newFragmentingWriter(NullLogger, ch, ChecksumTypeCrc32.New())
+	r := newFragmentingReader(NullLogger, ch)
 	f(w, r)
 }
 
@@ -312,8 +312,8 @@ func runFragmentationTest(t *testing.T, args []string, expectedFragments [][]byt
 	sendCh := make(fragmentChannel, 10)
 	recvCh := make(fragmentChannel, 10)
 
-	w := newFragmentingWriter(sendCh, ChecksumTypeCrc32.New())
-	r := newFragmentingReader(recvCh)
+	w := newFragmentingWriter(NullLogger, sendCh, ChecksumTypeCrc32.New())
+	r := newFragmentingReader(NullLogger, recvCh)
 
 	var fragments [][]byte
 	var actualArgs []string

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -72,6 +72,7 @@ func (s fragmentingReadState) isReadingArgument() bool {
 }
 
 type fragmentingReader struct {
+	logger           Logger
 	state            fragmentingReadState
 	remainingChunks  [][]byte
 	curChunk         []byte
@@ -82,8 +83,9 @@ type fragmentingReader struct {
 	err              error
 }
 
-func newFragmentingReader(receiver fragmentReceiver) *fragmentingReader {
+func newFragmentingReader(logger Logger, receiver fragmentReceiver) *fragmentingReader {
 	return &fragmentingReader{
+		logger:           logger,
 		receiver:         receiver,
 		hasMoreFragments: true,
 	}

--- a/fragmenting_writer.go
+++ b/fragmenting_writer.go
@@ -135,6 +135,7 @@ func (s fragmentingWriterState) isWritingArgument() bool {
 // checksum.  It relies on an underlying fragmentSender, which creates and
 // flushes the fragments as needed
 type fragmentingWriter struct {
+	logger      Logger
 	sender      fragmentSender
 	checksum    Checksum
 	curFragment *writableFragment
@@ -144,8 +145,9 @@ type fragmentingWriter struct {
 }
 
 // newFragmentingWriter creates a new fragmenting writer
-func newFragmentingWriter(sender fragmentSender, checksum Checksum) *fragmentingWriter {
+func newFragmentingWriter(logger Logger, sender fragmentSender, checksum Checksum) *fragmentingWriter {
 	return &fragmentingWriter{
+		logger:   logger,
 		sender:   sender,
 		checksum: checksum,
 		state:    fragmentingWriteStart,

--- a/inbound.go
+++ b/inbound.go
@@ -92,10 +92,10 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	response.AddAnnotation(AnnotationKeyServerReceive)
 	response.mex = mex
 	response.conn = c
-	response.contents = newFragmentingWriter(response, initialFragment.checksumType.New())
 	response.cancel = cancel
 	response.span = callReq.Tracing
 	response.log = c.log.WithFields(LogField{"In-Response", callReq.ID()})
+	response.contents = newFragmentingWriter(response.log, response, initialFragment.checksumType.New())
 	response.headers = transportHeaders{}
 	response.messageForFragment = func(initial bool) message {
 		if initial {
@@ -119,7 +119,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	call.response = response
 	call.log = c.log.WithFields(LogField{"In-Call", callReq.ID()})
 	call.messageForFragment = func(initial bool) message { return new(callReqContinue) }
-	call.contents = newFragmentingReader(call)
+	call.contents = newFragmentingReader(call.log, call)
 	call.statsReporter = c.statsReporter
 	call.createStatsTags(c.commonStatsTags)
 

--- a/outbound.go
+++ b/outbound.go
@@ -96,7 +96,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 		return new(callReqContinue)
 	}
 
-	call.contents = newFragmentingWriter(call, c.checksumType.New())
+	call.contents = newFragmentingWriter(call.log, call, c.checksumType.New())
 	span := CurrentSpan(ctx)
 	if span != nil {
 		call.callReq.Tracing = *span.NewChildSpan()
@@ -131,7 +131,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 
 		return new(callResContinue)
 	}
-	response.contents = newFragmentingReader(response)
+	response.contents = newFragmentingReader(response.log, response)
 	response.statsReporter = call.statsReporter
 	response.commonStatsTags = call.commonStatsTags
 

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -52,8 +52,8 @@ type ChannelOpts struct {
 	// ProcessName defaults to ServiceName + "-[port]"
 	ProcessName string
 
-	// EnableLog defaults to false.
-	EnableLog bool
+	// Logger sets the logger.
+	Logger tchannel.Logger
 
 	// StatsReporter specifies the StatsReporter to use.
 	StatsReporter tchannel.StatsReporter
@@ -74,7 +74,9 @@ func defaultString(v string, defaultValue string) string {
 
 func getChannelOptions(opts *ChannelOpts, processName string) *tchannel.ChannelOptions {
 	var logger tchannel.Logger
-	if opts.EnableLog || *connectionLog {
+	if opts.Logger != nil {
+		logger = opts.Logger
+	} else if *connectionLog {
 		logger = tchannel.SimpleLogger
 	}
 

--- a/thrift/benchclient/main.go
+++ b/thrift/benchclient/main.go
@@ -87,7 +87,6 @@ func makeArg() string {
 	}
 
 	bs := []byte{}
-	// TODO(prashant) when this is 100000, get more arguments in message error.
 	for i := 0; i < *requestSize; i++ {
 		bs = append(bs, byte(i%26+'A'))
 	}

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -249,6 +249,8 @@ func (w *WriteBuffer) DeferByte() ByteRef {
 		return ByteRef(nil)
 	}
 
+	// Always zero out references, since the caller expects the default to be 0.
+	w.remaining[0] = 0
 	bufRef := ByteRef(w.remaining[0:])
 	w.remaining = w.remaining[1:]
 	return bufRef
@@ -257,25 +259,33 @@ func (w *WriteBuffer) DeferByte() ByteRef {
 // DeferUint16 reserves space in the buffer for a uint16, and returns a
 // reference that can be used to update that uint16
 func (w *WriteBuffer) DeferUint16() Uint16Ref {
-	return Uint16Ref(w.reserve(2))
+	return Uint16Ref(w.deferred(2))
 }
 
 // DeferUint32 reserves space in the buffer for a uint32, and returns a
 // reference that can be used to update that uint32
 func (w *WriteBuffer) DeferUint32() Uint32Ref {
-	return Uint32Ref(w.reserve(4))
+	return Uint32Ref(w.deferred(4))
 }
 
 // DeferUint64 reserves space in the buffer for a uint64, and returns a
 // reference that can be used to update that uint64
 func (w *WriteBuffer) DeferUint64() Uint64Ref {
-	return Uint64Ref(w.reserve(8))
+	return Uint64Ref(w.deferred(8))
 }
 
 // DeferBytes reserves space in the buffer for a fixed sequence of bytes, and
 // returns a reference that can be used to update those bytes
 func (w *WriteBuffer) DeferBytes(n int) BytesRef {
-	return BytesRef(w.reserve(n))
+	return BytesRef(w.deferred(n))
+}
+
+func (w *WriteBuffer) deferred(n int) []byte {
+	bs := w.reserve(n)
+	for i := range bs {
+		bs[i] = 0
+	}
+	return bs
 }
 
 func (w *WriteBuffer) reserve(n int) []byte {


### PR DESCRIPTION
When frame pooling was enabled, some callReq frames came through
with the "more fragments" flag set, even though it was the last
frame for that call. This turns out to be because deferred bytes
are not always set, but instead, the caller assumes it is already 0.

When making Thrift requests, the Thrift server consumes all the bytes
and then calls Close, but since the fragment could have the continue
flag set, it sometimes threw this error unexpectedly.

To avoid these issue, deferred bytes are zeroed out by default.