### PR TITLE
Replace outputFile with outputDirectory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,10 @@ examples: clean setup thrift_example
 
 thrift_gen:
 	go build -o $(BUILD)/thrift-gen ./thrift/thrift-gen
-	$(BUILD)/thrift-gen --generateThrift --inputFile thrift/test.thrift
-	$(BUILD)/thrift-gen --generateThrift --inputFile examples/keyvalue/keyvalue.thrift
-	$(BUILD)/thrift-gen --generateThrift --inputFile examples/thrift/test.thrift
-	rm -rf trace/thrift/gen-go/tcollector && $(BUILD)/thrift-gen --generateThrift --inputFile trace/tcollector.thrift && cd trace && mv gen-go/* thrift/gen-go/
+	$(BUILD)/thrift-gen --generateThrift --inputFile thrift/test.thrift --outputDir thrift/gen-go/
+	$(BUILD)/thrift-gen --generateThrift --inputFile examples/keyvalue/keyvalue.thrift --outputDir examples/keyvalue/gen-go
+	$(BUILD)/thrift-gen --generateThrift --inputFile examples/thrift/test.thrift --outputDir examples/thrift/gen-go
+	rm -rf trace/thrift/gen-go/tcollector && $(BUILD)/thrift-gen --generateThrift --inputFile trace/tcollector.thrift --outputDir trace/thrift/gen-go/
 
 .PHONY: all help clean fmt format get_thrift install install_ci test test_ci vet
 .SILENT: all help clean fmt format test vet

--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -91,7 +91,7 @@ func runTest(t *testing.T, thriftFile string) error {
 	}
 
 	// Run go build to ensure that the generated code builds.
-	cmd := exec.Command("go", "build", ".")
+	cmd := exec.Command("go", "build", "./...")
 	cmd.Dir = filepath.Join(tempDir, packageName(thriftFile))
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("Build failed. Output = \n%v\n", string(output))

--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -68,32 +68,31 @@ func copyFile(src, dst string) error {
 	return err
 }
 
-// setupDirectory creates a temporary directory and copies the Thrift file into that directory.
-func setupDirectory(thriftFile string) (string, string, error) {
+// setupDirectory creates a temporary directory.
+func setupDirectory(thriftFile string) (string, error) {
 	tempDir, err := ioutil.TempDir("", "thrift-gen")
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	outFile := filepath.Join(tempDir, "test.thrift")
-	return tempDir, outFile, copyFile(thriftFile, outFile)
+	return tempDir, nil
 }
 
 func runTest(t *testing.T, thriftFile string) error {
-	tempDir, thriftFile, err := setupDirectory(thriftFile)
+	tempDir, err := setupDirectory(thriftFile)
 	if err != nil {
 		return err
 	}
 
 	// Generate code from the Thrift file.
 	t.Logf("runTest in %v", tempDir)
-	if err := processFile(true /* generateThrift */, thriftFile, ""); err != nil {
+	if err := processFile(true /* generateThrift */, thriftFile, tempDir); err != nil {
 		return fmt.Errorf("processFile(%s) failed: %v", thriftFile, err)
 	}
 
 	// Run go build to ensure that the generated code builds.
 	cmd := exec.Command("go", "build", ".")
-	cmd.Dir = filepath.Join(tempDir, "gen-go", "test")
+	cmd.Dir = filepath.Join(tempDir, packageName(thriftFile))
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("Build failed. Output = \n%v\n", string(output))
 	}

--- a/thrift/thrift-gen/generate.go
+++ b/thrift/thrift-gen/generate.go
@@ -61,31 +61,30 @@ func deleteRemote(dir string) error {
 	return nil
 }
 
-func runThrift(inFile string, thriftImport string) (string, error) {
+func runThrift(inFile string, outDir string, thriftImport string) error {
 	inFile, err := filepath.Abs(inFile)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	dir, filename := filepath.Split(inFile)
+	filename := filepath.Base(inFile)
 	baseName := strings.TrimSuffix(filename, filepath.Ext(filename))
-	genDir := filepath.Join(dir, "gen-go")
-	outDir := filepath.Join(genDir, baseName)
+	genDir := filepath.Join(outDir, baseName)
 
 	// Delete any existing generated code for this Thrift file.
-	if err := execCmd("rm", "-rf", outDir); err != nil {
-		return "", fmt.Errorf("failed to delete directory %s: %v", genDir, err)
+	if err := execCmd("rm", "-rf", genDir); err != nil {
+		return fmt.Errorf("failed to delete directory %s: %v", genDir, err)
 	}
 
 	// Generate the Apache Thrift generated code.
-	if err := execThrift("-r", "--gen", "go:thrift_import="+thriftImport, "-o", dir, inFile); err != nil {
-		return "", fmt.Errorf("Thrift compile failed: %v", err)
+	if err := execThrift("-r", "--gen", "go:thrift_import="+thriftImport, "-out", outDir, inFile); err != nil {
+		return fmt.Errorf("Thrift compile failed: %v", err)
 	}
 
 	// Delete the -remote folders.
 	if err := deleteRemote(outDir); err != nil {
-		return "", fmt.Errorf("failed to delete -remote folders: %v", err)
+		return fmt.Errorf("failed to delete -remote folders: %v", err)
 	}
 
-	return filepath.Join(outDir, "tchan-"+baseName+".go"), nil
+	return nil
 }

--- a/thrift/thrift-gen/generate.go
+++ b/thrift/thrift-gen/generate.go
@@ -66,11 +66,8 @@ func runThrift(inFile string, outDir string, thriftImport string) error {
 		return err
 	}
 
-	filename := filepath.Base(inFile)
-	baseName := strings.TrimSuffix(filename, filepath.Ext(filename))
-	genDir := filepath.Join(outDir, baseName)
-
 	// Delete any existing generated code for this Thrift file.
+	genDir := filepath.Join(outDir, packageName(inFile))
 	if err := execCmd("rm", "-rf", genDir); err != nil {
 		return fmt.Errorf("failed to delete directory %s: %v", genDir, err)
 	}


### PR DESCRIPTION
thrift-gen will soon generate multiple files (for includes, templates)
and so use an output directory relative to the current directory rather
than a single file.

This is a breaking change:
 - outputFile is no longer a valid flag
 - outputDir is relative to the current directory, and nothing is
   relative to the input thrift file.

Each thrift file will get a folder with the package name in the
specified output directory.

cc: @thanodnl 