### PR TITLE
Add InboundConnection test utility

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -508,6 +508,11 @@ func (c *Connection) recvMessage(ctx context.Context, msg message, resCh <-chan 
 	}
 }
 
+// RemotePeerInfo returns the peer info for the remote peer.
+func (c *Connection) RemotePeerInfo() PeerInfo {
+	return c.remotePeerInfo
+}
+
 // NextMessageID reserves the next available message id for this connection
 func (c *Connection) NextMessageID() uint32 {
 	return atomic.AddUint32(&c.nextMessageID, 1)

--- a/inbound.go
+++ b/inbound.go
@@ -58,6 +58,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 
 	c.log.Debugf("span=%s", callReq.Tracing)
 	call := new(InboundCall)
+	call.conn = c
 	ctx, cancel := newIncomingContext(call, callReq.TimeToLive, &callReq.Tracing)
 
 	mex, err := c.inbound.newExchange(ctx, c.framePool, callReq.messageType(), frame.Header.ID, mexChannelBufferSize)
@@ -199,6 +200,7 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall) {
 type InboundCall struct {
 	reqResReader
 
+	conn            *Connection
 	response        *InboundCallResponse
 	serviceName     string
 	operation       []byte

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -42,6 +42,17 @@ func OutboundConnection(call *OutboundCall) (*Connection, net.Conn) {
 	return conn, conn.conn
 }
 
+// InboundConnection returns the underlying connection for an incoming call.
+func InboundConnection(call IncomingCall) (*Connection, net.Conn) {
+	inboundCall, ok := call.(*InboundCall)
+	if !ok {
+		return nil, nil
+	}
+
+	conn := inboundCall.conn
+	return conn, conn.conn
+}
+
 // NewSpan returns a Span for testing.
 func NewSpan(traceID uint64, parentID uint64, spanID uint64) Span {
 	return Span{traceID: traceID, parentID: parentID, spanID: spanID, flags: defaultTracingFlags}


### PR DESCRIPTION
This allows tests to get the remote peer information for a given call.

r @junchaowu 