### PR TITLE
Thrift benchmark cleanup

### DIFF
--- a/thrift/benchclient/main.go
+++ b/thrift/benchclient/main.go
@@ -38,6 +38,7 @@ import (
 
 var (
 	requestSize = flag.Int("requestSize", 10000, "The number of bytes of each request")
+	serviceName = flag.String("serviceName", "bench-server", "The benchmark server's service name")
 	timeout     = flag.Duration("timeout", time.Second, "Timeout for each request")
 )
 
@@ -52,7 +53,7 @@ func main() {
 	for _, host := range flag.Args() {
 		ch.Peers().Add(host)
 	}
-	thriftClient := thrift.NewClient(ch, "bench-server", nil)
+	thriftClient := thrift.NewClient(ch, *serviceName, nil)
 	client := gen.NewTChanSecondServiceClient(thriftClient)
 
 	fmt.Println("bench-client started")

--- a/thrift/thrift_bench_test.go
+++ b/thrift/thrift_bench_test.go
@@ -46,10 +46,10 @@ var (
 	useHyperbahn   = flag.Bool("useHyperbahn", false, "Whether to advertise and route requests through Hyperbahn")
 	hyperbahnNodes = flag.String("hyperbahnNodes", "127.0.0.1:21300,127.0.0.1:21301", "Comma-separated list of Hyperbahn nodes")
 	requestSize    = flag.Int("requestSize", 10000, "Call payload size")
-	timeout        = flag.Duration("timeout", time.Second, "Timeout for each call")
+	timeout        = flag.Duration("callTimeout", time.Second, "Timeout for each call")
 )
 
-const benchServerName = "bench-server123"
+const benchServerName = "bench-server"
 
 func setupBenchServer() ([]string, error) {
 	ch, err := testutils.NewServer(&testutils.ChannelOpts{

--- a/thrift/thrift_bench_test.go
+++ b/thrift/thrift_bench_test.go
@@ -49,9 +49,11 @@ var (
 	timeout        = flag.Duration("timeout", time.Second, "Timeout for each call")
 )
 
+const benchServerName = "bench-server123"
+
 func setupBenchServer() ([]string, error) {
 	ch, err := testutils.NewServer(&testutils.ChannelOpts{
-		ServiceName: "bench-server",
+		ServiceName: benchServerName,
 		DefaultConnectionOptions: tchannel.ConnectionOptions{
 			FramePool: tchannel.NewSyncFramePool(),
 		},
@@ -59,6 +61,7 @@ func setupBenchServer() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(benchServerName, "started on", ch.PeerInfo().HostPort)
 
 	server := thrift.NewServer(ch)
 	server.Register(gen.NewTChanSecondServiceServer(benchSecondHandler{}))
@@ -169,6 +172,7 @@ func startClient(servers []string) (*benchClient, error) {
 	}
 
 	flags := []string{
+		"--serviceName", benchServerName,
 		"--requestSize", fmt.Sprint(*requestSize),
 		"--timeout", fmt.Sprint(*timeout),
 	}


### PR DESCRIPTION
Pass service name from server -> clients
Print the host:port selected by the server