### PR TITLE
Simplify testutils.NewServer and NewChannel

### DIFF
--- a/channel_utils_test.go
+++ b/channel_utils_test.go
@@ -25,18 +25,12 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
 )
 
 // NewServer creates a new server and returns the channel, service name, and host port.
 func NewServer(t testing.TB, opts *testutils.ChannelOpts) (*Channel, string, string) {
-	ch, err := testutils.NewServer(opts)
-	require.NoError(t, err, "NewServer failed")
-	if err != nil {
-		return nil, "", ""
-	}
-
+	ch := testutils.NewServer(t, opts)
 	peerInfo := ch.PeerInfo()
 	return ch, peerInfo.ServiceName, peerInfo.HostPort
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -196,8 +196,7 @@ func TestPing(t *testing.T) {
 		ctx, cancel := NewContext(time.Second)
 		defer cancel()
 
-		clientCh, err := testutils.NewClient(nil)
-		require.NoError(t, err)
+		clientCh := testutils.NewClient(t, nil)
 		require.NoError(t, clientCh.Ping(ctx, hostPort))
 	})
 }

--- a/hyperbahn/client_test.go
+++ b/hyperbahn/client_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
 )
@@ -105,11 +104,10 @@ func TestParseConfiguration(t *testing.T) {
 		}
 
 		config := Configuration{InitialNodes: tt.peersArg, InitialNodesFile: peerFile}
-		ch, err := testutils.NewClient(nil)
-		require.NoError(t, err, "%v: testutils.NewClient failed", tt.name)
+		ch := testutils.NewClient(t, nil)
 		defer ch.Close()
 
-		_, err = NewClient(ch, config, nil)
+		_, err := NewClient(ch, config, nil)
 		if tt.wantErr {
 			assert.Error(t, err, "%v: NewClient expected to fail")
 			continue

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -39,7 +39,7 @@ func TestActiveCallReq(t *testing.T) {
 	defer cancel()
 
 	// Note: This test leaks a message exchange due to the modification of IDs in the relay.
-	require.NoError(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	testutils.WithServer(t, nil, func(ch *Channel, hostPort string) {
 		gotCall := make(chan struct{})
 		unblock := make(chan struct{})
 
@@ -74,7 +74,7 @@ func TestActiveCallReq(t *testing.T) {
 			"expected already active error, got %v", err)
 
 		close(unblock)
-	}))
+	})
 }
 
 func TestInboundConnection(t *testing.T) {

--- a/incoming_test.go
+++ b/incoming_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/uber/tchannel-go"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
 )
 
