### PR TITLE
Fix bugs related to writing after timeout

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -493,7 +493,7 @@ func (c *Connection) sendMessage(msg message) error {
 func (c *Connection) recvMessage(ctx context.Context, msg message, resCh <-chan *Frame) error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return GetContextError(ctx.Err())
 
 	case frame := <-resCh:
 		err := frame.read(msg)

--- a/connection.go
+++ b/connection.go
@@ -491,6 +491,10 @@ func (c *Connection) sendMessage(msg message) error {
 // recvMessage blocks waiting for a standalone response message (typically a
 // control message)
 func (c *Connection) recvMessage(ctx context.Context, msg message, resCh <-chan *Frame) error {
+	if err := ctx.Err(); err != nil {
+		return GetContextError(err)
+	}
+
 	select {
 	case <-ctx.Done():
 		return GetContextError(ctx.Err())

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,8 @@ package tchannel
 
 import (
 	"fmt"
+
+	"golang.org/x/net/context"
 )
 
 const (
@@ -129,6 +131,14 @@ func (se SystemError) Code() SystemErrCode {
 func IsSystemError(err error) bool {
 	_, ok := err.(SystemError)
 	return ok
+}
+
+// GetContextError converts the context error to a tchannel error.
+func GetContextError(err error) error {
+	if err == context.DeadlineExceeded {
+		return ErrTimeout
+	}
+	return err
 }
 
 // GetSystemErrorCode returns the code to report for the given error.  If the error is a SystemError, we can

--- a/errors.go
+++ b/errors.go
@@ -127,12 +127,6 @@ func (se SystemError) Code() SystemErrCode {
 	return se.code
 }
 
-// IsSystemError returns whether the error is a system error.
-func IsSystemError(err error) bool {
-	_, ok := err.(SystemError)
-	return ok
-}
-
 // GetContextError converts the context error to a tchannel error.
 func GetContextError(err error) error {
 	if err == context.DeadlineExceeded {

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -255,8 +255,9 @@ func (r *fragmentingReader) recvAndParseNextFragment(initial bool) error {
 
 	r.curFragment, r.err = r.receiver.recvNextFragment(initial)
 	if r.err != nil {
-		if IsSystemError(r.err) {
-			// System errors are still reported (e.g. latency, trace reporting).
+		if err, ok := r.err.(errorMessage); ok {
+			// Serialized system errors are still reported (e.g. latency, trace reporting).
+			r.err = err.AsSystemError()
 			r.receiver.doneReading(r.err)
 		}
 		return r.err

--- a/messages.go
+++ b/messages.go
@@ -292,6 +292,11 @@ func (m errorMessage) AsSystemError() error {
 	return NewSystemError(m.errCode, m.message)
 }
 
+// Error returns the error message from the converted
+func (m errorMessage) Error() string {
+	return m.AsSystemError().Error()
+}
+
 type pingReq struct {
 	noBodyMsg
 	id uint32

--- a/mex.go
+++ b/mex.go
@@ -64,7 +64,7 @@ func (mex *messageExchange) forwardPeerFrame(frame *Frame) error {
 	case <-mex.ctx.Done():
 		// Note: One slow reader processing a large request could stall the connection.
 		// If we see this, we need to increase the recvCh buffer size.
-		return mex.ctx.Err()
+		return GetContextError(mex.ctx.Err())
 	}
 }
 
@@ -76,7 +76,7 @@ func (mex *messageExchange) recvPeerFrame() (*Frame, error) {
 		return frame, nil
 
 	case <-mex.ctx.Done():
-		return nil, mex.ctx.Err()
+		return nil, GetContextError(mex.ctx.Err())
 	}
 }
 

--- a/mex.go
+++ b/mex.go
@@ -81,7 +81,8 @@ func (mex *messageExchange) recvPeerFrame() (*Frame, error) {
 }
 
 // recvPeerFrameOfType waits for a new frame of a given type from the peer, failing
-// if the next frame received is not of that type
+// if the next frame received is not of that type.
+// If an error frame is returned, then the errorMessage is returned as the error.
 func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, error) {
 	frame, err := mex.recvPeerFrame()
 	if err != nil {
@@ -101,7 +102,7 @@ func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, er
 		if err := errMsg.read(&rbuf); err != nil {
 			return nil, err
 		}
-		return nil, errMsg.AsSystemError()
+		return nil, errMsg
 
 	default:
 		// TODO(mmihic): Should be treated as a protocol error

--- a/outbound.go
+++ b/outbound.go
@@ -148,7 +148,6 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 // frame to the response channel waiting for it
 func (c *Connection) handleCallRes(frame *Frame) bool {
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
-		c.outbound.removeExchange(frame.Header.ID)
 		return true
 	}
 	return false
@@ -158,7 +157,6 @@ func (c *Connection) handleCallRes(frame *Frame) bool {
 // forwarding the frame to the response channel waiting for it
 func (c *Connection) handleCallResContinue(frame *Frame) bool {
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
-		c.outbound.removeExchange(frame.Header.ID)
 		return true
 	}
 	return false

--- a/reqres.go
+++ b/reqres.go
@@ -228,10 +228,10 @@ func (r *reqResReader) recvNextFragment(initial bool) (*readableFragment, error)
 	message := r.messageForFragment(initial)
 	frame, err := r.mex.recvPeerFrameOfType(message.messageType())
 	if err != nil {
-		if IsSystemError(err) {
-			// Record the error without shutting down the exchange, since this should go through
-			// the standard doneReading path.
-			r.err = err
+		if err, ok := err.(errorMessage); ok {
+			// If we received a serialized error from the other side, then we should go through
+			// the normal doneReading path so stats get updated with this error.
+			r.err = err.AsSystemError()
 			return nil, err
 		}
 

--- a/reqres.go
+++ b/reqres.go
@@ -142,6 +142,10 @@ func (w *reqResWriter) flushFragment(fragment *writableFragment) error {
 		return w.err
 	}
 
+	if err := w.mex.ctx.Err(); err != nil {
+		return w.failed(GetContextError(err))
+	}
+
 	frame := fragment.frame.(*Frame)
 	frame.Header.SetPayloadSize(uint16(fragment.contents.BytesWritten()))
 	select {

--- a/reqres.go
+++ b/reqres.go
@@ -110,6 +110,10 @@ func (w *reqResWriter) arg3Writer() (ArgWriter, error) {
 
 // newFragment creates a new fragment for marshaling into
 func (w *reqResWriter) newFragment(initial bool, checksum Checksum) (*writableFragment, error) {
+	if err := w.mex.ctx.Err(); err != nil {
+		return nil, w.failed(GetContextError(err))
+	}
+
 	message := w.messageForFragment(initial)
 
 	// Create the frame

--- a/reqres.go
+++ b/reqres.go
@@ -142,7 +142,7 @@ func (w *reqResWriter) flushFragment(fragment *writableFragment) error {
 	frame.Header.SetPayloadSize(uint16(fragment.contents.BytesWritten()))
 	select {
 	case <-w.mex.ctx.Done():
-		return w.failed(w.mex.ctx.Err())
+		return w.failed(GetContextError(w.mex.ctx.Err()))
 	case w.conn.sendCh <- frame:
 		return nil
 	}


### PR DESCRIPTION
context.DeadlineExceeded is now ErrTimeout

All code checking ctx.Done in a select will first ensure there's no errors already, since select will randomly select any of the available cases. 