### PR TITLE
Add more features to tchannel benchmarks

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/uber/tchannel-go",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.5.1",
 	"Packages": [
 		"./..."
 	],
@@ -15,13 +15,25 @@
 			"Rev": "e2d8818d10f59a279d5a97778c1c4ecdbcd5c9df"
 		},
 		{
+			"ImportPath": "github.com/davecgh/go-spew/spew",
+			"Rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
+		},
+		{
 			"ImportPath": "github.com/jessevdk/go-flags",
 			"Comment": "v1-297-g1b89bf7",
 			"Rev": "1b89bf73cd2c3a911d7b2a279ab085c4a18cf539"
 		},
 		{
+			"ImportPath": "github.com/pmezard/go-difflib/difflib",
+			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+		},
+		{
 			"ImportPath": "github.com/samuel/go-thrift/parser",
 			"Rev": "713394955d265d43898cc08f6240fe0f488e8eb6"
+		},
+		{
+			"ImportPath": "github.com/streadway/quantile",
+			"Rev": "b0c588724d25ae13f5afb3d90efec0edc636432b"
 		},
 		{
 			"ImportPath": "github.com/stretchr/objx",

--- a/connection_bench_test.go
+++ b/connection_bench_test.go
@@ -21,17 +21,21 @@
 package tchannel_test
 
 import (
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	. "github.com/uber/tchannel-go"
 
+	"github.com/streadway/quantile"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
 	"golang.org/x/net/context"
 )
+
+const benchService = "bench-server"
 
 type benchmarkHandler struct{}
 
@@ -45,64 +49,152 @@ func (h *benchmarkHandler) Handle(ctx context.Context, args *raw.Args) (*raw.Res
 func (h *benchmarkHandler) OnError(ctx context.Context, err error) {
 }
 
-func setupServer(b *testing.B) (ch *Channel, svcName, svcHostPort string) {
-	serverCh := testutils.NewServer(b, nil)
+type latencyTracker struct {
+	sync.Mutex
+
+	started   time.Time
+	estimator *quantile.Estimator
+}
+
+func newLatencyTracker() *latencyTracker {
+	return &latencyTracker{
+		estimator: quantile.New(
+			quantile.Unknown(0.01),
+			quantile.Known(0.50, 0.01),
+			quantile.Known(0.95, 0.001),
+			quantile.Known(0.99, 0.0005),
+			quantile.Known(1.0, 0.0005),
+		),
+		started: time.Now(),
+	}
+}
+
+func (lt *latencyTracker) addLatency(d time.Duration) {
+	lt.Lock()
+	lt.estimator.Add(float64(d))
+	lt.Unlock()
+}
+
+func (lt *latencyTracker) reset() {
+	*lt = *newLatencyTracker()
+}
+
+func (lt *latencyTracker) report(t testing.TB) {
+	duration := time.Since(lt.started)
+	lt.Lock()
+	t.Logf("%6v calls, %5.0f RPS (%v per call). Latency: Average: %v P95: %v P99: %v P100: %v",
+		lt.estimator.Samples(),
+		float64(lt.estimator.Samples())/float64(duration)*float64(time.Second),
+		duration/time.Duration(lt.estimator.Samples()),
+		time.Duration(lt.estimator.Get(0.50)),
+		time.Duration(lt.estimator.Get(0.95)),
+		time.Duration(lt.estimator.Get(0.99)),
+		time.Duration(lt.estimator.Get(1.0)),
+	)
+	lt.Unlock()
+}
+
+func setupServer(t testing.TB) *Channel {
+	serverCh := testutils.NewServer(t, testutils.NewOpts().SetServiceName("bench-server"))
 	handler := &benchmarkHandler{}
 	serverCh.Register(raw.Wrap(handler), "echo")
+	return serverCh
+}
 
-	peerInfo := serverCh.PeerInfo()
-	return serverCh, peerInfo.ServiceName, peerInfo.HostPort
+type benchmarkConfig struct {
+	numCalls         int
+	numServers       int
+	numClients       int
+	workersPerClient int
+	numBytes         int
+}
+
+func benchmarkCallsN(b *testing.B, c benchmarkConfig) {
+	var (
+		clients []*Channel
+		servers []*Channel
+	)
+	lt := newLatencyTracker()
+
+	if c.numBytes == 0 {
+		c.numBytes = 100
+	}
+	data := testutils.RandBytes(c.numBytes)
+
+	// Set up clients and servers.
+	for i := 0; i < c.numServers; i++ {
+		servers = append(servers, setupServer(b))
+	}
+	for i := 0; i < c.numClients; i++ {
+		clients = append(clients, testutils.NewClient(b, nil))
+		for _, s := range servers {
+			clients[i].Peers().Add(s.PeerInfo().HostPort)
+
+			// Initialize a connection
+			ctx, cancel := NewContext(50 * time.Millisecond)
+			assert.NoError(b, clients[i].Ping(ctx, s.PeerInfo().HostPort), "Initial ping failed")
+			cancel()
+		}
+	}
+
+	// Make calls from clients to the servers
+	call := func(sc *SubChannel) {
+		ctx, cancel := NewContext(50 * time.Millisecond)
+		start := time.Now()
+		_, _, _, err := raw.CallSC(ctx, sc, "echo", nil, data)
+		duration := time.Since(start)
+		cancel()
+		if assert.NoError(b, err, "Call failed") {
+			lt.addLatency(duration)
+		}
+	}
+
+	reqsLeft := testutils.Decrementor(c.numCalls)
+	clientWorker := func(client *Channel, clientNum, workerNum int) {
+		sc := client.GetSubChannel(benchService)
+		for reqsLeft() {
+			call(sc)
+		}
+	}
+	clientRunner := func(client *Channel, clientNum int) {
+		testutils.RunN(c.workersPerClient, func(i int) {
+			clientWorker(client, clientNum, i)
+		})
+	}
+
+	lt.reset()
+	defer lt.report(b)
+	b.ResetTimer()
+
+	testutils.RunN(c.numClients, func(i int) {
+		clientRunner(clients[i], i)
+	})
 }
 
 func BenchmarkCallsSerial(b *testing.B) {
-	serverCh, svcName, svcHostPort := setupServer(b)
-	defer serverCh.Close()
-
-	clientCh := testutils.NewClient(b, nil)
-
-	started := time.Now()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ctx, cancel := NewContext(10 * time.Millisecond)
-		_, _, _, err := raw.Call(ctx, clientCh, svcHostPort, svcName, "echo", []byte("data111"), []byte("data222"))
-		assert.NoError(b, err)
-		cancel()
-	}
-	b.StopTimer()
-	duration := time.Since(started)
-	b.Logf("Executed %v calls in %v, avg time = %v\n", b.N, duration, duration/time.Duration(b.N))
+	benchmarkCallsN(b, benchmarkConfig{
+		numCalls:         b.N,
+		numServers:       1,
+		numClients:       1,
+		workersPerClient: 1,
+	})
 }
 
-func BenchmarkCallsConcurrent(b *testing.B) {
-	const numWorkers = 5
+func BenchmarkCallsConcurrentServer(b *testing.B) {
+	benchmarkCallsN(b, benchmarkConfig{
+		numCalls:         b.N,
+		numServers:       1,
+		numClients:       runtime.GOMAXPROCS(0),
+		workersPerClient: 1,
+	})
+}
 
-	serverCh, svcName, svcHostPort := setupServer(b)
-	defer serverCh.Close()
-
-	var wg sync.WaitGroup
-	inCh := make(chan struct{})
-	for i := 0; i < numWorkers; i++ {
-		go func() {
-			clientCh := testutils.NewClient(b, nil)
-			defer clientCh.Close()
-
-			for range inCh {
-				ctx, cancel := NewContext(time.Second)
-
-				_, _, _, err := raw.Call(ctx, clientCh, svcHostPort, svcName, "echo", []byte("data111"), []byte("data222"))
-				assert.NoError(b, err)
-
-				cancel()
-				wg.Done()
-			}
-		}()
-	}
-
-	for i := 0; i < b.N; i++ {
-		wg.Add(1)
-		inCh <- struct{}{}
-	}
-
-	wg.Wait()
-	close(inCh)
+func BenchmarkCallsConcurrentClient(b *testing.B) {
+	parallelism := runtime.GOMAXPROCS(0)
+	benchmarkCallsN(b, benchmarkConfig{
+		numCalls:         b.N,
+		numServers:       parallelism,
+		numClients:       1,
+		workersPerClient: parallelism,
+	})
 }

--- a/testutils/counter.go
+++ b/testutils/counter.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutils
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Decrementor returns a function that can be called from multiple goroutines and ensures
+// it will only return true n times.
+func Decrementor(n int) func() bool {
+	n64 := int64(n)
+	return func() bool {
+		newN := atomic.AddInt64(&n64, -1)
+		return newN >= 0
+	}
+}
+
+// RunN runs the given f n times (and passes the run's index) and waits till they complete.
+// It starts n-1 goroutines, and runs one instance in the current goroutine.
+func RunN(n int, f func(i int)) {
+	var wg sync.WaitGroup
+	for i := 0; i < n-1; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			f(i)
+		}(i)
+	}
+	f(n - 1)
+	wg.Wait()
+}


### PR DESCRIPTION
This change adds latency metrics to benchmark output.

The benchmarking code for all scenarios now shares a parametrized function. This makes it much easier to try out different combinations of parameters.