### PR TITLE
Move goroutine verification to separate package

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+	"github.com/uber/tchannel-go/testutils/goroutines"
 	"golang.org/x/net/context"
 )
 
@@ -93,7 +94,7 @@ func TestCloseAfterTimeout(t *testing.T) {
 		// Unblock the testHandler so that a goroutine isn't leaked.
 		<-testHandler.blockErr
 	})
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 // TestCloseStress ensures that once a Channel is closed, it cannot be reached.
@@ -317,7 +318,7 @@ func (t *closeSemanticsTest) runTest(ctx context.Context) {
 
 func TestCloseSemantics(t *testing.T) {
 	// We defer the check as we want it to run after the SetTimeout clears the timeout.
-	defer VerifyNoBlockedGoroutines(t)
+	defer goroutines.VerifyNoLeaks(t, nil)
 	defer testutils.SetTimeout(t, 2*time.Second)()
 
 	ctx, cancel := NewContext(time.Second)
@@ -329,7 +330,7 @@ func TestCloseSemantics(t *testing.T) {
 
 func TestCloseSemanticsIsolated(t *testing.T) {
 	// We defer the check as we want it to run after the SetTimeout clears the timeout.
-	defer VerifyNoBlockedGoroutines(t)
+	defer goroutines.VerifyNoLeaks(t, nil)
 	defer testutils.SetTimeout(t, 2*time.Second)()
 
 	ctx, cancel := NewContext(time.Second)
@@ -379,7 +380,7 @@ func TestCloseSingleChannel(t *testing.T) {
 	// Once all calls are complete, the channel should be closed.
 	runtime.Gosched()
 	assert.Equal(t, ChannelClosed, ch.State())
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestCloseOneSide(t *testing.T) {
@@ -422,7 +423,7 @@ func TestCloseOneSide(t *testing.T) {
 
 	// We need to close all open TChannels before verifying blocked goroutines.
 	ch2.Close()
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 // TestCloseSendError tests that system errors are not attempted to be sent when
@@ -466,7 +467,7 @@ func TestCloseSendError(t *testing.T) {
 	wg.Wait()
 
 	clientCh.Close()
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func callWithNewClient(t *testing.T, hostPort string) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+	"github.com/uber/tchannel-go/testutils/goroutines"
 	"golang.org/x/net/context"
 )
 
@@ -318,7 +319,7 @@ func TestTimeout(t *testing.T) {
 		// Verify the server-side receives an error from the context.
 		assert.Equal(t, context.DeadlineExceeded, <-testHandler.blockErr)
 	})
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestLargeOperation(t *testing.T) {
@@ -342,7 +343,7 @@ func TestLargeTimeout(t *testing.T) {
 		_, _, _, err := raw.Call(ctx, ch, hostPort, testServiceName, "echo", testArg2, testArg3)
 		assert.NoError(t, err, "Call failed")
 	})
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestFragmentation(t *testing.T) {
@@ -396,7 +397,7 @@ func TestFragmentationSlowReader(t *testing.T) {
 		close(startReading)
 		<-handlerComplete
 	})
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestWriteArg3AfterTimeout(t *testing.T) {
@@ -436,7 +437,7 @@ func TestWriteArg3AfterTimeout(t *testing.T) {
 		case <-timedOut:
 		}
 	})
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestWriteErrorAfterTimeout(t *testing.T) {
@@ -462,7 +463,7 @@ func TestWriteErrorAfterTimeout(t *testing.T) {
 		close(timedOut)
 		<-done
 	})
-	VerifyNoBlockedGoroutines(t)
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestReadTimeout(t *testing.T) {

--- a/testutils/goroutines/stacks.go
+++ b/testutils/goroutines/stacks.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goroutines
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func getStackBuffer(all bool) []byte {
+	for i := 4096; ; i *= 2 {
+		buf := make([]byte, i)
+		if n := runtime.Stack(buf, all); n < i {
+			return buf
+		}
+	}
+}
+
+// parseGoStackHeader parses a stack header that looks like:
+// goroutine 643 [runnable]:\n
+// And returns the goroutine ID, and the state.
+func parseGoStackHeader(line string) (goroutineID int, state string) {
+	line = strings.TrimSuffix(line, ":\n")
+	parts := strings.SplitN(line, " ", 3)
+	if len(parts) != 3 {
+		panic(fmt.Sprintf("unexpected stack header format: %v", line))
+	}
+
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse goroutine ID: %v", parts[1]))
+	}
+
+	state = strings.TrimSuffix(strings.TrimPrefix(parts[2], "["), "]")
+	return id, state
+}
+
+// Stack represents a single Goroutine's stack.
+type Stack struct {
+	id        int
+	state     string
+	fullStack *bytes.Buffer
+}
+
+// ID returns the goroutine ID.
+func (s Stack) ID() int {
+	return s.id
+}
+
+// State returns the Goroutine's state.
+func (s Stack) State() string {
+	return s.state
+}
+
+// Full returns the full stack trace for this goroutine.
+func (s Stack) Full() []byte {
+	return s.fullStack.Bytes()
+}
+
+func (s Stack) String() string {
+	return fmt.Sprintf("Goroutine %v in state %v:\n%s", s.id, s.state, s.Full())
+}
+
+// GetAll returns the stacks for all running goroutines.
+func GetAll() []Stack {
+	var stacks []Stack
+
+	var curStack *Stack
+	stackReader := bufio.NewReader(bytes.NewReader(getStackBuffer(true /* all */)))
+	for {
+		line, err := stackReader.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic("stack reader failed")
+		}
+
+		// If we see the goroutine header, start a new stack.
+		if strings.HasPrefix(line, "goroutine ") {
+			// flush any previous stack
+			if curStack != nil {
+				stacks = append(stacks, *curStack)
+			}
+			id, goState := parseGoStackHeader(line)
+			curStack = &Stack{
+				id:        id,
+				state:     goState,
+				fullStack: &bytes.Buffer{},
+			}
+		}
+		curStack.fullStack.WriteString(line)
+	}
+
+	if curStack != nil {
+		stacks = append(stacks, *curStack)
+	}
+	return stacks
+}

--- a/testutils/goroutines/verify.go
+++ b/testutils/goroutines/verify.go
@@ -18,92 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tchannel_test
+package goroutines
 
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
 
-func getStacks() []byte {
-	for i := 4096; ; i *= 2 {
-		buf := make([]byte, i)
-		if n := runtime.Stack(buf, true /* all */); n < i {
-			return buf
-		}
-	}
-}
-
-// parseGoStackHeader parses a stack header that looks like:
-// goroutine 643 [runnable]:\n
-// And returns the goroutine ID, and the state.
-func parseGoStackHeader(line string) (goroutineID int, state string) {
-	line = strings.TrimSuffix(line, ":\n")
-	parts := strings.SplitN(line, " ", 3)
-	if len(parts) != 3 {
-		panic(fmt.Sprintf("unexpected stack header format: %v", line))
-	}
-
-	id, err := strconv.Atoi(parts[1])
-	if err != nil {
-		panic(fmt.Sprintf("failed to parse goroutine ID: %v", parts[1]))
-	}
-
-	state = strings.TrimSuffix(strings.TrimPrefix(parts[2], "["), "]")
-	return id, state
-}
-
-type goroutineStack struct {
-	id        int
-	fullStack *bytes.Buffer
-	goState   string
-}
-
-func getAllStacks() []goroutineStack {
-	var stacks []goroutineStack
-
-	var curStack *goroutineStack
-	stackReader := bufio.NewReader(bytes.NewReader(getStacks()))
-	for {
-		line, err := stackReader.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			panic("stack reader failed")
-		}
-
-		// If we see the goroutine header, start a new stack.
-		if strings.HasPrefix(line, "goroutine ") {
-			// flush any previous stack
-			if curStack != nil {
-				stacks = append(stacks, *curStack)
-			}
-			id, goState := parseGoStackHeader(line)
-			curStack = &goroutineStack{
-				id:        id,
-				goState:   goState,
-				fullStack: &bytes.Buffer{},
-			}
-		}
-		curStack.fullStack.WriteString(line)
-	}
-
-	if curStack != nil {
-		stacks = append(stacks, *curStack)
-	}
-	return stacks
-}
-
 // isLeak returns whether the given stack contains a stack frame that is considered a leak.
-func (s goroutineStack) isLeak() bool {
+func (s Stack) isLeak() bool {
 	isLeakLine := func(line string) bool {
 		return strings.Contains(line, "(*Channel).Serve") ||
 			strings.Contains(line, "(*Connection).readFrames") ||
@@ -127,8 +55,8 @@ func (s goroutineStack) isLeak() bool {
 	}
 }
 
-func getLeakStacks(stacks []goroutineStack) []goroutineStack {
-	var leakStacks []goroutineStack
+func getLeakStacks(stacks []Stack) []Stack {
+	var leakStacks []Stack
 	for _, s := range stacks {
 		if s.isLeak() {
 			leakStacks = append(leakStacks, s)
@@ -137,25 +65,39 @@ func getLeakStacks(stacks []goroutineStack) []goroutineStack {
 	return leakStacks
 }
 
-// VerifyNoBlockedGoroutines verifies that there are no goroutines in the global space
-// that are stuck inside of readFrames or writeFrames.
+// filterStacks will filter any stacks excluded by the given VerifyOpts.
+func filterStacks(stacks []Stack, opts *VerifyOpts) []Stack {
+	filtered := stacks[:0]
+	for _, stack := range stacks {
+		if opts.ShouldSkip(stack) {
+			continue
+		}
+		filtered = append(filtered, stack)
+	}
+	return filtered
+}
+
+// VerifyNoLeaks verifies that there are no goroutines running that are stuck
+// inside of readFrames or writeFrames.
 // Since some goroutines may still be performing work in the background, we retry the
 // checks if any goroutines are fine in a running state a finite number of times.
-func VerifyNoBlockedGoroutines(t *testing.T) {
+func VerifyNoLeaks(t *testing.T, opts *VerifyOpts) {
 	retryStates := map[string]struct{}{
 		"runnable": struct{}{},
 		"running":  struct{}{},
 		"syscall":  struct{}{},
 	}
-	const maxAttempts = 10
+	const maxAttempts = 50
 	var leakAttempts int
+	var stacks []Stack
 
 retry:
 	for i := 0; i < maxAttempts; i++ {
-		// Ignore the first stack which is the current goroutine.
-		stacks := getAllStacks()[1:]
+		// Ignore the first stack which is the current goroutine that is doing the verification.
+		stacks = GetAll()[1:]
+		stacks = filterStacks(stacks, opts)
 		for _, stack := range stacks {
-			if _, ok := retryStates[stack.goState]; ok {
+			if _, ok := retryStates[stack.State()]; ok {
 				runtime.Gosched()
 				if i > maxAttempts/2 {
 					time.Sleep(time.Millisecond)
@@ -172,21 +114,20 @@ retry:
 		if len(leakStacks) > 0 && leakAttempts < 3 {
 			leakAttempts++
 			i--
-			continue retry
+			continue
 		}
 
 		for _, v := range leakStacks {
-			t.Errorf("Found leaked goroutine in state %q Full stack:\n%s\n",
-				v.goState, v.fullStack.String())
+			t.Errorf("Found leaked goroutine: %v", v)
 		}
 
 		// Note: we cannot use NumGoroutine here as it includes system goroutines
 		// while runtime.Stack does not: https://github.com/golang/go/issues/11706
 		if len(stacks) > 2 {
-			t.Errorf("Expect at most 2 goroutines, found more:\n%s", getStacks())
+			t.Errorf("Expect at most 2 goroutines, found more:\n%s", stacks)
 		}
 		return
 	}
 
-	t.Errorf("VerifyNoBlockedGoroutines failed: too many retries")
+	t.Errorf("VerifyNoBlockedGoroutines failed: too many retries. Stacks:\n%s", stacks)
 }

--- a/testutils/goroutines/verify_opts.go
+++ b/testutils/goroutines/verify_opts.go
@@ -18,18 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tchannel_test
+package goroutines
 
-import (
-	"testing"
+import "bytes"
 
-	"github.com/uber/tchannel-go/testutils/goroutines"
-)
+// VerifyOpts contains
+type VerifyOpts struct {
+	// Exclude is a string that will exclude a stack from being considered a leak.
+	Exclude string
+}
 
-// This file is named z_* so that it is the last test file compiled by Go, and so
-// is run after all the other tests.
+// ShouldSkip returns whether the given stack should be skipped when doing verification.
+func (opts *VerifyOpts) ShouldSkip(s Stack) bool {
+	if opts == nil || len(opts.Exclude) == 0 {
+		return false
+	}
 
-// TestNoGoroutinesLeaked verifies that no tests have leaked goroutines.
-func TestNoGoroutinesLeaked(t *testing.T) {
-	goroutines.VerifyNoLeaks(t, nil)
+	return bytes.Contains(s.Full(), []byte(opts.Exclude))
 }


### PR DESCRIPTION
This makes it easier to get stacks for debugging (goroutines.GetAll).
The verification can become more complicated without bloating the
tchannel package.