### PR TITLE
Add logging for connection close

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -794,6 +794,7 @@ func (c *Connection) closeNetwork() {
 	// NB(mmihic): The sender goroutine will exit once the connection is
 	// closed; no need to close the send channel (and closing the send
 	// channel would be dangerous since other goroutine might be sending)
+	c.log.Debugf("Closing underlying network connection")
 	atomic.AddInt32(&c.closeNetworkCalled, 1)
 	if err := c.conn.Close(); err != nil {
 		c.log.Warnf("could not close connection to peer %s: %v", c.remotePeerInfo, err)

--- a/connection_test.go
+++ b/connection_test.go
@@ -426,3 +426,15 @@ func TestReadTimeout(t *testing.T) {
 		}
 	})
 }
+
+func TestGracefulClose(t *testing.T) {
+	WithVerifiedServer(t, nil, func(ch1 *Channel, hp1 string) {
+		WithVerifiedServer(t, nil, func(ch2 *Channel, hp2 string) {
+			ctx, cancel := NewContext(time.Second)
+			defer cancel()
+
+			assert.NoError(t, ch1.Ping(ctx, hp2), "Ping from ch1 -> ch2 failed")
+			assert.NoError(t, ch2.Ping(ctx, hp1), "Ping from ch2 -> ch1 failed")
+		})
+	})
+}


### PR DESCRIPTION
Verify that closing channels gracefully doesn't cause any error logging.