@@ -40,10 +39,9 @@ func TestPeersIncomingConnection(t *testing.T) {
 	}()
 
 	newService := func(svcName string) (*Channel, string) {
-		ch, err := testutils.NewServer(&testutils.ChannelOpts{ServiceName: svcName})
-		require.NoError(t, err, "NewServer failed")
+		ch, _, hostPort := NewServer(t, &testutils.ChannelOpts{ServiceName: svcName})
 		channels = append(channels, ch)
-		return ch, ch.PeerInfo().HostPort
+		return ch, hostPort
 	}
 
 	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {

--- a/json/retry_test.go
+++ b/json/retry_test.go
@@ -25,14 +25,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
 )
 
 func TestRetryJSONCall(t *testing.T) {
-	ch, err := testutils.NewServer(nil)
-	require.NoError(t, err, "NewServer failed")
+	ch := testutils.NewServer(t, nil)
 	ch.Peers().Add(ch.PeerInfo().HostPort)
 
 	count := 0
@@ -51,7 +49,7 @@ func TestRetryJSONCall(t *testing.T) {
 	client := NewClient(ch, ch.ServiceName(), nil)
 
 	var res map[string]string
-	err = client.Call(ctx, "test", nil, &res)
+	err := client.Call(ctx, "test", nil, &res)
 	assert.NoError(t, err, "Call should succeed")
 	assert.Equal(t, 5, count, "Handler should have been invoked 5 times")
 }

--- a/peer_test.go
+++ b/peer_test.go
@@ -30,23 +30,18 @@ import (
 	. "github.com/uber/tchannel-go"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
 )
 
 func TestGetPeerNoPeer(t *testing.T) {
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
-
+	ch := testutils.NewClient(t, nil)
 	peer, err := ch.Peers().Get(nil)
 	assert.Equal(t, ErrNoPeers, err, "Empty peer list should return error")
 	assert.Nil(t, peer, "should not return peer")
 }
 
 func TestGetPeerSinglePeer(t *testing.T) {
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
-
+	ch := testutils.NewClient(t, nil)
 	ch.Peers().Add("1.1.1.1:1234")
 
 	peer, err := ch.Peers().Get(nil)
@@ -61,9 +56,7 @@ func TestGetPeerAvoidPrevSelected(t *testing.T) {
 		peer3 = "3.3.3.3:3"
 	)
 
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
-
+	ch := testutils.NewClient(t, nil)
 	a, m := testutils.StrArray, testutils.StrMap
 	tests := []struct {
 		peers        []string

--- a/retry_request_test.go
+++ b/retry_request_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/uber/tchannel-go"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
 	"golang.org/x/net/context"
@@ -37,18 +36,16 @@ func TestRequestStateRetry(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	server, err := testutils.NewServer(nil)
-	require.NoError(t, err, "NewServer failed")
+	server := testutils.NewServer(t, nil)
 	defer server.Close()
 	server.Register(raw.Wrap(newTestHandler(t)), "echo")
 
-	client, err := testutils.NewClient(nil)
+	client := testutils.NewClient(t, nil)
 	defer client.Close()
-	require.NoError(t, err, "NewClient failed")
 
 	counter := 0
 	sc := client.GetSubChannel(server.PeerInfo().ServiceName)
-	err = client.RunWithRetry(ctx, func(ctx context.Context, rs *RequestState) error {
+	err := client.RunWithRetry(ctx, func(ctx context.Context, rs *RequestState) error {
 		defer func() { counter++ }()
 
 		assert.Equal(t, counter, len(rs.SelectedPeers), "SelectedPeers should not be reused")

--- a/retry_test.go
+++ b/retry_test.go
@@ -104,8 +104,7 @@ func TestCanRetry(t *testing.T) {
 }
 
 func TestNoRetry(t *testing.T) {
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
+	ch := testutils.NewClient(t, nil)
 
 	e := getTestErrors()
 	retryOpts := &RetryOptions{RetryOn: RetryNever}
@@ -121,8 +120,7 @@ func TestNoRetry(t *testing.T) {
 }
 
 func TestRetryTillMaxAttempts(t *testing.T) {
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
+	ch := testutils.NewClient(t, nil)
 
 	setErr := ErrServerBusy
 	runTest := func(maxAttempts, numErrors, expectCounter int, expectErr error) {
@@ -167,9 +165,7 @@ func TestRetrySubContextNoTimeoutPerAttempt(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
-
+	ch := testutils.NewClient(t, nil)
 	counter := 0
 	ch.RunWithRetry(ctx, func(sctx context.Context, _ *RequestState) error {
 		counter++
@@ -185,9 +181,7 @@ func TestRetrySubContextTimeoutPerAttempt(t *testing.T) {
 		SetTimeoutPerAttempt(time.Millisecond).Build()
 	defer cancel()
 
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
-
+	ch := testutils.NewClient(t, nil)
 	var lastDeadline time.Time
 
 	counter := 0
@@ -209,8 +203,7 @@ func TestRetrySubContextTimeoutPerAttempt(t *testing.T) {
 
 func TestRetryNetConnect(t *testing.T) {
 	e := getTestErrors()
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err, "NewClient failed")
+	ch := testutils.NewClient(t, nil)
 
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()

--- a/subchannel_test.go
+++ b/subchannel_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
 )
@@ -36,8 +35,7 @@ type chanSet struct {
 }
 
 func withNewSet(t *testing.T, f func(*testing.T, chanSet)) {
-	ch, err := testutils.NewClient(nil)
-	require.NoError(t, err)
+	ch := testutils.NewClient(t, nil)
 	f(t, chanSet{
 		main:     ch,
 		sub:      ch.GetSubChannel("hyperbahn"),

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -31,19 +31,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// WithServer sets up a TChannel that is listening and runs the given function with the channel.
-func WithServer(opts *ChannelOpts, f func(ch *tchannel.Channel, hostPort string)) error {
-	ch, err := NewServer(opts)
-	if err != nil {
-		return err
-	}
-	f(ch, ch.PeerInfo().HostPort)
-	ch.Close()
-	return nil
-}
-
-// NewServer creates a TChannel that is listening and returns the channel.
-func NewServer(opts *ChannelOpts) (*tchannel.Channel, error) {
+// NewServerChannel creates a TChannel that is listening and returns the channel.
+func NewServerChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 	if opts == nil {
 		opts = &ChannelOpts{}
 	}
@@ -73,8 +62,8 @@ func NewServer(opts *ChannelOpts) (*tchannel.Channel, error) {
 
 var totalClients uint32
 
-// NewClient creates a TChannel that is not listening.
-func NewClient(opts *ChannelOpts) (*tchannel.Channel, error) {
+// NewClientChannel creates a TChannel that is not listening.
+func NewClientChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 	if opts == nil {
 		opts = &ChannelOpts{}
 	}

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -41,6 +41,17 @@ type ChannelOpts struct {
 
 	// ServiceName defaults to DefaultServerName or DefaultClientName.
 	ServiceName string
+
+	// LogVerification contains options for controlling the log verification.
+	LogVerification LogVerification
+
+	// optFn is run with the channel options before creating the channel.
+	optFn func(*ChannelOpts)
+}
+
+// LogVerification contains options to control the log verification.
+type LogVerification struct {
+	Disabled bool
 }
 
 // SetServiceName sets ServiceName.
@@ -84,6 +95,9 @@ func getChannelOptions(opts *ChannelOpts) *tchannel.ChannelOptions {
 	if opts.Logger == nil && *connectionLog {
 		opts.Logger = tchannel.SimpleLogger
 	}
+	if opts.optFn != nil {
+		opts.optFn(opts)
+	}
 	return &opts.ChannelOptions
 }
 
@@ -96,4 +110,10 @@ func DefaultOpts(opts *ChannelOpts) *ChannelOpts {
 		return NewOpts()
 	}
 	return opts
+}
+
+// WrapLogger wraps the given logger with extra verification.
+func (v *LogVerification) WrapLogger(l tchannel.Logger) tchannel.Logger {
+	// TODO(prashant): Add error log verification.
+	return l
 }

--- a/thrift/benchclient/main.go
+++ b/thrift/benchclient/main.go
@@ -45,9 +45,9 @@ var (
 func main() {
 	flag.Parse()
 
-	ch, err := testutils.NewClient(nil)
+	ch, err := testutils.NewClientChannel(nil)
 	if err != nil {
-		log.Fatalf("err")
+		log.Fatalf("Failed to create client channel: %v", err)
 	}
 
 	for _, host := range flag.Args() {

--- a/thrift/context_test.go
+++ b/thrift/context_test.go
@@ -47,7 +47,7 @@ func TestContextBuilder(t *testing.T) {
 	defer cancel()
 
 	var called bool
-	testutils.WithServer(nil, func(ch *tchannel.Channel, hostPort string) {
+	testutils.WithServer(t, nil, func(ch *tchannel.Channel, hostPort string) {
 		peerInfo := ch.PeerInfo()
 
 		testutils.RegisterFunc(t, ch, "SecondService::Echo", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {

--- a/thrift/thrift_bench_test.go
+++ b/thrift/thrift_bench_test.go
@@ -52,7 +52,7 @@ var (
 const benchServerName = "bench-server"
 
 func setupBenchServer() ([]string, error) {
-	ch, err := testutils.NewServer(testutils.NewOpts().
+	ch, err := testutils.NewServerChannel(testutils.NewOpts().
 		SetServiceName(benchServerName).
 		SetFramePool(tchannel.NewSyncFramePool()))
 	if err != nil {

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -196,10 +196,8 @@ func TestClientHostPort(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	s1ch, err := testutils.NewServer(nil)
-	require.NoError(t, err, "testutils.NewServer failed")
-	s2ch, err := testutils.NewServer(nil)
-	require.NoError(t, err, "testutils.NewServer failed")
+	s1ch := testutils.NewServer(t, nil)
+	s2ch := testutils.NewServer(t, nil)
 	defer s1ch.Close()
 	defer s2ch.Close()
 
@@ -289,7 +287,7 @@ func withSetup(t *testing.T, f func(ctx Context, args testArgs)) {
 }
 
 func setupServer(h *mocks.TChanSimpleService, sh *mocks.TChanSecondService) (*tchannel.Channel, *Server, error) {
-	ch, err := testutils.NewServer(nil)
+	ch, err := testutils.NewServerChannel(nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -302,7 +300,7 @@ func setupServer(h *mocks.TChanSimpleService, sh *mocks.TChanSecondService) (*tc
 
 func getClients(serverCh *tchannel.Channel) (gen.TChanSimpleService, gen.TChanSecondService, error) {
 	serverInfo := serverCh.PeerInfo()
-	ch, err := testutils.NewClient(nil)
+	ch, err := testutils.NewClientChannel(nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/trace/zipkin_tracereporter_test.go
+++ b/trace/zipkin_tracereporter_test.go
@@ -309,7 +309,7 @@ func withSetup(t *testing.T, f func(ctx thrift.Context, args testArgs)) {
 }
 
 func setupServer(h *mocks.TChanTCollector) (*tchannel.Channel, error) {
-	tchan, err := testutils.NewServer(&testutils.ChannelOpts{
+	tchan, err := testutils.NewServerChannel(&testutils.ChannelOpts{
 		ServiceName: tcollectorServiceName,
 	})
 	if err != nil {
@@ -322,7 +322,7 @@ func setupServer(h *mocks.TChanTCollector) (*tchannel.Channel, error) {
 }
 
 func getClient(dst string) (tchannel.TraceReporter, error) {
-	tchan, err := testutils.NewClient(nil)
+	tchan, err := testutils.NewClientChannel(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -164,13 +164,11 @@ func TestTraceReportingEnabled(t *testing.T) {
 		WithVerifiedServer(t, tt.serverOpts, func(ch *Channel, hostPort string) {
 			ch.Register(raw.Wrap(newTestHandler(t)), "echo")
 
-			clientCh, err := testutils.NewClient(tt.clientOpts)
-			require.NoError(t, err, "NewClient failed")
-
+			clientCh := testutils.NewClient(t, tt.clientOpts)
 			ctx, cancel := NewContext(time.Second)
 			defer cancel()
 
-			_, _, _, err = raw.Call(ctx, clientCh, hostPort, ch.PeerInfo().ServiceName, "echo", nil, []byte("arg3"))
+			_, _, _, err := raw.Call(ctx, clientCh, hostPort, ch.PeerInfo().ServiceName, "echo", nil, []byte("arg3"))
 			require.NoError(t, err, "raw.Call failed")
 
 			binaryAnnotations := []BinaryAnnotation{

--- a/verify_utils_test.go
+++ b/verify_utils_test.go
@@ -26,18 +26,17 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
 )
 
 // WithVerifiedServer runs the given test function with a server channel that is verified
 // at the end to make sure there are no leaks (e.g. no exchanges leaked).
 func WithVerifiedServer(t *testing.T, opts *testutils.ChannelOpts, f func(serverCh *Channel, hostPort string)) {
-	ch, err := testutils.NewServer(opts)
-	require.NoError(t, err, "NewServer failed")
-
-	f(ch, ch.PeerInfo().HostPort)
-	ch.Close()
+	var ch *Channel
+	testutils.WithServer(t, opts, func(serverCh *Channel, hostPort string) {
+		f(serverCh, hostPort)
+		ch = serverCh
+	})
 
 	// Wait till the channel is closed
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Now they take a testing.TB so they can require NoError