### PR TITLE
Use introspection API to check for empty exchanges

### DIFF
--- a/frame_pool_test.go
+++ b/frame_pool_test.go
@@ -64,7 +64,7 @@ func TestFramesReleased(t *testing.T) {
 		maxRandArg           = 512 * 1024
 	)
 
-	var connections []*Connection
+	var serverExchanges, clientExchanges string
 	pool := NewRecordingFramePool()
 	WithVerifiedServer(t, &testutils.ChannelOpts{
 		ServiceName: "swap-server",
@@ -116,8 +116,8 @@ func TestFramesReleased(t *testing.T) {
 
 		wg.Wait()
 
-		connections = append(connections, GetConnections(serverCh)...)
-		connections = append(connections, GetConnections(clientCh)...)
+		serverExchanges = CheckEmptyExchanges(serverCh)
+		clientExchanges = CheckEmptyExchanges(clientCh)
 	})
 
 	// Wait a few milliseconds for the closing of channels to take effect.
@@ -128,8 +128,11 @@ func TestFramesReleased(t *testing.T) {
 	}
 
 	// Check the message exchanges and make sure they are all empty.
-	if exchangesLeft := CheckEmptyExchangesConns(connections); exchangesLeft != "" {
-		t.Errorf("Found uncleared message exchanges:\n%v", exchangesLeft)
+	if serverExchanges != "" {
+		t.Errorf("Found uncleared message exchanges on server:\n%s", serverExchanges)
+	}
+	if clientExchanges != "" {
+		t.Errorf("Found uncleared message exchanges on client:\n%s", clientExchanges)
 	}
 }
 

--- a/introspection.go
+++ b/introspection.go
@@ -76,6 +76,7 @@ type SubChannelRuntimeState struct {
 
 // ConnectionRuntimeState is the runtime state for a single connection.
 type ConnectionRuntimeState struct {
+	ID               uint32               `json:"id"`
 	ConnectionState  string               `json:"connectionState"`
 	LocalHostPort    string               `json:"localHostPort"`
 	RemoteHostPort   string               `json:"remoteHostPort"`
@@ -160,6 +161,7 @@ func (p *Peer) IntrospectState(opts *IntrospectionOptions) PeerRuntimeState {
 // IntrospectState returns the runtime state for this connection.
 func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRuntimeState {
 	return ConnectionRuntimeState{
+		ID:               c.connID,
 		ConnectionState:  c.state.String(),
 		LocalHostPort:    c.conn.LocalAddr().String(),
 		RemoteHostPort:   c.conn.RemoteAddr().String(),

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -42,17 +42,6 @@ func OutboundConnection(call *OutboundCall) (*Connection, net.Conn) {
 	return conn, conn.conn
 }
 
-// GetConnections returns all connections for a channel.
-func GetConnections(ch *Channel) []*Connection {
-	var connections []*Connection
-	for _, p := range ch.peers.peers {
-		for _, c := range p.connections {
-			connections = append(connections, c)
-		}
-	}
-	return connections
-}
-
 // NewSpan returns a Span for testing.
 func NewSpan(traceID uint64, parentID uint64, spanID uint64) Span {
 	return Span{traceID: traceID, parentID: parentID, spanID: spanID, flags: defaultTracingFlags}

--- a/verify_utils_test.go
+++ b/verify_utils_test.go
@@ -48,7 +48,7 @@ func WithVerifiedServer(t *testing.T, opts *testutils.ChannelOpts, f func(server
 	}
 
 	// Check the message exchanges and make sure they are all empty.
-	if exchangesLeft := CheckEmptyExchangesConns(GetConnections(ch)); exchangesLeft != "" {
+	if exchangesLeft := CheckEmptyExchanges(ch); exchangesLeft != "" {
 		t.Errorf("Found uncleared message exchanges:\n%v", exchangesLeft)
 	}
 }


### PR DESCRIPTION
Test-only refactoring lets us get rid of the test-only `GetConnections` function used to access the internal connections in a Channel.