### PR TITLE
Ensure timeout goroutine is released when a call is completed

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -182,6 +182,8 @@ func TestCloseStress(t *testing.T) {
 }
 
 func TestCloseSemantics(t *testing.T) {
+	// We defer the check as we want it to run after the SetTimeout clears the timeout.
+	defer VerifyNoBlockedGoroutines(t)
 	defer testutils.SetTimeout(t, 2*time.Second)()
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
@@ -278,7 +280,6 @@ func TestCloseSemantics(t *testing.T) {
 
 	// Close s2 so we don't leave any goroutines running.
 	s2.Close()
-	VerifyNoBlockedGoroutines(t)
 }
 
 func TestCloseSingleChannel(t *testing.T) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -279,6 +279,19 @@ func TestLargeOperation(t *testing.T) {
 	})
 }
 
+func TestLargeTimeout(t *testing.T) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+		ch.Register(raw.Wrap(newTestHandler(t)), "echo")
+
+		ctx, cancel := NewContext(1000 * time.Second)
+		defer cancel()
+
+		_, _, _, err := raw.Call(ctx, ch, hostPort, testServiceName, "echo", testArg2, testArg3)
+		assert.NoError(t, err, "Call failed")
+	})
+	VerifyNoBlockedGoroutines(t)
+}
+
 func TestFragmentation(t *testing.T) {
 	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		ch.Register(raw.Wrap(newTestHandler(t)), "echo")

--- a/goroutines_utils_test.go
+++ b/goroutines_utils_test.go
@@ -169,6 +169,12 @@ retry:
 			t.Errorf("Found leaked goroutine in state %q Full stack:\n%s\n",
 				v.goState, v.fullStack.String())
 		}
+
+		// Note: we cannot use NumGoroutine here as it includes system goroutines
+		// while runtime.Stack does not: https://github.com/golang/go/issues/11706
+		if len(stacks) > 2 {
+			t.Errorf("Expect at most 2 goroutines, found more:\n%s", getStacks())
+		}
 		return
 	}
 

--- a/goroutines_utils_test.go
+++ b/goroutines_utils_test.go
@@ -107,7 +107,8 @@ func (s goroutineStack) isLeak() bool {
 	isLeakLine := func(line string) bool {
 		return strings.Contains(line, "(*Channel).Serve") ||
 			strings.Contains(line, "(*Connection).readFrames") ||
-			strings.Contains(line, "(*Connection).writeFrames")
+			strings.Contains(line, "(*Connection).writeFrames") ||
+			strings.Contains(line, "(*Connection).dispatchInbound.func")
 	}
 
 	lineReader := bufio.NewReader(bytes.NewReader(s.fullStack.Bytes()))

--- a/goroutines_utils_test.go
+++ b/goroutines_utils_test.go
@@ -42,9 +42,10 @@ func getStacks() []byte {
 }
 
 // parseGoStackHeader parses a stack header that looks like:
-// goroutine 643 [runnable]:
+// goroutine 643 [runnable]:\n
 // And returns the goroutine ID, and the state.
 func parseGoStackHeader(line string) (goroutineID int, state string) {
+	line = strings.TrimSuffix(line, ":\n")
 	parts := strings.SplitN(line, " ", 3)
 	if len(parts) != 3 {
 		panic(fmt.Sprintf("unexpected stack header format: %v", line))
@@ -109,9 +110,9 @@ func (s goroutineStack) isLeak() bool {
 			strings.Contains(line, "(*Connection).writeFrames")
 	}
 
+	lineReader := bufio.NewReader(bytes.NewReader(s.fullStack.Bytes()))
 	for {
-		s.fullStack.Reset()
-		line, err := s.fullStack.ReadString('\n')
+		line, err := lineReader.ReadString('\n')
 		if err == io.EOF {
 			return false
 		}

--- a/inbound.go
+++ b/inbound.go
@@ -283,7 +283,6 @@ type InboundCallResponse struct {
 // complete after this method is called, and no further data can be written.
 func (response *InboundCallResponse) SendSystemError(err error) error {
 	// Fail all future attempts to read fragments
-	response.cancel()
 	response.state = reqResWriterComplete
 	response.systemError = true
 	response.doneSending()
@@ -336,6 +335,9 @@ func (response *InboundCallResponse) doneSending() {
 	} else {
 		response.statsReporter.IncCounter("inbound.calls.success", response.commonStatsTags, 1)
 	}
+
+	// Cancel the context since the response is complete.
+	response.cancel()
 
 	// The message exchange is still open if there are no errors, call shutdown.
 	if response.err == nil {


### PR DESCRIPTION
Cancel the context that the timeout goroutine is waiting on when a call is complete.

Add test utilities to catch ensure we catch all leaked goroutines in tests, and add a specific test for this case (which fails without the fix).