### PR TITLE
Embed ChannelOptions in testutils.ChannelOpts

### DIFF
--- a/frame_pool_test.go
+++ b/frame_pool_test.go
@@ -66,12 +66,10 @@ func TestFramesReleased(t *testing.T) {
 
 	var serverExchanges, clientExchanges string
 	pool := NewRecordingFramePool()
-	WithVerifiedServer(t, &testutils.ChannelOpts{
-		ServiceName: "swap-server",
-		DefaultConnectionOptions: ConnectionOptions{
-			FramePool: pool,
-		},
-	}, func(serverCh *Channel, hostPort string) {
+	opts := testutils.NewOpts().
+		SetServiceName("swap-server").
+		SetFramePool(pool)
+	WithVerifiedServer(t, opts, func(serverCh *Channel, hostPort string) {
 		serverCh.Register(raw.Wrap(&swapper{t}), "swap")
 
 		clientCh, err := NewChannel("swap-client", nil)
@@ -154,12 +152,10 @@ func TestDirtyFrameRequests(t *testing.T) {
 	// Create the largest required random cache.
 	testutils.RandBytes(argSizes[len(argSizes)-1])
 
-	WithVerifiedServer(t, &testutils.ChannelOpts{
-		ServiceName: "swap-server",
-		DefaultConnectionOptions: ConnectionOptions{
-			FramePool: dirtyFramePool{},
-		},
-	}, func(serverCh *Channel, hostPort string) {
+	opts := testutils.NewOpts().
+		SetServiceName("swap-server").
+		SetFramePool(dirtyFramePool{})
+	WithVerifiedServer(t, opts, func(serverCh *Channel, hostPort string) {
 		peerInfo := serverCh.PeerInfo()
 		serverCh.Register(raw.Wrap(&swapper{t}), "swap")
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -69,15 +69,13 @@ func TestStatsCalls(t *testing.T) {
 
 	clientStats := newRecordingStatsReporter()
 	serverStats := newRecordingStatsReporter()
-	serverOpts := &testutils.ChannelOpts{
-		StatsReporter: serverStats,
-	}
+	serverOpts := testutils.NewOpts().SetStatsReporter(serverStats)
 	WithVerifiedServer(t, serverOpts, func(serverCh *Channel, hostPort string) {
 		handler := raw.Wrap(newTestHandler(t))
 		serverCh.Register(handler, "echo")
 		serverCh.Register(handler, "app-error")
 
-		ch, err := testutils.NewClient(&testutils.ChannelOpts{StatsReporter: clientStats})
+		ch, err := testutils.NewClient(testutils.NewOpts().SetStatsReporter(clientStats))
 		require.NoError(t, err)
 
 		ctx, cancel := NewContext(time.Second * 5)

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutils
+
+import (
+	"flag"
+
+	"github.com/uber/tchannel-go"
+)
+
+var connectionLog = flag.Bool("connectionLog", false, "Enables connection logging in tests")
+
+// Default service names for the test channels.
+const (
+	DefaultServerName = "testService"
+	DefaultClientName = "testService-client"
+)
+
+// ChannelOpts contains options to create a test channel using WithServer
+type ChannelOpts struct {
+	tchannel.ChannelOptions
+
+	// ServiceName defaults to DefaultServerName or DefaultClientName.
+	ServiceName string
+}
+
+// SetServiceName sets ServiceName.
+func (o *ChannelOpts) SetServiceName(svcName string) *ChannelOpts {
+	o.ServiceName = svcName
+	return o
+}
+
+// SetStatsReporter sets StatsReporter in ChannelOptions.
+func (o *ChannelOpts) SetStatsReporter(statsReporter tchannel.StatsReporter) *ChannelOpts {
+	o.StatsReporter = statsReporter
+	return o
+}
+
+// SetTraceReporter sets TraceReporter in ChannelOptions.
+func (o *ChannelOpts) SetTraceReporter(traceReporter tchannel.TraceReporter) *ChannelOpts {
+	o.TraceReporter = traceReporter
+	return o
+}
+
+// SetFramePool sets FramePool in DefaultConnectionOptions.
+func (o *ChannelOpts) SetFramePool(framePool tchannel.FramePool) *ChannelOpts {
+	o.DefaultConnectionOptions.FramePool = framePool
+	return o
+}
+
+func defaultString(v string, defaultValue string) string {
+	if v == "" {
+		return defaultValue
+	}
+	return v
+}
+
+func getChannelOptions(opts *ChannelOpts) *tchannel.ChannelOptions {
+	if opts.Logger == nil && *connectionLog {
+		opts.Logger = tchannel.SimpleLogger
+	}
+	return &opts.ChannelOptions
+}
+
+// NewOpts returns a new ChannelOpts that can be used in a chained fashion.
+func NewOpts() *ChannelOpts { return &ChannelOpts{} }
+
+// DefaultOpts will return opts if opts is non-nil, NewOpts otherwise.
+func DefaultOpts(opts *ChannelOpts) *ChannelOpts {
+	if opts == nil {
+		return NewOpts()
+	}
+	return opts
+}

--- a/thrift/thrift_bench_test.go
+++ b/thrift/thrift_bench_test.go
@@ -52,12 +52,9 @@ var (
 const benchServerName = "bench-server"
 
 func setupBenchServer() ([]string, error) {
-	ch, err := testutils.NewServer(&testutils.ChannelOpts{
-		ServiceName: benchServerName,
-		DefaultConnectionOptions: tchannel.ConnectionOptions{
-			FramePool: tchannel.NewSyncFramePool(),
-		},
-	})
+	ch, err := testutils.NewServer(testutils.NewOpts().
+		SetServiceName(benchServerName).
+		SetFramePool(tchannel.NewSyncFramePool()))
 	if err != nil {
 		return nil, err
 	}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -129,7 +129,7 @@ func TestTraceReportingEnabled(t *testing.T) {
 		gotSpans = append(gotSpans, span)
 	})
 
-	traceReporterOpts := &testutils.ChannelOpts{TraceReporter: testTraceReporter}
+	traceReporterOpts := testutils.NewOpts().SetTraceReporter(testTraceReporter)
 	tests := []struct {
 		name       string
 		serverOpts *testutils.ChannelOpts
@@ -195,7 +195,7 @@ func TestTraceReportingDisabled(t *testing.T) {
 		gotCalls++
 	})
 
-	traceReporterOpts := &testutils.ChannelOpts{TraceReporter: testTraceReporter}
+	traceReporterOpts := testutils.NewOpts().SetTraceReporter(testTraceReporter)
 	WithVerifiedServer(t, traceReporterOpts, func(ch *Channel, hostPort string) {
 		ch.Register(raw.Wrap(newTestHandler(t)), "echo")
 


### PR DESCRIPTION
This simplifies the code as we don't copy from structs that look almost
exactly the same.