### PR TITLE
Don't GC peers that are explicitly added via Peers.Add

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -93,6 +93,7 @@ func (l *PeerList) Add(hostPort string) *Peer {
 	}
 
 	p := l.parent.Add(hostPort)
+	p.addSC()
 	ps := newPeerScore(p, l.scoreCalculator.GetScore(p))
 
 	l.peersByHostPort[hostPort] = ps
@@ -302,6 +303,13 @@ func (p *Peer) AddInboundConnection(c *Connection) error {
 
 	p.connectionStateChanged(c)
 	return nil
+}
+
+// addSC adds a reference to a peer from a subchannel (e.g. peer list).
+func (p *Peer) addSC() {
+	p.mut.Lock()
+	p.scCount++
+	p.mut.Unlock()
 }
 
 // canRemove returns whether this peer can be safely removed from the root peer list.


### PR DESCRIPTION
We should only remove peers that were not explicitly added via Peers.Add when GCing peers.

Otherwise, in the following scenario:
- host1 is added via Peers.Add
- host1 connects, and then disconnects, and has 0 connections
- we GC host1 from root peer list

Now if some other isolated subchannel tries to reference host1, it will get a separate instance of the peer, since it has been removed from the root peer list.