### PR TITLE
If timeout is set as 0, then the request should fail immediately

### DIFF
--- a/context_builder.go
+++ b/context_builder.go
@@ -125,9 +125,6 @@ func (cb *ContextBuilder) setIncomingCall(call IncomingCall) *ContextBuilder {
 // Build returns a ContextWithHeaders that can be used to make calls.
 func (cb *ContextBuilder) Build() (ContextWithHeaders, context.CancelFunc) {
 	timeout := cb.Timeout
-	if timeout == 0 {
-		timeout = defaultTimeout
-	}
 
 	if cb.TracingDisabled {
 		cb.span.EnableTracing(false)

--- a/context_test.go
+++ b/context_test.go
@@ -23,13 +23,12 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	. "github.com/uber/tchannel-go"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+	"golang.org/x/net/context"
 )
 
 var cn = "hello"
@@ -56,6 +55,15 @@ func TestNewContextBuilderDisableTracing(t *testing.T) {
 	defer cancel()
 
 	assert.False(t, CurrentSpan(ctx).TracingEnabled(), "Tracing should be disabled")
+}
+
+func TestNewContextTimeoutZero(t *testing.T) {
+	ctx, cancel := NewContextBuilder(0).Build()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	assert.True(t, ok, "Context missing deadline")
+	assert.True(t, deadline.Sub(time.Now()) <= 0, "Deadline should be Now or earlier")
 }
 
 func TestShardKeyPropagates(t *testing.T) {


### PR DESCRIPTION
If an inbound call comes in with ttl=0 (which should be invalid), we should timeout straight away. The code previously used 1 second.