### PR TITLE
Retry unexpected errors in Hyperbahn client

### DIFF
--- a/hyperbahn/advertise_test.go
+++ b/hyperbahn/advertise_test.go
@@ -52,7 +52,7 @@ func TestInitialAdvertiseFailedRetry(t *testing.T) {
 		count := 0
 		adHandler := func(ctx json.Context, req *AdRequest) (*AdResponse, error) {
 			count++
-			return nil, tchannel.ErrServerBusy
+			return nil, tchannel.NewSystemError(tchannel.ErrCodeUnexpected, "unexpected")
 		}
 		json.Register(hypCh, json.Handlers{"ad": adHandler}, nil)
 

--- a/hyperbahn/call.go
+++ b/hyperbahn/call.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 
 	"github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/json"
 )
 
 var errEphemeralPeer = errors.New("cannot advertise on channel that has not called ListenAndServe")
@@ -64,7 +63,9 @@ func (c *Client) sendAdvertise() error {
 		return errEphemeralPeer
 	}
 
-	ctx, cancel := json.NewContext(c.opts.Timeout)
+	ctx, cancel := tchannel.NewContextBuilder(c.opts.Timeout).
+		SetRetryOptions(&tchannel.RetryOptions{RetryOn: tchannel.RetryIdempotent}).
+		Build()
 	defer cancel()
 
 	// Disable tracing on Hyperbahn advertise messages to avoid cascading failures (see #790).

--- a/retry_test.go
+++ b/retry_test.go
@@ -87,6 +87,7 @@ func TestCanRetry(t *testing.T) {
 		{RetryConnectionError, []error{e.Busy, e.Declined, e.Network, e.Connection}},
 		{RetryNonIdempotent, []error{e.Busy, e.Declined}},
 		{RetryUnexpected, []error{e.Busy, e.Declined, e.Unexpected}},
+		{RetryIdempotent, []error{e.Busy, e.Declined, e.Timeout, e.Network, e.Connection, e.Unexpected, e.Cancelled}},
 	}
 
 	for _, tt := range tests {

--- a/retryon_string.go
+++ b/retryon_string.go
@@ -4,9 +4,9 @@ package tchannel
 
 import "fmt"
 
-const _RetryOn_name = "RetryDefaultRetryConnectionErrorRetryNeverRetryNonIdempotentRetryUnexpected"
+const _RetryOn_name = "RetryDefaultRetryConnectionErrorRetryNeverRetryNonIdempotentRetryUnexpectedRetryIdempotent"
 
-var _RetryOn_index = [...]uint8{0, 12, 32, 42, 60, 75}
+var _RetryOn_index = [...]uint8{0, 12, 32, 42, 60, 75, 90}
 
 func (i RetryOn) String() string {
 	if i < 0 || i+1 >= RetryOn(len(_RetryOn_index)) {


### PR DESCRIPTION
Hyperbahn is idempotent, so add a `RetryIdempotent` option and use it in the Hyperbahn client.
Fixes #63