### PR TITLE
Fix frame pooling bug on error responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,10 @@ godep:
 test_ci: test
 
 test: clean setup
-	echo Testing packages:
+	@echo Testing packages:
 	go test $(TEST_PKGS) $(TEST_ARG) -parallel=4
+	@echo Running frame pool tests
+	go test -run TestFramesReleased -stressTest $(TEST_ARG)
 
 benchmark: clean setup
 	echo Running benchmarks:

--- a/connection.go
+++ b/connection.go
@@ -674,7 +674,7 @@ func (c *Connection) readFrames(_ uint32) {
 		case messageTypePingRes:
 			releaseFrame = c.handlePingRes(frame)
 		case messageTypeError:
-			c.handleError(frame)
+			releaseFrame = c.handleError(frame)
 		default:
 			// TODO(mmihic): Log and close connection with protocol error
 			c.log.Errorf("Received unexpected frame %s from %s", frame.Header, c.remotePeerInfo)

--- a/mex.go
+++ b/mex.go
@@ -82,6 +82,7 @@ func (mex *messageExchange) recvPeerFrame() (*Frame, error) {
 	case frame := <-mex.recvCh:
 		if frame.Header.ID != mex.msgID {
 			mex.mexset.log.Errorf("recvPeerFrame mex %v received message with unexpected ID: %v", mex.msgID, frame.Header)
+			return nil, errUnexpectedFrameType
 		}
 		return frame, nil
 	case <-mex.ctx.Done():

--- a/mex.go
+++ b/mex.go
@@ -100,6 +100,9 @@ func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, er
 		return frame, nil
 
 	case messageTypeError:
+		// If we read an error frame, we can release it once we deserialize it.
+		defer mex.framePool.Release(frame)
+
 		errMsg := errorMessage{
 			id: frame.Header.ID,
 		}

--- a/mex.go
+++ b/mex.go
@@ -80,6 +80,9 @@ func (mex *messageExchange) recvPeerFrame() (*Frame, error) {
 
 	select {
 	case frame := <-mex.recvCh:
+		if frame.Header.ID != mex.msgID {
+			mex.mexset.log.Errorf("recvPeerFrame mex %v received message with unexpected ID: %v", mex.msgID, frame.Header)
+		}
 		return frame, nil
 	case <-mex.ctx.Done():
 		return nil, GetContextError(mex.ctx.Err())
@@ -115,8 +118,8 @@ func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, er
 
 	default:
 		// TODO(mmihic): Should be treated as a protocol error
-		mex.mexset.log.Warnf("Received unexpected message %v, expected %v for %d",
-			frame.Header.messageType, msgType, frame.Header.ID)
+		mex.mexset.log.Warnf("Received unexpected frame: %v expected %v[%v]",
+			frame.Header, msgType, mex.msgID)
 
 		return nil, errUnexpectedFrameType
 	}
@@ -257,8 +260,8 @@ func (mexset *messageExchangeSet) forwardPeerFrame(frame *Frame) error {
 	}
 
 	if err := mex.forwardPeerFrame(frame); err != nil {
-		mexset.log.Infof("Unable to forward frame ID %v type %v length %v to %s: %v",
-			frame.Header.ID, frame.Header.messageType, frame.Header.FrameSize(), mexset.name, err)
+		mexset.log.Infof("Unable to forward frame %v length %v to %s: %v",
+			frame.Header, frame.Header.FrameSize(), mexset.name, err)
 		return err
 	}
 


### PR DESCRIPTION
Error frames were being released to the pool too early (and being overwritten), causing "unexpected frame" errors instead of the real error message from the error frame. Hold on to error frames for longer, and validate more scenarios in the frame pool test.

Also improve debugging and add a safety check to ensure that unexpected message IDs are rejected earlier.