### PR TITLE
Fix for TestFragmentation failures

### DIFF
--- a/mex.go
+++ b/mex.go
@@ -58,8 +58,10 @@ func (mex *messageExchange) forwardPeerFrame(frame *Frame) error {
 	select {
 	case mex.recvCh <- frame:
 		return nil
-	default:
-		return errMexChannelFull
+	case <-mex.ctx.Done():
+		// Note: One slow reader processing a large request could stall the connection.
+		// If we see this, we need to increase the recvCh buffer size.
+		return mex.ctx.Err()
 	}
 }
 

--- a/mex.go
+++ b/mex.go
@@ -232,7 +232,8 @@ func (mexset *messageExchangeSet) forwardPeerFrame(frame *Frame) error {
 	}
 
 	if err := mex.forwardPeerFrame(frame); err != nil {
-		mexset.log.Warnf("Unable to forward %s to peer: %v", frame, err)
+		mexset.log.Warnf("Unable to forward frame ID %v type %v length %v to peer: %v",
+			frame.Header.ID, frame.Header.messageType, frame.Header.FrameSize(), err)
 		return err
 	}
 


### PR DESCRIPTION
TestFragmentation sends a large payload (>5 frames), but since the mex
recvCh is a much smaller buffer (2 frames), if the reader has not
processed the frames before the mex receives a new frame, it would
immediately drop the frame and the test would fail.

Change logic to instead try to send the frame till the timeout.
This means a connection's processing may be stalled if there is is a
slow reader that receives a large number of frames.
If we see this in production (very unlikely), we can increase the mex's
recvCh buffer size.