### PR TITLE
Support pprof integration in TChannel

### DIFF
--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pprof
+
+import (
+	"net/http"
+
+	_ "net/http/pprof" // So pprof endpoints are registered on DefaultServeMux.
+
+	"github.com/uber/tchannel-go"
+	thttp "github.com/uber/tchannel-go/http"
+	"golang.org/x/net/context"
+)
+
+func serveHTTP(req *http.Request, response *tchannel.InboundCallResponse) {
+	rw, finish := thttp.ResponseWriter(response)
+	http.DefaultServeMux.ServeHTTP(rw, req)
+	finish()
+}
+
+// Register registers pprof endpoints on the given registrar under _pprof.
+// The _pprof endpoint uses as-http and is a tunnel to the default serve mux.
+func Register(registrar tchannel.Registrar) {
+	handler := func(ctx context.Context, call *tchannel.InboundCall) {
+		req, err := thttp.ReadRequest(call)
+		if err != nil {
+			registrar.Logger().Warnf("Failed to read HTTP request: %v", err)
+			return
+		}
+
+		serveHTTP(req, call.Response())
+	}
+	registrar.Register(tchannel.HandlerFunc(handler), "_pprof")
+}

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pprof
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+	thttp "github.com/uber/tchannel-go/http"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+func TestPProfEndpoint(t *testing.T) {
+	ch := testutils.NewServer(t, nil)
+	Register(ch)
+
+	ctx, cancel := tchannel.NewContext(time.Second)
+	defer cancel()
+
+	req, err := http.NewRequest("GET", "/debug/pprof/block?debug=1", nil)
+	require.NoError(t, err, "NewRequest failed")
+
+	call, err := ch.BeginCall(ctx, ch.PeerInfo().HostPort, ch.ServiceName(), "_pprof", nil)
+	require.NoError(t, err, "BeginCall failed")
+	require.NoError(t, err, thttp.WriteRequest(call, req), "thttp.WriteRequest failed")
+
+	response, err := thttp.ReadResponse(call.Response())
+	require.NoError(t, err, "ReadResponse failed")
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	body, err := ioutil.ReadAll(response.Body)
+	if assert.NoError(t, err, "Read body failed") {
+		assert.Contains(t, string(body), "contention", "Response does not contain expected string")
+	}
+}


### PR DESCRIPTION
Use as-http to accept HTTP requests for pprof over TChannel.
A proxy should be used to accept HTTP connections from go tool pprof
and convert them to TChannel.