### PR TITLE
Prefer connected peers over unconnected peers

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -409,6 +409,15 @@ func (p *Peer) NumInbound() int {
 	return count
 }
 
+// NumConnections returns the number of inbound and outbound connections for this peer.
+func (p *Peer) NumConnections() (inbound int, outbound int) {
+	p.mut.RLock()
+	inbound = len(p.inboundConnections)
+	outbound = len(p.outboundConnections)
+	p.mut.RUnlock()
+	return inbound, outbound
+}
+
 // NumPendingOutbound returns the number of pending outbound calls.
 func (p *Peer) NumPendingOutbound() int {
 	count := 0

--- a/peer.go
+++ b/peer.go
@@ -401,14 +401,6 @@ func (p *Peer) BeginCall(ctx context.Context, serviceName string, operationName 
 	return call, err
 }
 
-// NumInbound returns the number of inbound connections to this node.
-func (p *Peer) NumInbound() int {
-	p.mut.RLock()
-	count := len(p.inboundConnections)
-	p.mut.RUnlock()
-	return count
-}
-
 // NumConnections returns the number of inbound and outbound connections for this peer.
 func (p *Peer) NumConnections() (inbound int, outbound int) {
 	p.mut.RLock()

--- a/peer_test.go
+++ b/peer_test.go
@@ -341,7 +341,10 @@ func waitTillInboundEmpty(t *testing.T, ch *Channel, hostPort string) {
 
 	start := time.Now()
 	timedOut := func() bool { return time.Since(start) > time.Second }
-	for peer.NumInbound() > 0 && !timedOut() {
+	for !timedOut() {
+		if inbound, _ := peer.NumConnections(); inbound == 0 {
+			break
+		}
 		time.Sleep(time.Microsecond)
 	}
 	time.Sleep(time.Microsecond) // so any extra processing can happen.


### PR DESCRIPTION
Even when using "prefer incoming" as the strategy, we should prefer to
use connected peers over unconnected peers.

@junchaowu 