### PR TITLE
Expose remote PeerInfo on IncomingCall

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -480,13 +480,13 @@ func callWithNewClient(t *testing.T, hostPort string) {
 
 func TestNoLeakedState(t *testing.T) {
 	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
-		state1 := ch.IntrospectState(&IntrospectionOptions{})
+		state1 := ch.IntrospectState(nil)
 		for i := 0; i < 100; i++ {
 			callWithNewClient(t, hostPort)
 		}
 
 		time.Sleep(time.Millisecond)
-		state2 := ch.IntrospectState(&IntrospectionOptions{})
+		state2 := ch.IntrospectState(nil)
 		assert.Equal(t, state1, state2, "State mismatch")
 	})
 }

--- a/context.go
+++ b/context.go
@@ -46,6 +46,11 @@ type IncomingCall interface {
 
 	// ShardKey returns the shard key from the ShardKey transport header.
 	ShardKey() string
+
+	// RemotePeer returns the caller's peer information.
+	// If the caller is an ephemeral peer, then the HostPort cannot be used to make new
+	// connections to the caller.
+	RemotePeer() PeerInfo
 }
 
 func getTChannelParams(ctx context.Context) *tchannelCtxParams {

--- a/inbound.go
+++ b/inbound.go
@@ -259,6 +259,11 @@ func (call *InboundCall) ShardKey() string {
 	return call.headers[ShardKey]
 }
 
+// RemotePeer returns the caller's peer info.
+func (call *InboundCall) RemotePeer() PeerInfo {
+	return call.conn.RemotePeerInfo()
+}
+
 // Reads the entire operation name (arg1) from the request stream.
 func (call *InboundCall) readOperation() error {
 	var arg1 []byte

--- a/incoming_test.go
+++ b/incoming_test.go
@@ -72,13 +72,12 @@ func TestPeersIncomingConnection(t *testing.T) {
 		}
 
 		// verify number of peers/connections on the client side
-		opts := &IntrospectionOptions{}
-		serverState := ch.IntrospectState(opts).RootPeers
+		serverState := ch.IntrospectState(nil).RootPeers
 		serverHostPort := ch.PeerInfo().HostPort
 
 		assert.Equal(t, len(serverState), 2, "Incorrect peer count")
 		for _, client := range []*Channel{ringpop, hyperbahn} {
-			clientPeerState := client.IntrospectState(opts).RootPeers
+			clientPeerState := client.IntrospectState(nil).RootPeers
 			clientHostPort := client.PeerInfo().HostPort
 			assert.Equal(t, len(clientPeerState), 1, "Incorrect peer count")
 			assert.Equal(t, len(clientPeerState[serverHostPort].OutboundConnections), 1, "Incorrect outbound connection count")

--- a/introspection.go
+++ b/introspection.go
@@ -119,6 +119,10 @@ type PeerRuntimeState struct {
 // IntrospectState returns the RuntimeState for this channel.
 // Note: this is purely for debugging and monitoring, and may slow down your Channel.
 func (ch *Channel) IntrospectState(opts *IntrospectionOptions) *RuntimeState {
+	if opts == nil {
+		opts = &IntrospectionOptions{}
+	}
+
 	ch.mutable.mut.RLock()
 	conns := len(ch.mutable.conns)
 	ch.mutable.mut.RUnlock()

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -33,6 +33,9 @@ type FakeIncomingCall struct {
 
 	// ShardKeyF is the intended destination for this call.
 	ShardKeyF string
+
+	// RemotePeer is the calling service's peer info.
+	RemotePeerF tchannel.PeerInfo
 }
 
 // CallerName returns the caller name as specified in the fake call.
@@ -43,6 +46,11 @@ func (f *FakeIncomingCall) CallerName() string {
 // ShardKey returns the shard key as specified in the fake call.
 func (f *FakeIncomingCall) ShardKey() string {
 	return f.ShardKeyF
+}
+
+// RemotePeer returns the caller's peer info.
+func (f *FakeIncomingCall) RemotePeer() tchannel.PeerInfo {
+	return f.RemotePeerF
 }
 
 // NewIncomingCall creates an incoming call for tests.


### PR DESCRIPTION
This lets you access the host:port of the caller for an incoming call. You can access this using `CurrentCall(ctx).RemotePeer()`

cc: @nomis52  @shawnburke 