### PR TITLE
Optionally, allow SubChannels to isolate their PeerLists

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -441,7 +441,7 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string, connectionOptio
 // incomingConnectionActive adds a new active connection to our peer list.
 func (ch *Channel) incomingConnectionActive(c *Connection) {
 	c.log.Debugf("Add connection as an active peer for %v", c.remotePeerInfo.HostPort)
-	p := ch.peers.GetOrAdd(c.remotePeerInfo.HostPort)
+	p := ch.rootPeers().GetOrAdd(c.remotePeerInfo.HostPort)
 	p.AddConnection(c)
 
 	ch.mutable.mut.Lock()

--- a/channel.go
+++ b/channel.go
@@ -153,7 +153,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		handlers:          &handlerMap{},
 		subChannels:       &subChannelMap{},
 	}
-	ch.peers = newPeerList(ch)
+	ch.peers = newPeerList(ch).newChild()
 
 	ch.mutable.peerInfo = LocalPeerInfo{
 		PeerInfo: PeerInfo{
@@ -177,6 +177,11 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 
 	ch.registerInternal()
 	return ch, nil
+}
+
+// ConnectionOptions returns the channel's connection options.
+func (ch *Channel) ConnectionOptions() *ConnectionOptions {
+	return &ch.connectionOptions
 }
 
 // Serve serves incoming requests using the provided listener.
@@ -278,13 +283,22 @@ func (ch *Channel) createCommonStats() {
 
 // GetSubChannel returns a SubChannel for the given service name. If the subchannel does not
 // exist, it is created.
-func (ch *Channel) GetSubChannel(serviceName string) *SubChannel {
-	return ch.subChannels.getOrAdd(serviceName, ch)
+func (ch *Channel) GetSubChannel(serviceName string, opts ...SubChannelOption) *SubChannel {
+	sub := ch.subChannels.getOrAdd(serviceName, ch)
+	for _, opt := range opts {
+		opt(sub)
+	}
+	return sub
 }
 
 // Peers returns the PeerList for the channel.
 func (ch *Channel) Peers() *PeerList {
 	return ch.peers
+}
+
+// rootPeers returns the root PeerList for the channel.
+func (ch *Channel) rootPeers() *PeerList {
+	return ch.peers.parent
 }
 
 // BeginCall starts a new call to a remote peer, returning an OutboundCall that can
@@ -485,7 +499,7 @@ func (ch *Channel) State() ChannelState {
 
 // Close starts a graceful Close for the channel. This does not happen immediately:
 // 1. This call closes the Listener and starts closing connections.
-// 2. When all incoming connections are drainged, the connection blocks new outgoing calls.
+// 2. When all incoming connections are drained, the connection blocks new outgoing calls.
 // 3. When all connections are drainged, the channel's state is updated to Closed.
 func (ch *Channel) Close() {
 	ch.mutable.mut.Lock()
@@ -500,5 +514,5 @@ func (ch *Channel) Close() {
 	}
 	ch.mutable.mut.Unlock()
 
-	ch.peers.Close()
+	ch.rootPeers().Close()
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,4 +79,35 @@ func TestStats(t *testing.T) {
 		assert.Equal(t, v, subTags[k], "subchannel missing tag %v", k)
 	}
 	assert.Equal(t, "subch", subTags["subchannel"], "subchannel tag missing")
+}
+
+func TestIsolatedSubChannelsDontSharePeers(t *testing.T) {
+	ch, err := NewChannel("svc", &ChannelOptions{
+		Logger: NewLogger(ioutil.Discard),
+	})
+	require.NoError(t, err, "NewChannel failed")
+
+	sub := ch.GetSubChannel("svc-ringpop")
+	if ch.peers != sub.peers {
+		t.Log("Channel and subchannel don't share the same peer list.")
+		t.Fail()
+	}
+
+	isolatedSub := ch.GetSubChannel("svc-shy-ringpop", Isolated)
+	if ch.peers == isolatedSub.peers {
+		t.Log("Channel and isolated subchannel share the same peer list.")
+		t.Fail()
+	}
+
+	// Nobody knows about the peer.
+	assert.Nil(t, ch.peers.peersByHostPort["127.0.0.1:3000"])
+	assert.Nil(t, sub.peers.peersByHostPort["127.0.0.1:3000"])
+	assert.Nil(t, isolatedSub.peers.peersByHostPort["127.0.0.1:3000"])
+
+	// Uses of the parent channel should be reflected in the subchannel, but
+	// not the isolated subchannel.
+	ch.BeginCall(context.Background(), "127.0.0.1:3000", "foo", "Bar::baz", nil)
+	assert.NotNil(t, ch.peers.peersByHostPort["127.0.0.1:3000"])
+	assert.NotNil(t, sub.peers.peersByHostPort["127.0.0.1:3000"])
+	assert.Nil(t, isolatedSub.peers.peersByHostPort["127.0.0.1:3000"])
 }

--- a/peer.go
+++ b/peer.go
@@ -38,24 +38,57 @@ var (
 	peerRng = NewRand(time.Now().UnixNano())
 )
 
+type Connectable interface {
+	Connect(context.Context, string, *ConnectionOptions) (*Connection, error)
+	ConnectionOptions() *ConnectionOptions
+}
+
 // PeerList maintains a list of Peers.
 type PeerList struct {
-	channel *Channel
+	channel Connectable
+	parent  *PeerList
 
 	mut             sync.RWMutex // mut protects peers.
 	peersByHostPort map[string]*Peer
 	peers           []*Peer
 }
 
-func newPeerList(channel *Channel) *PeerList {
+func newPeerList(channel Connectable) *PeerList {
 	return &PeerList{
 		channel:         channel,
 		peersByHostPort: make(map[string]*Peer),
 	}
 }
 
+func (l *PeerList) isRoot() bool {
+	return l.parent == nil
+}
+
+// Siblings don't share peer lists (though they take care not to double-connect
+// to the same hosts).
+func (l *PeerList) newSibling() *PeerList {
+	sib := newPeerList(l.channel)
+	sib.parent = l.parent
+	return sib
+}
+
+// Children ensure that their parent's peer list is a superset of their own.
+func (l *PeerList) newChild() *PeerList {
+	child := newPeerList(l.channel)
+	child.parent = l
+	return child
+}
+
 // Add adds a peer to the list if it does not exist, or returns any existing peer.
 func (l *PeerList) Add(hostPort string) *Peer {
+	l.mut.RLock()
+
+	if p, ok := l.peersByHostPort[hostPort]; ok {
+		l.mut.RUnlock()
+		return p
+	}
+
+	l.mut.RUnlock()
 	l.mut.Lock()
 	defer l.mut.Unlock()
 
@@ -63,7 +96,14 @@ func (l *PeerList) Add(hostPort string) *Peer {
 		return p
 	}
 
-	p := newPeer(l.channel, hostPort)
+	var p *Peer
+	if l.isRoot() {
+		// To avoid duplicate connections, only the root list should create new
+		// peers. All other lists should keep refs to the root list's peers.
+		p = newPeer(l.channel, hostPort)
+	} else {
+		p = l.parent.Add(hostPort)
+	}
 	l.peersByHostPort[hostPort] = p
 	l.peers = append(l.peers, p)
 	return p
@@ -124,14 +164,14 @@ func (l *PeerList) Close() {
 
 // Peer represents a single autobahn service or client with a unique host:port.
 type Peer struct {
-	channel  *Channel
+	channel  Connectable
 	hostPort string
 
 	mut         sync.RWMutex // mut protects connections.
 	connections []*Connection
 }
 
-func newPeer(channel *Channel, hostPort string) *Peer {
+func newPeer(channel Connectable, hostPort string) *Peer {
 	return &Peer{
 		channel:  channel,
 		hostPort: hostPort,
@@ -198,7 +238,7 @@ func (p *Peer) AddConnection(c *Connection) error {
 
 // Connect adds a new outbound connection to the peer.
 func (p *Peer) Connect(ctx context.Context) (*Connection, error) {
-	c, err := p.channel.Connect(ctx, p.hostPort, &p.channel.connectionOptions)
+	c, err := p.channel.Connect(ctx, p.hostPort, p.channel.ConnectionOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/subchannel.go
+++ b/subchannel.go
@@ -26,6 +26,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+type SubChannelOption func(*SubChannel)
+
+func Isolated(s *SubChannel) {
+	s.peers = s.topChannel.peers.newSibling()
+}
+
 // SubChannel allows calling a specific service on a channel.
 // TODO(prashant): Allow creating a subchannel with default call options.
 // TODO(prashant): Allow registering handlers on a subchannel.

--- a/subchannel_test.go
+++ b/subchannel_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+type chanSet struct {
+	main     tchannel.Registrar
+	sub      tchannel.Registrar
+	isolated tchannel.Registrar
+}
+
+func newSet() (chanSet, error) {
+	ch, err := testutils.NewClient(nil)
+	if err != nil {
+		return chanSet{}, err
+	}
+	return chanSet{
+		main:     ch,
+		sub:      ch.GetSubChannel("hyperbahn"),
+		isolated: ch.GetSubChannel("ringpop", tchannel.Isolated),
+	}, nil
+}
+
+// Assert that two Registrars have references to the same Peer.
+func assertHaveSameRef(t *testing.T, r1, r2 tchannel.Registrar) {
+	p1, err := r1.Peers().Get()
+	assert.NoError(t, err, "First registrar has no peers.")
+
+	p2, err := r2.Peers().Get()
+	assert.NoError(t, err, "Second registrar has no peers.")
+
+	assert.True(t, p1 == p2, "Registrars have references to different peers.")
+}
+
+func assertNoPeer(t *testing.T, r tchannel.Registrar) {
+	_, err := r.Peers().Get()
+	assert.Equal(t, err, tchannel.ErrNoPeers)
+}
+
+func TestMainAddVisibility(t *testing.T) {
+	// Adding a peer to the main channel should be reflected in the subchannel,
+	// but not the isolated subchannel.
+	set, err := newSet()
+	if err != nil {
+		require.NoError(t, err, "newSet failed")
+	}
+
+	set.main.Peers().Add("127.0.0.1:3000")
+	assertHaveSameRef(t, set.main, set.sub)
+	assertNoPeer(t, set.isolated)
+}
+
+func TestSubchannelAddVisibility(t *testing.T) {
+	// Adding a peer to a non-isolated subchannel should be reflected in the
+	// main channel but not in isolated siblings.
+	set, err := newSet()
+	if err != nil {
+		require.NoError(t, err, "newSet failed")
+	}
+
+	set.sub.Peers().Add("127.0.0.1:3000")
+	assertHaveSameRef(t, set.main, set.sub)
+	assertNoPeer(t, set.isolated)
+}
+
+func TestIsolatedAddVisibility(t *testing.T) {
+	// Adding a peer to an isolated subchannel shouldn't change the main
+	// channel or sibling channels.
+	set, err := newSet()
+	if err != nil {
+		require.NoError(t, err, "newSet failed")
+	}
+
+	set.isolated.Peers().Add("127.0.0.1:3000")
+
+	_, err = set.isolated.Peers().Get()
+	assert.NoError(t, err)
+
+	assertNoPeer(t, set.main)
+	assertNoPeer(t, set.sub)
+}
+
+func TestAddReusesPeers(t *testing.T) {
+	// Adding to both a channel and an isolated subchannel shouldn't create two
+	// separate peers.
+	set, err := newSet()
+	if err != nil {
+		require.NoError(t, err, "newSet failed")
+	}
+
+	set.main.Peers().Add("127.0.0.1:3000")
+	set.isolated.Peers().Add("127.0.0.1:3000")
+
+	assertHaveSameRef(t, set.main, set.sub)
+	assertHaveSameRef(t, set.main, set.isolated)
+}


### PR DESCRIPTION
(Discussed with @prashantv last night.)

This PR allows subchannels to (optionally) maintain a separate peer list from the parent channel without creating duplicate connections to the same host. It accomplishes this by building an inheritance chain among peer lists such that parent lists are the union of their children's lists.

@prashantv is planning to add some extra tests to make sure that this approach works well with graceful shutdown. I'll leave it up to him whether the tests added to `channel_test.go` are necessary - they test a subset of the cases that `subchannel_test.go` explores, but they do so through a different interface.