### PR TITLE
Disable retries when reporting traces to TCollector

### DIFF
--- a/json/call.go
+++ b/json/call.go
@@ -141,7 +141,6 @@ func wrapCall(ctx Context, call *tchannel.OutboundCall, operation string, arg, r
 		return respErr
 	}
 
-	fmt.Println("resp headers", respHeaders)
 	ctx.SetResponseHeaders(respHeaders)
 	return nil
 }

--- a/trace/zipkin_tracereporter.go
+++ b/trace/zipkin_tracereporter.go
@@ -90,6 +90,7 @@ func (r *ZipkinTraceReporter) Report(
 func (r *ZipkinTraceReporter) zipkinReport(data *zipkinData) error {
 	ctx, cancel := tc.NewContextBuilder(time.Second).
 		DisableTracing().
+		SetRetryOptions(&tc.RetryOptions{RetryOn: tc.RetryNever}).
 		SetShardKey(base64Encode(data.Span.TraceID())).Build()
 	defer cancel()
 

--- a/trace/zipkin_tracereporter.go
+++ b/trace/zipkin_tracereporter.go
@@ -106,7 +106,7 @@ func (r *ZipkinTraceReporter) zipkinReport(data *zipkinData) error {
 func (r *ZipkinTraceReporter) zipkinSpanWorker() {
 	for data := range r.c {
 		if err := r.zipkinReport(&data); err != nil {
-			r.logger.Infof("Zipkin Span submit failed. Get error: %v", err)
+			r.logger.Infof("Zipkin Span submit failed: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
The test was verified to fail with #59 but without the retry change.