### PR TITLE
Isolated subchannels should not prefer incoming

### DIFF
--- a/peer_strategies.go
+++ b/peer_strategies.go
@@ -45,6 +45,24 @@ func newZeroCalculator() zeroCalculator {
 	return zeroCalculator{}
 }
 
+type leastPendingCalculator struct{}
+
+func (leastPendingCalculator) GetScore(p *Peer) uint64 {
+	inbound, outbound := p.NumConnections()
+	if inbound+outbound == 0 {
+		return math.MaxUint64
+	}
+
+	return uint64(p.NumPendingOutbound())
+}
+
+// newLeastPendingCalculator returns a strategy prefers any connected peer.
+// Within connected peers, least pending calls is used. Peers with less pending outbound calls
+// get a smaller score.
+func newLeastPendingCalculator() leastPendingCalculator {
+	return leastPendingCalculator{}
+}
+
 type preferIncomingCalculator struct{}
 
 func (preferIncomingCalculator) GetScore(p *Peer) uint64 {

--- a/subchannel.go
+++ b/subchannel.go
@@ -33,6 +33,7 @@ type SubChannelOption func(*SubChannel)
 func Isolated(s *SubChannel) {
 	s.Lock()
 	s.peers = s.topChannel.peers.newSibling()
+	s.peers.SetStrategy(newLeastPendingCalculator())
 	s.Unlock()
 }
 


### PR DESCRIPTION
Isolated subchannels (usually used by ringpop applications) do not have
a prefernece on peers with incoming vs outgoing connections.
Add a leastPending calculator and update tests to verify that neither
incoming or outgoing are preferred.

cc @thanodnl 