### PR TITLE
Add UnmarshallYAML to hyperbahn FailStrategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build
 Godeps/_workspace
 thrift-gen-release/
+.idea

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -57,6 +57,10 @@
 		{
 			"ImportPath": "golang.org/x/net/context",
 			"Rev": "6c89489cafabcbc76df9dbf84ebf07204673fecf"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
 		}
 	]
 }

--- a/hyperbahn/advertise_test.go
+++ b/hyperbahn/advertise_test.go
@@ -306,7 +306,7 @@ func TestRetryFailure(t *testing.T) {
 	})
 }
 
-func TestCanUnmarshallYAMLFailStrategy(t *testing.T) {
+func TestCanUnmarshalYAMLFailStrategy(t *testing.T) {
 	tests := []struct {
 		strategy string
 		expected FailStrategy

--- a/hyperbahn/client.go
+++ b/hyperbahn/client.go
@@ -58,6 +58,23 @@ const (
 
 const hyperbahnServiceName = "hyperbahn"
 
+func (f *FailStrategy) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+	var strategy string
+	if err := unmarshal(&strategy); err != nil {
+		return err
+	}
+
+	switch strategy {
+	case "fatal":
+		*f = FailStrategyFatal
+	case "ignore":
+		*f = FailStrategyIgnore
+	default:
+		return fmt.Errorf("not a valid fail strategy: %q", strategy)
+	}
+	return nil
+}
+
 // ClientOptions are used to configure this Hyperbahn client.
 type ClientOptions struct {
 	// Timeout defaults to 1 second if it is not set.


### PR DESCRIPTION
Adding UnmarshallYAML so we can specify a FailStrategy in yaml config files.