### PR TITLE
The goType function should be passed in to the initial funcs map for …

### DIFF
--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -82,6 +82,8 @@ func TestExternalTemplate(t *testing.T) {
 
 {{ range .AST.Services }}
 // Service {{ .Name }} has {{ len .Methods }} methods.
+{{ range .Methods }}
+// func {{ .Name | goPublicName }} ({{ range .Arguments }}{{ .Type | goType }}, {{ end }}) ({{ if .ReturnType }}{{ .ReturnType | goType }}{{ end }}){{ end }}
 {{ end }}
 	`
 	templateFile := writeTempFile(t, template1)
@@ -91,9 +93,15 @@ func TestExternalTemplate(t *testing.T) {
 
 // Service S1 has 1 methods.
 
+// func M1 ([]byte, ) ([]byte)
+
 // Service S2 has 1 methods.
 
+// func M2 (*S, ) (*S)
+
 // Service S3 has 1 methods.
+
+// func M3 () ()
 `
 
 	opts := processOptions{
@@ -108,45 +116,6 @@ func TestExternalTemplate(t *testing.T) {
 
 		// Verify the contents of the extra file.
 		outFile := filepath.Join(dir, packageName(templateFile)+"-service_extend.go")
-		return verifyFileContents(outFile, expected)
-	}
-	if err := runTest(t, opts, checks); err != nil {
-		t.Errorf("Failed to run test: %v", err)
-	}
-}
-
-func TestExternalTemplateWithGoType(t *testing.T) {
-	template1 := `package {{ .Package }}
-
-{{ range .AST.Services }}
-// Service {{ .Name }} has {{ len .Methods }} methods.
-{{ range .Methods }}
-// func {{ .Name | goPublicName }} ({{ range .Arguments }}{{ .Type | goType }}, {{ end }}) ({{ .ReturnType | goType }}){{ end }}
-{{ end }}
-	`
-	templateFile := writeTempFile(t, template1)
-	defer os.Remove(templateFile)
-
-	expected := `package binary
-
-// Service Test has 2 methods.
-
-// func M1 ([]byte, ) ([]byte)
-// func M2 ([]byte, *S, ) (*S)
-`
-
-	opts := processOptions{
-		InputFile:     "test_files/binary.thrift",
-		TemplateFiles: []string{templateFile},
-	}
-	checks := func(dir string) error {
-		dir = filepath.Join(dir, "binary")
-		if err := checkDirectoryFiles(dir, 5); err != nil {
-			return err
-		}
-
-		// Verify the contents of the extra file.
-		outFile := filepath.Join(dir, packageName(templateFile)+"-binary.go")
 		return verifyFileContents(outFile, expected)
 	}
 	if err := runTest(t, opts, checks); err != nil {

--- a/thrift/thrift-gen/template.go
+++ b/thrift/thrift-gen/template.go
@@ -38,12 +38,19 @@ type Template struct {
 	template *template.Template
 }
 
+// dummyGoType is a function to be passed to the test/template package as the named
+// function 'goType'. This named function is overwritten by an actual implementation
+// specific to the thrift file being rendered at the time of rendering.
+func dummyGoType() string {
+	return ""
+}
+
 func parseTemplate(contents string) (*template.Template, error) {
 	funcs := map[string]interface{}{
 		"contextType":   contextType,
 		"goPrivateName": goName,
 		"goPublicName":  goPublicName,
-		"goType":        func() string { return "" },
+		"goType":        dummyGoType,
 	}
 	return template.New("thrift-gen").Funcs(funcs).Parse(contents)
 }

--- a/thrift/thrift-gen/template.go
+++ b/thrift/thrift-gen/template.go
@@ -43,6 +43,7 @@ func parseTemplate(contents string) (*template.Template, error) {
 		"contextType":   contextType,
 		"goPrivateName": goName,
 		"goPublicName":  goPublicName,
+		"goType":        func() string { return "" },
 	}
 	return template.New("thrift-gen").Funcs(funcs).Parse(contents)
 }

--- a/thrift/thrift-gen/test_files/service_extend.thrift
+++ b/thrift/thrift-gen/test_files/service_extend.thrift
@@ -1,9 +1,13 @@
+struct S {
+  1: binary s1
+}
+
 service S1 {
-  void M1()
+  binary M1(1: binary bits)
 }
 
 service S2 extends S1 {
-  void M2()
+  S M2(1: S s)
 }
 
 service S3 extends S2 {


### PR DESCRIPTION
…templates using it to compile.

@prashantv I was pretty sure that I tested the binary, but somehow the latest version did not compile my template. During the parsing phase of the template it didn't have a `goType` func defined. I added a stub in the initial function list, and added tests to make sure the `goType` is replaced with the working version of the function.

In the test I used a `.thrift` file that has a User defined struct since that was the first time that I ran into the necessity of using `goType`.

cc @uber/ringpop 