### PR TITLE
Avoid previously selected peers when retrying

### DIFF
--- a/incoming_test.go
+++ b/incoming_test.go
@@ -68,7 +68,7 @@ func TestPeersIncomingConnection(t *testing.T) {
 		assert.NotNil(t, rootPeers[ringpopHostPort], "missing ringpop peer")
 
 		for _, sc := range []Registrar{ch, hyperbahnSC, ringpopSC} {
-			_, err := sc.Peers().Get()
+			_, err := sc.Peers().Get(nil)
 			assert.Equal(t, ErrNoPeers, err,
 				"incoming connections should not be added to non-root peer list")
 		}

--- a/peer_strategies.go
+++ b/peer_strategies.go
@@ -40,14 +40,3 @@ func (r *randCalculator) GetScore(p *Peer) uint64 {
 func newRandCalculator() *randCalculator {
 	return &randCalculator{rng: NewRand(time.Now().UnixNano())}
 }
-
-type preferIncomingCalculator struct {
-}
-
-func newPreferIncomingCalculator() *preferIncomingCalculator {
-	return &preferIncomingCalculator{}
-}
-
-func (r *preferIncomingCalculator) GetScore(p *Peer) uint64 {
-	return 0
-}

--- a/peer_test.go
+++ b/peer_test.go
@@ -21,7 +21,10 @@
 package tchannel_test
 
 import (
+	"fmt"
 	"testing"
+
+	. "github.com/uber/tchannel-go"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,8 +35,8 @@ func TestGetPeerNoPeer(t *testing.T) {
 	ch, err := testutils.NewClient(nil)
 	require.NoError(t, err, "NewClient failed")
 
-	peer, err := ch.Peers().Get()
-	assert.Error(t, err, "Empty peer list should return error")
+	peer, err := ch.Peers().Get(nil)
+	assert.Equal(t, ErrNoPeers, err, "Empty peer list should return error")
 	assert.Nil(t, peer, "should not return peer")
 }
 
@@ -43,7 +46,69 @@ func TestGetPeerSinglePeer(t *testing.T) {
 
 	ch.Peers().Add("1.1.1.1:1234")
 
-	peer, err := ch.Peers().Get()
+	peer, err := ch.Peers().Get(nil)
 	assert.NoError(t, err, "peer list should return contained element")
 	assert.Equal(t, "1.1.1.1:1234", peer.HostPort(), "returned peer mismatch")
+}
+
+func TestGetPeerAvoidPrevSelected(t *testing.T) {
+	const (
+		peer1 = "1.1.1.1:1"
+		peer2 = "2.2.2.2:2"
+		peer3 = "3.3.3.3:3"
+	)
+
+	ch, err := testutils.NewClient(nil)
+	require.NoError(t, err, "NewClient failed")
+
+	a, m := testutils.StrArray, testutils.StrMap
+	tests := []struct {
+		peers        []string
+		prevSelected map[string]struct{}
+		expected     map[string]struct{}
+	}{
+		{
+			peers:    a(peer1),
+			expected: m(peer1),
+		},
+		{
+			peers:        a(peer1, peer2),
+			prevSelected: m(peer1),
+			expected:     m(peer2),
+		},
+		{
+			peers:        a(peer1, peer2, peer3),
+			prevSelected: m(peer1, peer2),
+			expected:     m(peer3),
+		},
+		{
+			peers:        a(peer1),
+			prevSelected: m(peer1),
+			expected:     m(peer1),
+		},
+		{
+			peers:        a(peer1, peer2, peer3),
+			prevSelected: m(peer1, peer2, peer3),
+			expected:     m(peer1, peer2, peer3),
+		},
+	}
+
+	for i, tt := range tests {
+		peers := ch.GetSubChannel(fmt.Sprintf("test-%d", i), Isolated).Peers()
+		for _, p := range tt.peers {
+			peers.Add(p)
+		}
+
+		gotPeer, err := peers.Get(tt.prevSelected)
+		if err != nil {
+			t.Errorf("Got unexpected error selecting peer: %v", err)
+			continue
+		}
+
+		got := gotPeer.HostPort()
+		if _, ok := tt.expected[got]; !ok {
+			t.Errorf("Got unexpected peer, expected one of %v got %v\n  Peers = %v PrevSelected = %v",
+				tt.expected, got, tt.peers, tt.prevSelected)
+		}
+	}
 }

--- a/subchannel.go
+++ b/subchannel.go
@@ -77,7 +77,7 @@ func (c *SubChannel) BeginCall(ctx context.Context, operationName string, callOp
 		callOptions = defaultCallOptions
 	}
 
-	peer, err := c.peers.Get()
+	peer, err := c.peers.Get(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/subchannel_test.go
+++ b/subchannel_test.go
@@ -47,17 +47,17 @@ func withNewSet(t *testing.T, f func(*testing.T, chanSet)) {
 
 // Assert that two Registrars have references to the same Peer.
 func assertHaveSameRef(t *testing.T, r1, r2 tchannel.Registrar) {
-	p1, err := r1.Peers().Get()
+	p1, err := r1.Peers().Get(nil)
 	assert.NoError(t, err, "First registrar has no peers.")
 
-	p2, err := r2.Peers().Get()
+	p2, err := r2.Peers().Get(nil)
 	assert.NoError(t, err, "Second registrar has no peers.")
 
 	assert.True(t, p1 == p2, "Registrars have references to different peers.")
 }
 
 func assertNoPeer(t *testing.T, r tchannel.Registrar) {
-	_, err := r.Peers().Get()
+	_, err := r.Peers().Get(nil)
 	assert.Equal(t, err, tchannel.ErrNoPeers)
 }
 
@@ -87,7 +87,7 @@ func TestIsolatedAddVisibility(t *testing.T) {
 		// channel or sibling channels.
 		set.isolated.Peers().Add("127.0.0.1:3000")
 
-		_, err := set.isolated.Peers().Get()
+		_, err := set.isolated.Peers().Get(nil)
 		assert.NoError(t, err)
 
 		assertNoPeer(t, set.main)

--- a/testutils/lists.go
+++ b/testutils/lists.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutils
+
+// StrArray will return an array with the given strings.
+func StrArray(ss ...string) []string {
+	return ss
+}
+
+// StrMap returns a map where the keys are the given strings.
+func StrMap(ss ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ss))
+	for _, v := range ss {
+		m[v] = struct{}{}
+	}
+	return m
+}

--- a/thrift/client.go
+++ b/thrift/client.go
@@ -56,7 +56,7 @@ func (c *client) Call(ctx Context, thriftService, methodName string, req, resp t
 		peer = c.sc.Peers().GetOrAdd(c.opts.HostPort)
 	} else {
 		var err error
-		peer, err = c.sc.Peers().Get()
+		peer, err = c.sc.Peers().Get(nil)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Retries will try to avoid previously selected peers when possible.