### PR TITLE
Add support for external templates

### DIFF
--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -147,7 +147,12 @@ func runTest(t *testing.T, thriftFile string) error {
 
 	// Generate code from the Thrift file.
 	*packagePrefix = "../"
-	if err := processFile(true /* generateThrift */, thriftFile, tempDir); err != nil {
+	opts := processOptions{
+		GenerateThrift: true,
+		InputFile:      thriftFile,
+		OutputDir:      tempDir,
+	}
+	if err := processFile(opts); err != nil {
 		return fmt.Errorf("processFile(%s) in %q failed: %v", thriftFile, tempDir, err)
 	}
 

--- a/thrift/thrift-gen/gopath.go
+++ b/thrift/thrift-gen/gopath.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ResolveWithGoPath will resolve the filename relative to GOPATH and returns
+// the first file that exists, or an error otherwise.
+func ResolveWithGoPath(filename string) (string, error) {
+	for _, file := range goPathCandidates(filename) {
+		if _, err := os.Stat(file); !os.IsNotExist(err) {
+			return file, nil
+		}
+	}
+
+	return "", fmt.Errorf("file not found on GOPATH: %q", filename)
+}
+
+func goPathCandidates(filename string) []string {
+	candidates := []string{filename}
+	paths := filepath.SplitList(os.Getenv("GOPATH"))
+	for _, path := range paths {
+		resolvedFilename := filepath.Join(path, "src", filename)
+		candidates = append(candidates, resolvedFilename)
+	}
+
+	return candidates
+}

--- a/thrift/thrift-gen/gopath_test.go
+++ b/thrift/thrift-gen/gopath_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getFakeFS(t *testing.T) string {
+	files := []string{
+		"src/pkg1/sub/ringpop.thriftgen",
+		"src/pkg2/sub/ringpop.thriftgen",
+	}
+
+	tempDir, err := ioutil.TempDir("", "thriftgen")
+	require.NoError(t, err, "TempDir failed")
+
+	for _, f := range files {
+		require.NoError(t, os.MkdirAll(filepath.Join(tempDir, filepath.Dir(f)), 0770),
+			"Failed to create directory structure for %v", f)
+		require.NoError(t, ioutil.WriteFile(filepath.Join(tempDir, f), nil, 0660),
+			"Failed to create dummy file")
+	}
+	return tempDir
+}
+
+func TestGoPathCandidates(t *testing.T) {
+	tests := []struct {
+		goPath             string
+		filename           string
+		expectedCandidates []string
+	}{
+		{
+			goPath:   "onepath",
+			filename: "github.com/uber/tchannel-go/tchan.thrift-gen",
+			expectedCandidates: []string{
+				"github.com/uber/tchannel-go/tchan.thrift-gen",
+				"onepath/src/github.com/uber/tchannel-go/tchan.thrift-gen",
+			},
+		},
+		{
+			goPath:   "onepath:secondpath",
+			filename: "github.com/uber/tchannel-go/tchan.thrift-gen",
+			expectedCandidates: []string{
+				"github.com/uber/tchannel-go/tchan.thrift-gen",
+				"onepath/src/github.com/uber/tchannel-go/tchan.thrift-gen",
+				"secondpath/src/github.com/uber/tchannel-go/tchan.thrift-gen",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		os.Setenv("GOPATH", tt.goPath)
+		candidates := goPathCandidates(tt.filename)
+		if !reflect.DeepEqual(candidates, tt.expectedCandidates) {
+			t.Errorf("GOPATH=%s FileCandidatesWithGopath(%s) = %q, want %q",
+				tt.goPath, tt.filename, candidates, tt.expectedCandidates)
+		}
+	}
+}
+
+func TestResolveWithGoPath(t *testing.T) {
+	goPath1 := getFakeFS(t)
+	goPath2 := getFakeFS(t)
+	os.Setenv("GOPATH", goPath1+string(filepath.ListSeparator)+goPath2)
+	defer os.RemoveAll(goPath1)
+	defer os.RemoveAll(goPath2)
+
+	tests := []struct {
+		filename string
+		want     string
+		wantErr  bool
+	}{
+		{
+			filename: "pkg1/sub/ringpop.thriftgen",
+			want:     filepath.Join(goPath1, "src/pkg1/sub/ringpop.thriftgen"),
+		},
+		{
+			filename: "pkg2/sub/ringpop.thriftgen",
+			want:     filepath.Join(goPath1, "src/pkg2/sub/ringpop.thriftgen"),
+		},
+		{
+			filename: filepath.Join(goPath2, "src/pkg2/sub/ringpop.thriftgen"),
+			want:     filepath.Join(goPath2, "src/pkg2/sub/ringpop.thriftgen"),
+		},
+		{
+			filename: "pkg3/sub/ringpop.thriftgen",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		file, err := ResolveWithGoPath(tt.filename)
+		gotErr := err != nil
+		assert.Equal(t, tt.wantErr, gotErr, "%v expected error: %v got: %v", tt.filename, tt.wantErr, err)
+		assert.Equal(t, tt.want, file, "%v expected to resolve to %v, got %v", tt.filename, tt.want, file)
+	}
+}

--- a/thrift/thrift-gen/main.go
+++ b/thrift/thrift-gen/main.go
@@ -52,6 +52,7 @@ var (
 // TemplateData is the data passed to the template that generates code.
 type TemplateData struct {
 	Package  string
+	AST      *parser.Thrift
 	Services []*Service
 	Includes map[string]*Include
 	Imports  imports
@@ -74,6 +75,7 @@ func main() {
 }
 
 type parseState struct {
+	ast      *parser.Thrift
 	global   *State
 	services []*Service
 }
@@ -144,7 +146,7 @@ func parseFile(inputFile string) (map[string]parseState, error) {
 		if err != nil {
 			return nil, fmt.Errorf("wrap services failed: %v", err)
 		}
-		allParsed[filename] = parseState{state, services}
+		allParsed[filename] = parseState{v, state, services}
 	}
 	return allParsed, setExtends(allParsed)
 }
@@ -159,6 +161,7 @@ func generateCode(outputFile string, template *Template, pkg string, state parse
 
 	td := TemplateData{
 		Package:  pkg,
+		AST:      state.ast,
 		Includes: state.global.includes,
 		Services: state.services,
 		Imports: imports{

--- a/thrift/thrift-gen/main.go
+++ b/thrift/thrift-gen/main.go
@@ -43,7 +43,10 @@ var (
 	generateThrift = flag.Bool("generateThrift", false, "Whether to generate all Thrift go code")
 	inputFile      = flag.String("inputFile", "", "The .thrift file to generate a client for")
 	outputDir      = flag.String("outputDir", "gen-go", "The output directory to generate go code to.")
-	nlSpaceNL      = regexp.MustCompile(`\n[ \t]+\n`)
+	skipTChannel   = flag.Bool("skipTChannel", false, "Whether to skip the TChannel template")
+	templates      = NewStringSliceFlag("template", "Template file to compile code from")
+
+	nlSpaceNL = regexp.MustCompile(`\n[ \t]+\n`)
 )
 
 // TemplateData is the data passed to the template that generates code.

--- a/thrift/thrift-gen/main.go
+++ b/thrift/thrift-gen/main.go
@@ -56,6 +56,10 @@ type TemplateData struct {
 	Services []*Service
 	Includes map[string]*Include
 	Imports  imports
+
+	// global should not be directly exported to the template, but functions on
+	// global can be exposed to templates.
+	global *State
 }
 
 type imports struct {
@@ -164,6 +168,7 @@ func generateCode(outputFile string, template *Template, pkg string, state parse
 		AST:      state.ast,
 		Includes: state.global.includes,
 		Services: state.services,
+		global:   state.global,
 		Imports: imports{
 			Thrift:   *apacheThriftImport,
 			TChannel: tchannelThriftImport,

--- a/thrift/thrift-gen/main.go
+++ b/thrift/thrift-gen/main.go
@@ -148,3 +148,21 @@ func packageName(fullPath string) string {
 	file := strings.TrimSuffix(filename, filepath.Ext(filename))
 	return strings.ToLower(file)
 }
+
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	return strings.Join(*s, ", ")
+}
+
+func (s *stringSliceFlag) Set(in string) error {
+	*s = append(*s, in)
+	return nil
+}
+
+// NewStringSliceFlag creates a new string slice flag. The default value is always nil.
+func NewStringSliceFlag(name string, usage string) *[]string {
+	var ss stringSliceFlag
+	flag.Var(&ss, name, usage)
+	return (*[]string)(&ss)
+}

--- a/thrift/thrift-gen/template.go
+++ b/thrift/thrift-gen/template.go
@@ -40,7 +40,9 @@ type Template struct {
 
 func parseTemplate(contents string) (*template.Template, error) {
 	funcs := map[string]interface{}{
-		"contextType": contextType,
+		"contextType":   contextType,
+		"goPrivateName": goName,
+		"goPublicName":  goPublicName,
 	}
 	return template.New("thrift-gen").Funcs(funcs).Parse(contents)
 }
@@ -68,9 +70,16 @@ func cleanGeneratedCode(generated []byte) []byte {
 	return generated
 }
 
+// withStateFuncs adds functions to the template that are dependent upon state.
+func (t *Template) withStateFuncs(td TemplateData) *template.Template {
+	return t.template.Funcs(map[string]interface{}{
+		"goType": td.global.goType,
+	})
+}
+
 func (t *Template) execute(outputFile string, td TemplateData) error {
 	buf := &bytes.Buffer{}
-	if err := t.template.Execute(buf, td); err != nil {
+	if err := t.withStateFuncs(td).Execute(buf, td); err != nil {
 		return fmt.Errorf("failed to execute template: %v", err)
 	}
 

--- a/thrift/thrift-gen/template.go
+++ b/thrift/thrift-gen/template.go
@@ -32,11 +32,31 @@ import (
 	"text/template"
 )
 
-func parseTemplate() *template.Template {
+// Template represents a single thrift-gen template that will be used to generate code.
+type Template struct {
+	name     string
+	template *template.Template
+}
+
+func parseTemplate(contents string) (*template.Template, error) {
 	funcs := map[string]interface{}{
 		"contextType": contextType,
 	}
-	return template.Must(template.New("thrift-gen").Funcs(funcs).Parse(tchannelTmpl))
+	return template.New("thrift-gen").Funcs(funcs).Parse(contents)
+}
+
+func parseTemplateFile(file string) (*Template, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %v", file, err)
+	}
+
+	t, err := parseTemplate(string(bytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template in file %q: %v", file, err)
+	}
+
+	return &Template{packageName(file), t}, nil
 }
 
 func contextType() string {
@@ -48,9 +68,9 @@ func cleanGeneratedCode(generated []byte) []byte {
 	return generated
 }
 
-func executeTemplate(outputFile string, tmpl *template.Template, td TemplateData) error {
+func (t *Template) execute(outputFile string, td TemplateData) error {
 	buf := &bytes.Buffer{}
-	if err := tmpl.Execute(buf, td); err != nil {
+	if err := t.template.Execute(buf, td); err != nil {
 		return fmt.Errorf("failed to execute template: %v", err)
 	}
 
@@ -62,4 +82,8 @@ func executeTemplate(outputFile string, tmpl *template.Template, td TemplateData
 	// Run gofmt on the file (ignore any errors)
 	exec.Command("gofmt", "-w", outputFile).Run()
 	return nil
+}
+
+func (t *Template) outputFile(pkg string) string {
+	return fmt.Sprintf("%v-%v.go", t.name, pkg)
 }

--- a/thrift/thrift-gen/template.go
+++ b/thrift/thrift-gen/template.go
@@ -48,6 +48,11 @@ func parseTemplate(contents string) (*template.Template, error) {
 }
 
 func parseTemplateFile(file string) (*Template, error) {
+	file, err := ResolveWithGoPath(file)
+	if err != nil {
+		return nil, err
+	}
+
 	bytes, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %v", file, err)


### PR DESCRIPTION
Based on #94 with some refactorings.

External templates can be specified via the `-template` flag. This flag can be specified multiple times for multiple templates. Paths can be `GOPATH` relative, so the user does not need to specify absolute paths.

@thanodnl 