### PR TITLE
Run additional tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,12 @@ TEST_ARG ?= -race
 BUILD := ./build
 SRCS := $(foreach pkg,$(PKGS),$(wildcard $(pkg)/*.go))
 export GOPATH = $(GODEPS):$(OLDGOPATH)
-export PATH := $(realpath ./scripts/travis/thrift-release/linux-x86_64):$(PATH)
+
+PLATFORM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m)
+THRIFT_REL := ./scripts/travis/thrift-release/$(PLATFORM)-$(ARCH)
+
+export PATH := $(realpath $(THRIFT_REL)):$(PATH)
 
 
 # Separate packages that use testutils and don't, since they can have different flags.


### PR DESCRIPTION
There was a bug in the makefile where it wouldn't run the tests in the top
level directory.

This also adds support for running the tests on Darwin by setting the correct
Thrift path.