### PR TITLE
Allow trace sample rate to be 0

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -75,9 +75,9 @@ type ChannelOptions struct {
 	// Trace reporter factory to generate trace reporter instance.
 	TraceReporterFactory TraceReporterFactory
 
-	// TraceSampleRate is the rate of requests to sample, and should be in the range (0, 1].
-	// If this value is 0, then DefaultTraceSampleRate is used.
-	TraceSampleRate float64
+	// TraceSampleRate is the rate of requests to sample, and should be in the range [0, 1].
+	// If this value is not set, then DefaultTraceSampleRate is used.
+	TraceSampleRate *float64
 }
 
 // ChannelState is the state of a channel.
@@ -170,9 +170,9 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		timeNow = time.Now
 	}
 
-	traceSampleRate := opts.TraceSampleRate
-	if traceSampleRate == 0 {
-		traceSampleRate = DefaultTraceSampleRate
+	traceSampleRate := DefaultTraceSampleRate
+	if opts.TraceSampleRate != nil {
+		traceSampleRate = *opts.TraceSampleRate
 	}
 
 	ch := &Channel{

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -95,7 +95,7 @@ func (o *ChannelOpts) SetTimeNow(timeNow func() time.Time) *ChannelOpts {
 
 // SetTraceSampleRate sets the TraceSampleRate in ChannelOptions.
 func (o *ChannelOpts) SetTraceSampleRate(sampleRate float64) *ChannelOpts {
-	o.ChannelOptions.TraceSampleRate = sampleRate
+	o.ChannelOptions.TraceSampleRate = &sampleRate
 	return o
 }
 


### PR DESCRIPTION
Setting the trace sample rate to 0 is not the same as disable trace
reporting. You can disable trace reporting, but set trace sample rate to
something higher, which will cause external services to emit spans
You can enable trace reporting but set trace sample rate to 0 which
will cause incoming calls to be reported, but disable tracing for all
outgoing calls that originated at this service (e.g. without a parent).