### PR TITLE
Optimize metric key generation

### DIFF
--- a/stats/metrickey.go
+++ b/stats/metrickey.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package stats
+
+import (
+	"regexp"
+	"strings"
+)
+
+// DefaultMetricPrefix is the default mapping for metrics to statsd keys.
+func DefaultMetricPrefix(name string, tags map[string]string) string {
+	parts := []string{"tchannel", name}
+
+	var addKeys []string
+	switch {
+	case strings.HasPrefix(name, "outbound"):
+		addKeys = append(addKeys, "service", "target-service", "target-endpoint")
+		if strings.HasPrefix(name, "outbound.calls.retries") {
+			addKeys = append(addKeys, "retry-count")
+		}
+	case strings.HasPrefix(name, "inbound"):
+		addKeys = append(addKeys, "calling-service", "service", "endpoint")
+	}
+
+	for _, k := range addKeys {
+		v, ok := tags[k]
+		if !ok {
+			v = "no-" + k
+		}
+		parts = append(parts, clean(v))
+	}
+	return strings.Join(parts, ".")
+}
+
+var specialChars = regexp.MustCompile(`[{}/\\:\s.]`)
+
+// clean replaces special characters [{}/\\:\s.] with '-'
+func clean(keyPart string) string {
+	return specialChars.ReplaceAllString(keyPart, "-")
+}

--- a/stats/metrickey_test.go
+++ b/stats/metrickey_test.go
@@ -21,6 +21,7 @@
 package stats
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +87,9 @@ func TestClean(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.expected, clean(tt.key), "clean(%q) failed", tt.key)
+		buf := &bytes.Buffer{}
+		writeClean(buf, tt.key)
+		assert.Equal(t, tt.expected, buf.String(), "clean(%q) failed", tt.key)
 	}
 }
 
@@ -99,6 +102,7 @@ func BenchmarkMetricPrefix(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
+		MetricWithPrefix("", "outbound.calls.retries", outboundTags)
 		DefaultMetricPrefix("outbound.calls.retries", outboundTags)
 	}
 }

--- a/stats/metrickey_test.go
+++ b/stats/metrickey_test.go
@@ -26,14 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func mapWith(m map[string]string, key, value string) map[string]string {
-	newMap := map[string]string{key: value}
-	for k, v := range m {
-		newMap[k] = v
-	}
-	return newMap
-}
-
 func TestDefaultMetricPrefix(t *testing.T) {
 	outboundTags := map[string]string{
 		"service":         "callerS",

--- a/stats/metrickey_test.go
+++ b/stats/metrickey_test.go
@@ -89,3 +89,16 @@ func TestClean(t *testing.T) {
 		assert.Equal(t, tt.expected, clean(tt.key), "clean(%q) failed", tt.key)
 	}
 }
+
+func BenchmarkMetricPrefix(b *testing.B) {
+	outboundTags := map[string]string{
+		"service":         "callerS",
+		"target-service":  "targetS",
+		"target-endpoint": "targetE",
+		"retry-count":     "retryN",
+	}
+
+	for i := 0; i < b.N; i++ {
+		DefaultMetricPrefix("outbound.calls.retries", outboundTags)
+	}
+}

--- a/stats/statsdreporter.go
+++ b/stats/statsdreporter.go
@@ -21,8 +21,6 @@
 package stats
 
 import (
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/cactus/go-statsd-client/statsd"
@@ -64,36 +62,4 @@ func (r *statsdReporter) UpdateGauge(name string, tags map[string]string, value 
 
 func (r *statsdReporter) RecordTimer(name string, tags map[string]string, d time.Duration) {
 	r.client.TimingDuration(MetricKey(name, tags), d, samplingRate)
-}
-
-// DefaultMetricPrefix is the default mapping for metrics to statsd keys.
-func DefaultMetricPrefix(name string, tags map[string]string) string {
-	parts := []string{"tchannel", name}
-
-	var addKeys []string
-	switch {
-	case strings.HasPrefix(name, "outbound"):
-		addKeys = append(addKeys, "service", "target-service", "target-endpoint")
-		if strings.HasPrefix(name, "outbound.calls.retries") {
-			addKeys = append(addKeys, "retry-count")
-		}
-	case strings.HasPrefix(name, "inbound"):
-		addKeys = append(addKeys, "calling-service", "service", "endpoint")
-	}
-
-	for _, k := range addKeys {
-		v, ok := tags[k]
-		if !ok {
-			v = "no-" + k
-		}
-		parts = append(parts, clean(v))
-	}
-	return strings.Join(parts, ".")
-}
-
-var specialChars = regexp.MustCompile(`[{}/\\:\s.]`)
-
-// clean replaces special characters [{}/\\:\s.] with '-'
-func clean(keyPart string) string {
-	return specialChars.ReplaceAllString(keyPart, "-")
 }


### PR DESCRIPTION
Pool a `bytes.Buffer` and use that rather than creating new strings using `strings.Join`.