### PR TITLE
Pool checksum objects

### DIFF
--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -214,7 +214,7 @@ func (r *fragmentingReader) Close() error {
 			return r.err
 		}
 
-		r.receiver.doneReading(nil)
+		r.doneReading(nil)
 		r.curFragment.done()
 		r.curChunk = nil
 		r.state = fragmentingReadComplete
@@ -258,7 +258,7 @@ func (r *fragmentingReader) recvAndParseNextFragment(initial bool) error {
 		if err, ok := r.err.(errorMessage); ok {
 			// Serialized system errors are still reported (e.g. latency, trace reporting).
 			r.err = err.AsSystemError()
-			r.receiver.doneReading(r.err)
+			r.doneReading(r.err)
 		}
 		return r.err
 	}
@@ -297,4 +297,11 @@ func (r *fragmentingReader) recvAndParseNextFragment(initial bool) error {
 	// Pull out the first chunk to act as the current chunk
 	r.curChunk, r.remainingChunks = r.remainingChunks[0], r.remainingChunks[1:]
 	return nil
+}
+
+func (r *fragmentingReader) doneReading(err error) {
+	if r.checksum != nil {
+		r.checksum.Release()
+	}
+	r.receiver.doneReading(err)
 }

--- a/fragmenting_writer.go
+++ b/fragmenting_writer.go
@@ -60,10 +60,12 @@ type writableFragment struct {
 
 // finish finishes the fragment, updating the final checksum and fragment flags
 func (f *writableFragment) finish(hasMoreFragments bool) {
+	f.checksumRef.Update(f.checksum.Sum())
 	if hasMoreFragments {
 		f.flagsRef.Update(hasMoreFragmentsFlag)
+	} else {
+		f.checksum.Release()
 	}
-	f.checksumRef.Update(f.checksum.Sum())
 }
 
 // A writableChunk is a chunk of data within a fragment, representing the


### PR DESCRIPTION
This brings down the number of allocs in BenchmarkCallsSerial from
127 allocs/op to 115 allocs/op.

@akshayjshah 