### PR TITLE
Allow "optional" for arguments

### DIFF
--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -97,7 +97,7 @@ func TestExternalTemplate(t *testing.T) {
 
 // Service S2 has 1 methods.
 
-// func M2 (*S, ) (*S)
+// func M2 (*S, int32, ) (*S)
 
 // Service S3 has 1 methods.
 

--- a/thrift/thrift-gen/test_files/service_extend.thrift
+++ b/thrift/thrift-gen/test_files/service_extend.thrift
@@ -7,7 +7,7 @@ service S1 {
 }
 
 service S2 extends S1 {
-  S M2(1: S s)
+  S M2(1: optional S s, 2: optional i32 i)
 }
 
 service S3 extends S2 {
@@ -19,3 +19,4 @@ service S3 extends S2 {
 // var _ = TChanS3(nil).M1
 // var _ = TChanS3(nil).M2
 // var _ = TChanS3(nil).M3
+// var _ int32 = S2M2Args{}.I

--- a/thrift/thrift-gen/validate.go
+++ b/thrift/thrift-gen/validate.go
@@ -42,7 +42,8 @@ func validateMethod(svc *parser.Service, m *parser.Method) error {
 	}
 	for _, arg := range m.Arguments {
 		if arg.Optional {
-			return fmt.Errorf("service methods cannot contain optional arguments: %v.%v:%v", svc.Name, m.Name, arg.Name)
+			// Go treats argument structs as "Required" in the generated code interface.
+			arg.Optional = false
 		}
 	}
 	return nil


### PR DESCRIPTION
Thrift complains, but allows the code to compile.
We should not fail to compile it either.