### PR TITLE
Thrift tests and timeout handling clean up

### DIFF
--- a/thrift/server.go
+++ b/thrift/server.go
@@ -87,7 +87,7 @@ func (s *Server) RegisterHealthHandler(f HealthFunc) {
 func (s *Server) onError(err error) {
 	// TODO(prashant): Expose incoming call errors through options for NewServer.
 	// Timeouts should not be reported as errors.
-	if se, ok := err.(tchannel.SystemError); ok && se.Code() == tchannel.ErrCodeTimeout {
+	if tchannel.GetSystemErrorCode(err) == tchannel.ErrCodeTimeout {
 		s.log.Debugf("thrift Server timeout: %v", err)
 	} else {
 		s.log.Errorf("thrift Server error: %v", err)

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -271,14 +271,12 @@ func withSetup(t *testing.T, f func(ctx Context, args testArgs)) {
 	defer cancel()
 
 	// Start server
-	ch, server, err := setupServer(args.s1, args.s2)
-	require.NoError(t, err)
+	ch, server := setupServer(t, args.s1, args.s2)
 	defer ch.Close()
 	args.server = server
 
 	// Get client1
-	args.c1, args.c2, err = getClients(ch)
-	require.NoError(t, err)
+	args.c1, args.c2 = getClients(t, ch)
 
 	f(ctx, args)
 
@@ -286,29 +284,22 @@ func withSetup(t *testing.T, f func(ctx Context, args testArgs)) {
 	args.s2.AssertExpectations(t)
 }
 
-func setupServer(h *mocks.TChanSimpleService, sh *mocks.TChanSecondService) (*tchannel.Channel, *Server, error) {
-	ch, err := testutils.NewServerChannel(nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
+func setupServer(t *testing.T, h *mocks.TChanSimpleService, sh *mocks.TChanSecondService) (*tchannel.Channel, *Server) {
+	ch := testutils.NewServer(t, nil)
 	server := NewServer(ch)
 	server.Register(gen.NewTChanSimpleServiceServer(h))
 	server.Register(gen.NewTChanSecondServiceServer(sh))
-	return ch, server, nil
+	return ch, server
 }
 
-func getClients(serverCh *tchannel.Channel) (gen.TChanSimpleService, gen.TChanSecondService, error) {
+func getClients(t *testing.T, serverCh *tchannel.Channel) (gen.TChanSimpleService, gen.TChanSecondService) {
 	serverInfo := serverCh.PeerInfo()
-	ch, err := testutils.NewClientChannel(nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	ch := testutils.NewClient(t, nil)
 
 	ch.Peers().Add(serverInfo.HostPort)
 	client := NewClient(ch, serverInfo.ServiceName, nil)
 
 	simpleClient := gen.NewTChanSimpleServiceClient(client)
 	secondClient := gen.NewTChanSecondServiceClient(client)
-	return simpleClient, secondClient, nil
+	return simpleClient, secondClient
 }


### PR DESCRIPTION
Add test to ensure that timeouts when handling requests do not cause any warnings/errors.

Simplify logic to detect timeout errors in thrift.Server