### PR TITLE
Add version headers to init req/res

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -266,8 +268,11 @@ func (c *Connection) callOnCloseStateChange() {
 
 func (c *Connection) getInitParams() initParams {
 	return initParams{
-		InitParamHostPort:    c.localPeerInfo.HostPort,
-		InitParamProcessName: c.localPeerInfo.ProcessName,
+		InitParamHostPort:                c.localPeerInfo.HostPort,
+		InitParamProcessName:             c.localPeerInfo.ProcessName,
+		InitParamTChannelLanguage:        "go",
+		InitParamTChannelLanguageVersion: strings.TrimPrefix(runtime.Version(), "go"),
+		InitParamTChannelVersion:         VersionInfo,
 	}
 }
 

--- a/init_test.go
+++ b/init_test.go
@@ -23,6 +23,8 @@ package tchannel
 import (
 	"io"
 	"net"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -141,8 +143,11 @@ func TestHandleInitReqNewVersion(t *testing.T) {
 			initMessage: initMessage{
 				Version: CurrentProtocolVersion,
 				initParams: initParams{
-					InitParamHostPort:    ch.PeerInfo().HostPort,
-					InitParamProcessName: ch.PeerInfo().ProcessName,
+					InitParamHostPort:                ch.PeerInfo().HostPort,
+					InitParamProcessName:             ch.PeerInfo().ProcessName,
+					InitParamTChannelLanguage:        "go",
+					InitParamTChannelLanguageVersion: strings.TrimPrefix(runtime.Version(), "go"),
+					InitParamTChannelVersion:         VersionInfo,
 				},
 			},
 		}, msg, "unexpected init res")

--- a/messages.go
+++ b/messages.go
@@ -70,9 +70,14 @@ type initParams map[string]string
 const (
 	// InitParamHostPort contains the host and port of the peer process
 	InitParamHostPort = "host_port"
-
 	// InitParamProcessName contains the name of the peer process
 	InitParamProcessName = "process_name"
+	// InitParamTChannelLanguage contains the library language.
+	InitParamTChannelLanguage = "tchannel_language"
+	// InitParamTChannelLanguageVersion contains the language build/runtime version.
+	InitParamTChannelLanguageVersion = "tchannel_language_version"
+	// InitParamTChannelVersion contains the library version.
+	InitParamTChannelVersion = "tchannel_version"
 )
 
 // initMessage is the base for messages in the initialization handshake

--- a/version.go
+++ b/version.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+// VersionInfo identifies the version of the TChannel library.
+// Due to lack of proper package management, this version string will
+// be maintained manually.
+const VersionInfo = "0.0.1-dev"


### PR DESCRIPTION
Implements headers defined in https://github.com/uber/tchannel/pull/1398

Currently the version string is just 0.0.1-dev. I'll bump this manually on feature changes till I figure out a good long term solution.

cc @jcorbin @breerly 