### PR TITLE
Add outbound.calls.retries metric when doing retries

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -173,6 +173,14 @@ func (rs *RequestState) AddSelectedPeer(hostPort string) {
 	}
 }
 
+// RetryCount returns the retry attempt this is. Essentially, Attempt - 1.
+func (rs *RequestState) RetryCount() int {
+	if rs == nil {
+		return 0
+	}
+	return rs.Attempt - 1
+}
+
 // RunWithRetry will take a function that makes the TChannel call, and will
 // rerun it as specifed in the RetryOptions in the Context.
 func (ch *Channel) RunWithRetry(ctx context.Context, f RetriableFunc) error {

--- a/stats/statsdreporter.go
+++ b/stats/statsdreporter.go
@@ -74,6 +74,9 @@ func DefaultMetricPrefix(name string, tags map[string]string) string {
 	switch {
 	case strings.HasPrefix(name, "outbound"):
 		addKeys = append(addKeys, "service", "target-service", "target-endpoint")
+		if strings.HasPrefix(name, "outbound.calls.retries") {
+			addKeys = append(addKeys, "retry-count")
+		}
 	case strings.HasPrefix(name, "inbound"):
 		addKeys = append(addKeys, "calling-service", "service", "endpoint")
 	}

--- a/stats/statsdreporter_test.go
+++ b/stats/statsdreporter_test.go
@@ -39,6 +39,7 @@ func TestDefaultMetricPrefix(t *testing.T) {
 		"service":         "callerS",
 		"target-service":  "targetS",
 		"target-endpoint": "targetE",
+		"retry-count":     "retryN",
 	}
 	inboundTags := map[string]string{
 		"service":         "targetS",
@@ -55,6 +56,11 @@ func TestDefaultMetricPrefix(t *testing.T) {
 			name:     "outbound.calls.sent",
 			tags:     outboundTags,
 			expected: "tchannel.outbound.calls.sent.callerS.targetS.targetE",
+		},
+		{
+			name:     "outbound.calls.retries",
+			tags:     outboundTags,
+			expected: "tchannel.outbound.calls.retries.callerS.targetS.targetE.retryN",
 		},
 		{
 			name:     "inbound.calls.recvd",

--- a/stats_test.go
+++ b/stats_test.go
@@ -21,6 +21,7 @@
 package tchannel_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -209,8 +210,13 @@ func TestStatsWithRetries(t *testing.T) {
 				clientStats.Expected.IncCounter("outbound.calls.success", outboundTags, 1)
 			}
 			clientStats.Expected.IncCounter("outbound.calls.send", outboundTags, int64(tt.numAttempts))
-			for _, latency := range tt.perAttemptLatencies {
+			for i, latency := range tt.perAttemptLatencies {
 				clientStats.Expected.RecordTimer("outbound.calls.per-attempt.latency", outboundTags, latency)
+				if i > 0 {
+					tags := tagsForOutboundCall(serverCh, ch, "req")
+					tags["retry-count"] = fmt.Sprint(i)
+					clientStats.Expected.IncCounter("outbound.calls.retries", tags, 1)
+				}
 			}
 			clientStats.Expected.RecordTimer("outbound.calls.latency", outboundTags, tt.overallLatency)
 			clientStats.Validate(t)

--- a/stats_test.go
+++ b/stats_test.go
@@ -171,6 +171,19 @@ func TestStatsWithRetries(t *testing.T) {
 				perAttemptLatencies: a(20*time.Millisecond, 20*time.Millisecond),
 				overallLatency:      80 * time.Millisecond,
 			},
+			{
+				numFailures:         4,
+				numAttempts:         5,
+				perAttemptLatencies: a(20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond),
+				overallLatency:      200 * time.Millisecond,
+			},
+			{
+				numFailures:         5,
+				numAttempts:         5,
+				expectErr:           ErrServerBusy,
+				perAttemptLatencies: a(20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond),
+				overallLatency:      200 * time.Millisecond,
+			},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
Adds `outbound.calls.retries` metric as per #46 