### PR TITLE
Add log verification to tests to ensure there are no unexpected logs

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -134,6 +134,10 @@ type Connection struct {
 	nextMessageID   uint32
 	events          connectionEvents
 	commonStatsTags map[string]string
+
+	// closeNetworkCalled is used to avoid errors from being logged
+	// when this side closes a connection.
+	closeNetworkCalled int32
 }
 
 // nextConnID gives an ID for each connection for debugging purposes.
@@ -614,8 +618,12 @@ func (c *Connection) readFrames(_ uint32) {
 	for {
 		frame := c.framePool.Get()
 		if err := frame.ReadIn(c.conn); err != nil {
+			if atomic.LoadInt32(&c.closeNetworkCalled) == 0 {
+				c.connectionError(err)
+			} else {
+				c.log.Debugf("Ignoring error after connection was closed: %v", err)
+			}
 			c.framePool.Release(frame)
-			c.connectionError(err)
 			return
 		}
 
@@ -756,6 +764,7 @@ func (c *Connection) closeNetwork() {
 	// NB(mmihic): The sender goroutine will exit once the connection is
 	// closed; no need to close the send channel (and closing the send
 	// channel would be dangerous since other goroutine might be sending)
+	atomic.AddInt32(&c.closeNetworkCalled, 1)
 	if err := c.conn.Close(); err != nil {
 		c.log.Warnf("could not close connection to peer %s: %v", c.remotePeerInfo, err)
 	}

--- a/connection.go
+++ b/connection.go
@@ -557,9 +557,12 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 				return nil
 			default: // If the send buffer is full, log and return an error.
 			}
+			c.log.Warnf("Could not send error frame to %s for %d : %v",
+				c.remotePeerInfo, id, err)
+		} else {
+			c.log.Infof("Could not send error frame to %s on closed conn for %d : %v",
+				c.remotePeerInfo, id, err)
 		}
-		c.log.Warnf("Could not send error frame to %s for %d : %v",
-			c.remotePeerInfo, id, err)
 		return fmt.Errorf("failed to send error frame")
 	})
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -203,7 +203,7 @@ func TestPing(t *testing.T) {
 
 func TestBadRequest(t *testing.T) {
 	// ch will log an error when it receives a request for an unknown handler.
-	opts := testutils.NewOpts().DisableLogVerification()
+	opts := testutils.NewOpts().AddLogFilter("Could not find handler", 1)
 	WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 		ctx, cancel := NewContext(time.Second)
 		defer cancel()
@@ -327,7 +327,7 @@ func TestFragmentationSlowReader(t *testing.T) {
 	}
 
 	// Inbound forward will timeout and cause a warning log.
-	opts := testutils.NewOpts().DisableLogVerification()
+	opts := testutils.NewOpts().AddLogFilter("Unable to forward frame", 1)
 	WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 		ch.Register(HandlerFunc(handler), "echo")
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -202,7 +202,9 @@ func TestPing(t *testing.T) {
 }
 
 func TestBadRequest(t *testing.T) {
-	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+	// ch will log an error when it receives a request for an unknown handler.
+	opts := testutils.NewOpts().DisableLogVerification()
+	WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 		ctx, cancel := NewContext(time.Second)
 		defer cancel()
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -326,7 +326,9 @@ func TestFragmentationSlowReader(t *testing.T) {
 		close(handlerComplete)
 	}
 
-	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+	// Inbound forward will timeout and cause a warning log.
+	opts := testutils.NewOpts().DisableLogVerification()
+	WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 		ch.Register(HandlerFunc(handler), "echo")
 
 		arg2 := testutils.RandBytes(MaxFramePayloadSize * MexChannelBufferSize)

--- a/hyperbahn/advertise_test.go
+++ b/hyperbahn/advertise_test.go
@@ -136,7 +136,11 @@ func runRetryTest(t *testing.T, f func(r *retryTest)) {
 	withSetup(t, func(hypCh *tchannel.Channel, hostPort string) {
 		json.Register(hypCh, json.Handlers{"ad": r.adHandler}, nil)
 
-		serverCh := testutils.NewServer(t, &testutils.ChannelOpts{ServiceName: "my-client"})
+		// Advertise failures cause warning log messages.
+		opts := testutils.NewOpts().
+			SetServiceName("my-client").
+			AddLogFilter("Hyperbahn client registration failed", 10)
+		serverCh := testutils.NewServer(t, opts)
 		defer serverCh.Close()
 
 		var err error

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -38,8 +38,11 @@ func TestActiveCallReq(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	// Note: This test leaks a message exchange due to the modification of IDs in the relay.
-	testutils.WithServer(t, nil, func(ch *Channel, hostPort string) {
+	// Note: This test cannot use log verification as the duplicate ID causes a log.
+	// It does not use a verified server, as it leaks a message exchange due to the
+	// modification of IDs in the relay.
+	opts := testutils.NewOpts().DisableLogVerification()
+	testutils.WithServer(t, opts, func(ch *Channel, hostPort string) {
 		gotCall := make(chan struct{})
 		unblock := make(chan struct{})
 

--- a/mex.go
+++ b/mex.go
@@ -239,14 +239,14 @@ func (mexset *messageExchangeSet) forwardPeerFrame(frame *Frame) error {
 
 	if mex == nil {
 		// This is ok since the exchange might have expired or been cancelled
-		mexset.log.Warnf("received frame %s for %s message exchange that no longer exists",
+		mexset.log.Infof("received frame %s for %s message exchange that no longer exists",
 			frame.Header, mexset.name)
 		return nil
 	}
 
 	if err := mex.forwardPeerFrame(frame); err != nil {
-		mexset.log.Warnf("Unable to forward frame ID %v type %v length %v to peer: %v",
-			frame.Header.ID, frame.Header.messageType, frame.Header.FrameSize(), err)
+		mexset.log.Warnf("Unable to forward frame ID %v type %v length %v to %s: %v",
+			frame.Header.ID, frame.Header.messageType, frame.Header.FrameSize(), mexset.name, err)
 		return err
 	}
 

--- a/mex.go
+++ b/mex.go
@@ -239,7 +239,8 @@ func (mexset *messageExchangeSet) forwardPeerFrame(frame *Frame) error {
 
 	if mex == nil {
 		// This is ok since the exchange might have expired or been cancelled
-		mexset.log.Warnf("received frame %s for message exchange that no longer exists", frame.Header)
+		mexset.log.Warnf("received frame %s for %s message exchange that no longer exists",
+			frame.Header, mexset.name)
 		return nil
 	}
 

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -53,6 +53,14 @@ type ChannelOpts struct {
 // LogVerification contains options to control the log verification.
 type LogVerification struct {
 	Disabled bool
+
+	// AllowedFilter specifies the substring match to search
+	// for in the log message to skip raising an error.
+	AllowedFilter string
+
+	// AllowedCount is the maximum number of allowed warn+ logs matching
+	// AllowedFilter before errors are raised.
+	AllowedCount int
 }
 
 // SetServiceName sets ServiceName.
@@ -91,6 +99,14 @@ func (o *ChannelOpts) DisableLogVerification() *ChannelOpts {
 	return o
 }
 
+// AddLogFilter sets an allowed filter for warning/error logs and sets
+// the maximum number of times that log can occur.
+func (o *ChannelOpts) AddLogFilter(filter string, maxCount int) *ChannelOpts {
+	o.LogVerification.AllowedFilter = filter
+	o.LogVerification.AllowedCount = maxCount
+	return o
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue
@@ -121,5 +137,5 @@ func DefaultOpts(opts *ChannelOpts) *ChannelOpts {
 
 // WrapLogger wraps the given logger with extra verification.
 func (v *LogVerification) WrapLogger(t testing.TB, l tchannel.Logger) tchannel.Logger {
-	return errorLogger{l, t}
+	return errorLogger{l, t, v, &errorLoggerState{}}
 }

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -22,6 +22,7 @@ package testutils
 
 import (
 	"flag"
+	"testing"
 	"time"
 
 	"github.com/uber/tchannel-go"
@@ -113,7 +114,6 @@ func DefaultOpts(opts *ChannelOpts) *ChannelOpts {
 }
 
 // WrapLogger wraps the given logger with extra verification.
-func (v *LogVerification) WrapLogger(l tchannel.Logger) tchannel.Logger {
-	// TODO(prashant): Add error log verification.
-	return l
+func (v *LogVerification) WrapLogger(t testing.TB, l tchannel.Logger) tchannel.Logger {
+	return errorLogger{l, t}
 }

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -85,6 +85,12 @@ func (o *ChannelOpts) SetTimeNow(timeNow func() time.Time) *ChannelOpts {
 	return o
 }
 
+// DisableLogVerification disables log verification for this channel.
+func (o *ChannelOpts) DisableLogVerification() *ChannelOpts {
+	o.LogVerification.Disabled = true
+	return o
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -165,6 +165,7 @@ func TestTraceReportingEnabled(t *testing.T) {
 			ch.Register(raw.Wrap(newTestHandler(t)), "echo")
 
 			clientCh := testutils.NewClient(t, tt.clientOpts)
+			defer clientCh.Close()
 			ctx, cancel := NewContext(time.Second)
 			defer cancel()
 


### PR DESCRIPTION
All tests using `testutils.NewServer` or `testutils.NewClient` will have log verification enabled by default. Log verification ensures there are no warning of errors logged in tests, unless explicitly allowed.

Warning logs which should not have been warnings are cleaned up:
 - Message exchange missing
 - Connection reset error after the connection was explicitly closed.