### PR TITLE
Update Hyperbahn client to use retries

### DIFF
--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -86,6 +86,7 @@ func (c *Client) advertiseLoop() {
 				}
 				return
 			}
+			c.tchan.Logger().Warnf("Hyperbahn client registration failed (will retry): %v", err)
 			c.opts.Handler.OnError(ErrAdvertiseFailed{Cause: err, WillRetry: true})
 			sleepFor = fuzzInterval(advertiseRetryInterval * time.Duration(1<<consecutiveFailures))
 		} else {

--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -73,6 +73,7 @@ func (c *Client) advertiseLoop() {
 	for {
 		timeSleep(sleepFor)
 		if c.IsClosed() {
+			c.tchan.Logger().Infof("Hyperbahn client closed")
 			return
 		}
 

--- a/hyperbahn/call.go
+++ b/hyperbahn/call.go
@@ -70,12 +70,9 @@ func (c *Client) sendAdvertise() error {
 	// Disable tracing on Hyperbahn advertise messages to avoid cascading failures (see #790).
 	tchannel.CurrentSpan(ctx).EnableTracing(false)
 
-	sc := c.tchan.GetSubChannel(hyperbahnServiceName)
-	arg := c.createRequest()
 	var resp AdResponse
 	c.opts.Handler.On(SendAdvertise)
-
-	if err := json.CallSC(ctx, sc, "ad", arg, &resp); err != nil {
+	if err := c.client.Call(ctx, "ad", c.createRequest(), &resp); err != nil {
 		return err
 	}
 

--- a/hyperbahn/client.go
+++ b/hyperbahn/client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/uber/tchannel-go"
+	tjson "github.com/uber/tchannel-go/json"
 )
 
 // Client manages Hyperbahn connections and registrations.
@@ -36,6 +37,7 @@ type Client struct {
 	services []string
 	opts     ClientOptions
 	quit     chan struct{}
+	client   *tjson.Client
 }
 
 // FailStrategy is the strategy to use when registration fails maxRegistrationFailures
@@ -84,6 +86,7 @@ func NewClient(ch *tchannel.Channel, config Configuration, opts *ClientOptions) 
 		addPeer(ch, node)
 	}
 
+	client.client = tjson.NewClient(ch, hyperbahnServiceName, nil)
 	return client, nil
 }
 

--- a/retry.go
+++ b/retry.go
@@ -197,7 +197,7 @@ func (ch *Channel) RunWithRetry(ctx context.Context, f RetriableFunc) error {
 			return err
 		}
 
-		ch.log.Infof("Retrying request after it failed with error %v on attempt %v/%v", err, i, opts.MaxAttempts)
+		ch.log.Infof("Retrying request after it failed with error %v on attempt %v/%v", err, rs.Attempt, opts.MaxAttempts)
 	}
 
 	// Too many retries, return the last error


### PR DESCRIPTION
Use json.NewClient instead of the old json.Call* interface.

Fixes #55 