### PR TITLE
Full support for extending a service in an include

### DIFF
--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -116,8 +116,10 @@ func runTest(t *testing.T, thriftFile string) error {
 
 	// Run go build to ensure that the generated code builds.
 	cmd := exec.Command("go", "build", "./...")
-	cmd.Dir = filepath.Join(tempDir)
-	if output, err := cmd.CombinedOutput(); err != nil {
+	cmd.Dir = tempDir
+	// NOTE: we check output, since go build ./... returns 0 status code on failure:
+	// https://github.com/golang/go/issues/11407
+	if output, err := cmd.CombinedOutput(); err != nil || len(output) > 0 {
 		return fmt.Errorf("Build in %q failed.\nError: %v Output:\n%v\n", tempDir, err, string(output))
 	}
 

--- a/thrift/thrift-gen/extends.go
+++ b/thrift/thrift-gen/extends.go
@@ -37,17 +37,20 @@ func setExtends(state map[string]parseState) error {
 			}
 
 			var searchServices []*Service
+			var searchFor string
 			parts := strings.SplitN(s.Extends, ".", 2)
 			// If it's not imported, then look at the current file's services.
 			if len(parts) < 2 {
 				searchServices = v.services
+				searchFor = s.Extends
 			} else {
 				include := v.global.includes[parts[0]]
 				searchServices = state[include.file].services
+				searchFor = parts[1]
 			}
 
 			foundService := sort.Search(len(searchServices), func(i int) bool {
-				return searchServices[i].Name >= s.Extends
+				return searchServices[i].Name >= searchFor
 			})
 			if foundService == len(searchServices) {
 				return fmt.Errorf("failed to find base service %q for %q", s.Extends, s.Name)

--- a/thrift/thrift-gen/main.go
+++ b/thrift/thrift-gen/main.go
@@ -119,8 +119,7 @@ func parseFile(inputFile string) (map[string]parseState, error) {
 		}
 		allParsed[filename] = parseState{state, services}
 	}
-	setExtends(allParsed)
-	return allParsed, nil
+	return allParsed, setExtends(allParsed)
 }
 
 func generateCode(outputFile string, tmpl *template.Template, pkg string, state parseState) error {

--- a/thrift/thrift-gen/tchannel-template.go
+++ b/thrift/thrift-gen/tchannel-template.go
@@ -29,7 +29,7 @@ athrift "{{ .Imports.Thrift }}"
 // {{ .Interface }} is the interface that defines the server handler and client interface.
 type {{ .Interface }} interface {
 	{{ if .HasExtends }}
-		{{ .ExtendsService.Interface }}
+		{{ .ExtendsServicePrefix }}{{ .ExtendsService.Interface }}
 
 	{{ end }}
 	{{ range .Methods }}
@@ -44,7 +44,7 @@ type {{ .Interface }} interface {
 {{ range $svc := .Services }}
 type {{ .ClientStruct }} struct {
 	{{ if .HasExtends }}
-		{{ .ExtendsService.ClientStruct }}
+		{{ .ExtendsServicePrefix }}{{ .ExtendsService.Interface }}
 
 	{{ end }}
 	thriftService string
@@ -94,7 +94,7 @@ func {{ .ClientConstructor }}(client thrift.TChanClient) {{ .Interface }} {
 
 type {{ .ServerStruct }} struct {
 	{{ if .HasExtends }}
-		{{ .ExtendsService.ServerStruct }}
+		{{ .ExtendsServicePrefix }}{{ .ExtendsService.Interface }}
 
 	{{ end }}
 	handler {{ .Interface }}

--- a/thrift/thrift-gen/tchannel-template.go
+++ b/thrift/thrift-gen/tchannel-template.go
@@ -52,10 +52,10 @@ type {{ .ClientStruct }} struct {
 }
 
 
-func {{ .InternalClientConstructor }}(thriftService string, client thrift.TChanClient) *{{ .ClientStruct }} {
+func {{ .InheritedClientConstructor }}(thriftService string, client thrift.TChanClient) *{{ .ClientStruct }} {
 	return &{{ .ClientStruct }}{
 		{{ if .HasExtends }}
-			*{{ .ExtendsService.InternalClientConstructor }}(thriftService, client),
+			{{ .ExtendsServicePrefix }}{{ .ExtendsService.InheritedClientConstructor }}(thriftService, client),
 		{{ end }}
 		thriftService,
 		client,
@@ -64,7 +64,7 @@ func {{ .InternalClientConstructor }}(thriftService string, client thrift.TChanC
 
 // {{ .ClientConstructor }} creates a client that can be used to make remote calls.
 func {{ .ClientConstructor }}(client thrift.TChanClient) {{ .Interface }} {
-	return {{ .InternalClientConstructor }}("{{ .ThriftName }}", client)
+	return {{ .InheritedClientConstructor }}("{{ .ThriftName }}", client)
 }
 
 {{ range .Methods }}
@@ -100,19 +100,15 @@ type {{ .ServerStruct }} struct {
 	handler {{ .Interface }}
 }
 
-func {{ .InternalServerConstructor }}(handler {{ .Interface }}) *{{ .ServerStruct }} {
-	return &{{ .ServerStruct }}{
-		{{ if .HasExtends }}
-			*{{ .ExtendsService.InternalServerConstructor }}(handler),
-		{{ end }}
-		handler,
-	}
-}
-
 // {{ .ServerConstructor }} wraps a handler for {{ .Interface }} so it can be
 // registered with a thrift.Server.
 func {{ .ServerConstructor }}(handler {{ .Interface }}) thrift.TChanServer {
-	return {{ .InternalServerConstructor }}(handler)
+	return &{{ .ServerStruct }}{
+		{{ if .HasExtends }}
+			{{ .ExtendsServicePrefix }}{{ .ExtendsService.ServerConstructor }}(handler),
+		{{ end }}
+		handler,
+	}
 }
 
 func (s *{{ .ServerStruct }}) Service() string {

--- a/thrift/thrift-gen/test_files/include_test/svc_extend/svc_extend.thrift
+++ b/thrift/thrift-gen/test_files/include_test/svc_extend/svc_extend.thrift
@@ -4,3 +4,9 @@ service Foo extends shared.FooBase {
   shared.UUID getMyUUID(1: shared.UUID uuid, 2: shared.Health health)
   shared.Health health(1: shared.UUID uuid, 2: shared.Health health)
 }
+
+//Go code: svc_extend/test.go
+// package svc_extend
+// var _ = TChanFoo(nil).GetMyUUID
+// var _ = TChanFoo(nil).Health
+// var _ = TChanFoo(nil).GetUUID

--- a/thrift/thrift-gen/test_files/service_extend.thrift
+++ b/thrift/thrift-gen/test_files/service_extend.thrift
@@ -9,3 +9,9 @@ service S2 extends S1 {
 service S3 extends S2 {
   void M3()
 }
+
+//Go code: service_extend/test.go
+// package service_extend
+// var _ = TChanS3(nil).M1
+// var _ = TChanS3(nil).M2
+// var _ = TChanS3(nil).M3

--- a/thrift/thrift-gen/wrap.go
+++ b/thrift/thrift-gen/wrap.go
@@ -86,6 +86,14 @@ func (s *Service) HasExtends() bool {
 	return s.ExtendsService != nil
 }
 
+// ExtendsServicePrefix returns a package selector (if any) for the extended service.
+func (s *Service) ExtendsServicePrefix() string {
+	if dotIndex := strings.Index(s.Extends, "."); dotIndex > 0 {
+		return s.Extends[:dotIndex+1]
+	}
+	return ""
+}
+
 type byMethodName []*Method
 
 func (l byMethodName) Len() int           { return len(l) }

--- a/thrift/thrift-gen/wrap.go
+++ b/thrift/thrift-gen/wrap.go
@@ -42,6 +42,8 @@ type Service struct {
 
 	// methods is a cache of all methods.
 	methods []*Method
+	// inheritedMethods is a list of inherited method names.
+	inheritedMethods []string
 }
 
 // ThriftName returns the thrift identifier for this service.
@@ -118,6 +120,22 @@ func (s *Service) Methods() []*Method {
 	}
 	sort.Sort(byMethodName(s.methods))
 	return s.methods
+}
+
+// InheritedMethods returns names for inherited methods on this service.
+func (s *Service) InheritedMethods() []string {
+	if s.inheritedMethods != nil {
+		return s.inheritedMethods
+	}
+
+	for svc := s.ExtendsService; svc != nil; svc = svc.ExtendsService {
+		for m := range svc.Service.Methods {
+			s.inheritedMethods = append(s.inheritedMethods, m)
+		}
+	}
+	sort.Strings(s.inheritedMethods)
+
+	return s.inheritedMethods
 }
 
 // Method is a wrapper for parser.Method.

--- a/thrift/thrift-gen/wrap.go
+++ b/thrift/thrift-gen/wrap.go
@@ -66,11 +66,11 @@ func (s *Service) ClientConstructor() string {
 	return "NewTChan" + goPublicName(s.Name) + "Client"
 }
 
-// InternalClientConstructor returns the name of the internal constructor used to create the client
-// struct directly. This returns the type of ClientStruct rather than the interface, and is used
-// to recursively create any base service clients.
-func (s *Service) InternalClientConstructor() string {
-	return "newTChan" + goPublicName(s.Name) + "Client"
+// InheritedClientConstructor returns the name of the constructor used by the generated code
+// for inherited services. This allows the parent service to set the service name that should
+// be used.
+func (s *Service) InheritedClientConstructor() string {
+	return "NewTChan" + goPublicName(s.Name) + "InheritedClient"
 }
 
 // ServerStruct returns the name of the unexported struct that satisfies TChanServer.
@@ -81,13 +81,6 @@ func (s *Service) ServerStruct() string {
 // ServerConstructor returns the name of the constructor used to create the TChanServer interface.
 func (s *Service) ServerConstructor() string {
 	return "NewTChan" + goPublicName(s.Name) + "Server"
-}
-
-// InternalServerConstructor is the name of the internal constructor used to create the service
-// directly. This returns the type of ServerStruct rather than the interface, and is used
-// to recursively create any base service structs.
-func (s *Service) InternalServerConstructor() string {
-	return "newTChan" + goPublicName(s.Name) + "Server"
 }
 
 // HasExtends returns whether this service extends another service.


### PR DESCRIPTION
Cross-include extends were silently breaking due the following combination of issues:
 - `setExtends` was returning an error that was being ignored
 - `go build ./...` was not returning an invalid exit code, and so the test assumed the build was successful and the test did not fail

We now check the output of `go build ./...`  (which is silent on success) and if there's output, fail the test.

To make cross-include extends work, there were a couple of options:
1. Export the internal constructor functions so they can be called from other packages
2. Re-generate code for all extended methods.

2. becomes tricky since the methods cannot simply be copied directly to the parent, since all type references would need to be rewritten, and includes would require imports to be generated recursively.

The approach taken is 1, but with refactoring such that only the client needs an extra constructor exposed. The server-side now relies purely on the public interface, and simply calls the exported `Handle` function.

Fixes #100 