### PR TITLE
Add a post-response callback to Thrift server

### DIFF
--- a/thrift/options.go
+++ b/thrift/options.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import "github.com/apache/thrift/lib/go/thrift"
+
+// RegisterOption is the interface for options to Register.
+type RegisterOption interface {
+	Apply(h *handler)
+}
+
+// PostResponseCB registers a callback that is run after a response has been
+// compeltely processed (e.g. written to the channel).
+// This gives the server a chance to clean up resources from the response object
+type PostResponseCB func(method string, response thrift.TStruct)
+
+type optPostResponse PostResponseCB
+
+// OptPostResponse registers a PostResponseCB.
+func OptPostResponse(cb PostResponseCB) RegisterOption {
+	return optPostResponse(cb)
+}
+
+func (o optPostResponse) Apply(h *handler) {
+	h.postResponseCB = PostResponseCB(o)
+}


### PR DESCRIPTION
Uses the Option pattern (http://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html).

This allows us to avoid breaking backwards compatibility, and avoiding another method.

Few things to be careful about:
 - The response struct passed is NOT the same as what is returned by the server. It's the "Result" struct created by Thrift which also contains exceptions etc.
 - The method name does not have the service name prefix.

cc @martin-mao