### PR TITLE
Improved error logging

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -557,7 +557,8 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 		id:      id,
 		errCode: GetSystemErrorCode(err),
 		tracing: errorSpan,
-		message: err.Error()}); err != nil {
+		message: GetSystemErrorMessage(err),
+	}); err != nil {
 
 		// This shouldn't happen - it means writing the errorMessage is broken.
 		c.log.Warnf("Could not create outbound frame to %s for %d: %v",

--- a/errors.go
+++ b/errors.go
@@ -120,9 +120,9 @@ func NewWrappedSystemError(code SystemErrCode, wrapped error) error {
 	return SystemError{code: code, msg: fmt.Sprintf("sys err %x: %s", code, wrapped.Error()), wrapped: wrapped}
 }
 
-// Error returns the SystemError message, conforming to the error interface
+// Error returns the code and message, conforming to the error interface
 func (se SystemError) Error() string {
-	return se.msg
+	return fmt.Sprintf("tchannel error %v: %s", se.Code(), se.msg)
 }
 
 // Wrapped returns the wrapped error
@@ -133,6 +133,11 @@ func (se SystemError) Code() SystemErrCode {
 	return se.code
 }
 
+// Message returns the SystemError message.
+func (se SystemError) Message() string {
+	return se.msg
+}
+
 // GetContextError converts the context error to a tchannel error.
 func GetContextError(err error) error {
 	if err == context.DeadlineExceeded {
@@ -141,12 +146,22 @@ func GetContextError(err error) error {
 	return err
 }
 
-// GetSystemErrorCode returns the code to report for the given error.  If the error is a SystemError, we can
-// get the code directly.  Otherwise treat it as an unexpected error
+// GetSystemErrorCode returns the code to report for the given error.  If the error is a
+// SystemError, we can get the code directly.  Otherwise treat it as an unexpected error
 func GetSystemErrorCode(err error) SystemErrCode {
 	if se, ok := err.(SystemError); ok {
 		return se.Code()
 	}
 
 	return ErrCodeUnexpected
+}
+
+// GetSystemErrorMessage returns the message to report for the given error.  If the error is a
+// SystemError, we can get the underlying message. Otherwise, use the Error() method.
+func GetSystemErrorMessage(err error) string {
+	if se, ok := err.(SystemError); ok {
+		return se.Message()
+	}
+
+	return err.Error()
 }

--- a/init_test.go
+++ b/init_test.go
@@ -230,7 +230,9 @@ func TestInitReqGetsError(t *testing.T) {
 	_, err = ch.Peers().GetOrAdd(l.Addr().String()).GetConnection(ctx)
 	expectedErr := NewSystemError(ErrCodeBadRequest, "invalid host:port")
 	assert.Equal(t, expectedErr, err, "Error mismatch")
-	assert.Contains(t, logOut.String(), "[E] Connection error: invalid host:port", "Error should be logged")
+	assert.Contains(t, logOut.String(),
+		"[E] Connection error: tchannel error ErrCodeBadRequest: invalid host:port",
+		"Error should be logged")
 	close(connectionComplete)
 
 	<-listenerComplete

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -86,7 +86,12 @@ func (s *Server) RegisterHealthHandler(f HealthFunc) {
 
 func (s *Server) onError(err error) {
 	// TODO(prashant): Expose incoming call errors through options for NewServer.
-	s.log.Errorf("thrift Server error: %v", err)
+	// Timeouts should not be reported as errors.
+	if se, ok := err.(tchannel.SystemError); ok && se.Code() == tchannel.ErrCodeTimeout {
+		s.log.Debugf("thrift Server timeout: %v", err)
+	} else {
+		s.log.Errorf("thrift Server error: %v", err)
+	}
 }
 
 func (s *Server) handle(origCtx context.Context, handler handler, method string, call *tchannel.InboundCall) error {


### PR DESCRIPTION
Don't log errors on timeouts in thrift.Server
Improve SystemError messages to call out tchannel and the code.