### PR TITLE
Set checksum mismatch error on reader

### DIFF
--- a/fragmentation_test.go
+++ b/fragmentation_test.go
@@ -22,6 +22,8 @@ package tchannel
 
 import (
 	"bytes"
+	"io"
+	"io/ioutil"
 	"sync"
 	"testing"
 
@@ -297,8 +299,8 @@ func TestFragmentationChecksumMismatch(t *testing.T) {
 	reader, err := r.ArgReader(true /* last */)
 	assert.NoError(t, err)
 
-	var arg []byte
-	assert.Error(t, NewArgReader(reader, nil).Read(&arg))
+	_, err = io.Copy(ioutil.Discard, reader)
+	assert.Equal(t, errMismatchedChecksums, err)
 }
 
 func runFragmentationErrorTest(f func(w *fragmentingWriter, r *fragmentingReader)) {

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -290,7 +290,8 @@ func (r *fragmentingReader) recvAndParseNextFragment(initial bool) error {
 	// Validate checksums
 	localChecksum := r.checksum.Sum()
 	if bytes.Compare(r.curFragment.checksum, localChecksum) != 0 {
-		return errMismatchedChecksums
+		r.err = errMismatchedChecksums
+		return r.err
 	}
 
 	// Pull out the first chunk to act as the current chunk


### PR DESCRIPTION
Be consistent with the way other errors are handled in `recvAndParseNextFragment`