### PR TITLE
Add rules to generate a thrift-gen release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 build
 Godeps/_workspace
+release/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .DS_Store
 build
 Godeps/_workspace
-release/
+thrift-gen-release/

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ EXAMPLES=./examples/bench/server ./examples/bench/client ./examples/ping ./examp
 PKGS := . ./json ./hyperbahn ./thrift ./typed ./trace $(EXAMPLES)
 TEST_ARG ?= -race
 BUILD := ./build
-RELEASE := ./release
-RELEASE_LINUX := $(RELEASE)/linux-x86_64
-RELEASE_DARWIN := $(RELEASE)/darwin-x86_64
+THRIFT_GEN_RELEASE := ./thrift-gen-release
+THRIFT_GEN_RELEASE_LINUX := $(THRIFT_GEN_RELEASE)/linux-x86_64
+THRIFT_GEN_RELEASE_DARWIN := $(THRIFT_GEN_RELEASE)/darwin-x86_64
 SRCS := $(foreach pkg,$(PKGS),$(wildcard $(pkg)/*.go))
 export GOPATH = $(GODEPS):$(OLDGOPATH)
 
@@ -35,8 +35,8 @@ packages_test:
 setup:
 	mkdir -p $(BUILD)
 	mkdir -p $(BUILD)/examples
-	mkdir -p $(RELEASE_LINUX)
-	mkdir -p $(RELEASE_DARWIN)
+	mkdir -p $(THRIFT_GEN_RELEASE_LINUX)
+	mkdir -p $(THRIFT_GEN_RELEASE_DARWIN)
 
 get_thrift:
 	scripts/travis/get-thrift.sh
@@ -53,8 +53,7 @@ help:
 clean:
 	echo Cleaning build artifacts...
 	go clean
-	rm -rf $(BUILD)
-	rm -rf $(RELEASE)
+	rm -rf $(BUILD) $(THRIFT_GEN_RELEASE)
 	echo
 
 fmt format:
@@ -115,10 +114,10 @@ thrift_gen:
 	rm -rf trace/thrift/gen-go/tcollector && $(BUILD)/thrift-gen --generateThrift --inputFile trace/tcollector.thrift --outputDir trace/thrift/gen-go/
 
 release_thrift_gen: clean setup
-	GOOS=linux GOARCH=amd64 godep go build -o $(RELEASE_LINUX)/thrift-gen ./thrift/thrift-gen
-	GOOS=darwin GOARCH=amd64 godep go build -o $(RELEASE_DARWIN)/thrift-gen ./thrift/thrift-gen
-	tar -czf thrift-gen.tar.gz $(RELEASE)
-	mv thrift-gen.tar.gz $(RELEASE)/
+	GOOS=linux GOARCH=amd64 godep go build -o $(THRIFT_GEN_RELEASE_LINUX)/thrift-gen ./thrift/thrift-gen
+	GOOS=darwin GOARCH=amd64 godep go build -o $(THRIFT_GEN_RELEASE_DARWIN)/thrift-gen ./thrift/thrift-gen
+	tar -czf thrift-gen-release.tar.gz $(THRIFT_GEN_RELEASE)
+	mv thrift-gen-release.tar.gz $(THRIFT_GEN_RELEASE)/
 
-.PHONY: all help clean fmt format get_thrift install install_ci packages_test test test_ci vet
+.PHONY: all help clean fmt format get_thrift install install_ci release_thrift_gen packages_test test test_ci vet
 .SILENT: all help clean fmt format test vet


### PR DESCRIPTION
To test generated code on travis we need a version of `thrift-gen` available during ci. Before we used `go get github.com/uber/tchannel-go/thrift/thrift-gen` to install a version there. But since `go get` is unaware of the versions of dependencies used by `thrift-gen` this unexpectedly broke our tests.

With these changes we can reliably generate a release tarball via `make release_thrift_gen` and upload it to github to create a release of `thrift-gen`. We can then download a specific working binary of `thrift-gen` during ci to test our code generation.

Example usage:
 - https://github.com/uber/ringpop-go/blob/c258d404d6015d429e3385bb420d3d3747eddf0c/.travis.yml#L6
 - https://github.com/uber/ringpop-go/blob/c258d404d6015d429e3385bb420d3d3747eddf0c/scripts/travis/get-thrift-gen.sh
 - https://github.com/uber/ringpop-go/blob/c258d404d6015d429e3385bb420d3d3747eddf0c/Makefile#L2

For testing purposes I created an alpha release on https://github.com/thanodnl/tchannel-go/releases/tag/v0.1-alpha to test this on travis.