### PR TITLE
Close InitialNodesFile in parseConfig

### DIFF
--- a/hyperbahn/client.go
+++ b/hyperbahn/client.go
@@ -97,12 +97,10 @@ func parseConfig(config *Configuration) error {
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 
 		decoder := json.NewDecoder(f)
 		if err := decoder.Decode(&config.InitialNodes); err != nil {
-			return err
-		}
-		if err = f.Close(); err != nil {
 			return err
 		}
 	}

--- a/hyperbahn/client.go
+++ b/hyperbahn/client.go
@@ -102,6 +102,9 @@ func parseConfig(config *Configuration) error {
 		if err := decoder.Decode(&config.InitialNodes); err != nil {
 			return err
 		}
+		if err = f.Close(); err != nil {
+			return err
+		}
 	}
 
 	if len(config.InitialNodes) == 0 {


### PR DESCRIPTION
If `parseConfig` is run too many times, we begin to see `too many open files` errors.