### PR TITLE
Outbound calls to host:port should use root peers

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -328,7 +328,7 @@ func (ch *Channel) rootPeers() *RootPeerList {
 // BeginCall starts a new call to a remote peer, returning an OutboundCall that can
 // be used to write the arguments of the call.
 func (ch *Channel) BeginCall(ctx context.Context, hostPort, serviceName, operationName string, callOptions *CallOptions) (*OutboundCall, error) {
-	p := ch.peers.GetOrAdd(hostPort)
+	p := ch.rootPeers().GetOrAdd(hostPort)
 	return p.BeginCall(ctx, serviceName, operationName, callOptions)
 }
 
@@ -381,7 +381,7 @@ func (ch *Channel) serve() {
 
 // Ping sends a ping message to the given hostPort and waits for a response.
 func (ch *Channel) Ping(ctx context.Context, hostPort string) error {
-	peer := ch.Peers().GetOrAdd(hostPort)
+	peer := ch.rootPeers().GetOrAdd(hostPort)
 	conn, err := peer.GetConnection(ctx)
 	if err != nil {
 		return err

--- a/channel_test.go
+++ b/channel_test.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"golang.org/x/net/context"
 )
 
 func toMap(fields LogFields) map[string]interface{} {
@@ -106,7 +104,7 @@ func TestIsolatedSubChannelsDontSharePeers(t *testing.T) {
 
 	// Uses of the parent channel should be reflected in the subchannel, but
 	// not the isolated subchannel.
-	ch.BeginCall(context.Background(), "127.0.0.1:3000", "foo", "Bar::baz", nil)
+	ch.Peers().Add("127.0.0.1:3000")
 	assert.NotNil(t, ch.peers.peersByHostPort["127.0.0.1:3000"])
 	assert.NotNil(t, sub.peers.peersByHostPort["127.0.0.1:3000"])
 	assert.Nil(t, isolatedSub.peers.peersByHostPort["127.0.0.1:3000"])

--- a/thrift/client.go
+++ b/thrift/client.go
@@ -55,8 +55,7 @@ func NewClient(ch *tchannel.Channel, serviceName string, opts *ClientOptions) TC
 
 func (c *client) startCall(ctx context.Context, operation string, callOptions *tchannel.CallOptions) (*tchannel.OutboundCall, error) {
 	if c.opts.HostPort != "" {
-		return c.sc.Peers().GetOrAdd(c.opts.HostPort).
-			BeginCall(ctx, c.serviceName, operation, callOptions)
+		return c.ch.BeginCall(ctx, c.opts.HostPort, c.serviceName, operation, callOptions)
 	}
 	return c.sc.BeginCall(ctx, operation, callOptions)
 }


### PR DESCRIPTION
When calling a specific host:port, peers should not be added to the
shared peers list, but only to the root peers.