### PR TITLE
Reduce exchange buffer size

### DIFF
--- a/inbound.go
+++ b/inbound.go
@@ -60,7 +60,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	call := new(InboundCall)
 	ctx, cancel := newIncomingContext(call, callReq.TimeToLive, &callReq.Tracing)
 
-	mex, err := c.inbound.newExchange(ctx, c.framePool, callReq.messageType(), frame.Header.ID, 512)
+	mex, err := c.inbound.newExchange(ctx, c.framePool, callReq.messageType(), frame.Header.ID, 2)
 	if err != nil {
 		if err == errDuplicateMex {
 			err = errInboundRequestAlreadyActive

--- a/outbound.go
+++ b/outbound.go
@@ -55,7 +55,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 	}
 
 	requestID := c.NextMessageID()
-	mex, err := c.outbound.newExchange(ctx, c.framePool, messageTypeCallReq, requestID, 512)
+	mex, err := c.outbound.newExchange(ctx, c.framePool, messageTypeCallReq, requestID, 2)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
An exchange is used for a specific call, so the buffer does not need to be very large. In the common case, each call will only have one frame, so it only really needs to be 1 or 2.

cc @mmihic 