### PR TITLE
Allow mockery code generation on TChanClient.

### DIFF
--- a/thrift/interfaces.go
+++ b/thrift/interfaces.go
@@ -20,7 +20,7 @@
 
 package thrift
 
-import "github.com/apache/thrift/lib/go/thrift"
+import athrift "github.com/apache/thrift/lib/go/thrift"
 
 // This file defines interfaces that are used or exposed by thrift-gen generated code.
 // TChanClient is used by the generated code to make outgoing requests.
@@ -29,14 +29,14 @@ import "github.com/apache/thrift/lib/go/thrift"
 // TChanClient abstracts calling a Thrift endpoint, and is used by the generated client code.
 type TChanClient interface {
 	// Call should be passed the method to call and the request/response Thrift structs.
-	Call(ctx Context, serviceName, methodName string, req, resp thrift.TStruct) (success bool, err error)
+	Call(ctx Context, serviceName, methodName string, req, resp athrift.TStruct) (success bool, err error)
 }
 
 // TChanServer abstracts handling of an RPC that is implemented by the generated server code.
 type TChanServer interface {
 	// Handle should read the request from the given reqReader, and return the response struct.
 	// The arguments returned are success, result struct, unexpected error
-	Handle(ctx Context, methodName string, protocol thrift.TProtocol) (success bool, resp thrift.TStruct, err error)
+	Handle(ctx Context, methodName string, protocol athrift.TProtocol) (success bool, resp athrift.TStruct, err error)
 
 	// Service returns the service name.
 	Service() string


### PR DESCRIPTION
When using `mockery` to generate mocks for interfaces it generates uncompilable code for `TChanClient` due to package name collision on `thrift`. By importing apache's thrift as `athrift` mockery is able to generate compilable code so `TChanClient` can be mocked during tests in [ringpop-go](https://github.com/uber/ringpop-go).