### PR TITLE
Handle initReq with higher versions by downgrading in the initRes

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -332,7 +332,7 @@ func (c *Connection) handleInitReq(frame *Frame) {
 		return
 	}
 
-	if req.Version != CurrentProtocolVersion {
+	if req.Version < CurrentProtocolVersion {
 		c.protocolError(id, fmt.Errorf("Unsupported protocol version %d from peer", req.Version))
 		return
 	}


### PR DESCRIPTION
This is for backwards compatibility when we do introduce a v3 of the protocol.

cc @jcorbin 