### PR TITLE
Start timers at earliest possible time

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -91,12 +91,12 @@ func TestStatsCalls(t *testing.T) {
 		outboundTags := tagsForOutboundCall(serverCh, ch, "echo")
 		clientStats.Expected.IncCounter("outbound.calls.send", outboundTags, 1)
 		clientStats.Expected.IncCounter("outbound.calls.success", outboundTags, 1)
-		clientStats.Expected.RecordTimer("outbound.calls.per-attempt.latency", outboundTags, 200*time.Millisecond)
-		clientStats.Expected.RecordTimer("outbound.calls.latency", outboundTags, 200*time.Millisecond)
+		clientStats.Expected.RecordTimer("outbound.calls.per-attempt.latency", outboundTags, 100*time.Millisecond)
+		clientStats.Expected.RecordTimer("outbound.calls.latency", outboundTags, 100*time.Millisecond)
 		inboundTags := tagsForInboundCall(serverCh, ch, "echo")
 		serverStats.Expected.IncCounter("inbound.calls.recvd", inboundTags, 1)
 		serverStats.Expected.IncCounter("inbound.calls.success", inboundTags, 1)
-		serverStats.Expected.RecordTimer("inbound.calls.latency", inboundTags, 100*time.Millisecond)
+		serverStats.Expected.RecordTimer("inbound.calls.latency", inboundTags, 50*time.Millisecond)
 
 		_, _, resp, err := raw.Call(ctx, ch, hostPort, testServiceName, "app-error", nil, nil)
 		require.NoError(t, err)
@@ -106,12 +106,12 @@ func TestStatsCalls(t *testing.T) {
 		clientStats.Expected.IncCounter("outbound.calls.send", outboundTags, 1)
 		clientStats.Expected.IncCounter("outbound.calls.per-attempt.app-errors", outboundTags, 1)
 		clientStats.Expected.IncCounter("outbound.calls.app-errors", outboundTags, 1)
-		clientStats.Expected.RecordTimer("outbound.calls.per-attempt.latency", outboundTags, 200*time.Millisecond)
-		clientStats.Expected.RecordTimer("outbound.calls.latency", outboundTags, 200*time.Millisecond)
+		clientStats.Expected.RecordTimer("outbound.calls.per-attempt.latency", outboundTags, 100*time.Millisecond)
+		clientStats.Expected.RecordTimer("outbound.calls.latency", outboundTags, 100*time.Millisecond)
 		inboundTags = tagsForInboundCall(serverCh, ch, "app-error")
 		serverStats.Expected.IncCounter("inbound.calls.recvd", inboundTags, 1)
 		serverStats.Expected.IncCounter("inbound.calls.app-errors", inboundTags, 1)
-		serverStats.Expected.RecordTimer("inbound.calls.latency", inboundTags, 100*time.Millisecond)
+		serverStats.Expected.RecordTimer("inbound.calls.latency", inboundTags, 50*time.Millisecond)
 	})
 
 	clientStats.Validate(t)
@@ -155,27 +155,27 @@ func TestStatsWithRetries(t *testing.T) {
 			{
 				numFailures:         0,
 				numAttempts:         1,
-				perAttemptLatencies: a(20 * time.Millisecond),
-				overallLatency:      40 * time.Millisecond,
+				perAttemptLatencies: a(10 * time.Millisecond),
+				overallLatency:      20 * time.Millisecond,
 			},
 			{
 				numFailures:         1,
 				numAttempts:         2,
-				perAttemptLatencies: a(20*time.Millisecond, 20*time.Millisecond),
-				overallLatency:      80 * time.Millisecond,
+				perAttemptLatencies: a(10*time.Millisecond, 10*time.Millisecond),
+				overallLatency:      40 * time.Millisecond,
 			},
 			{
 				numFailures:         4,
 				numAttempts:         5,
-				perAttemptLatencies: a(20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond),
-				overallLatency:      200 * time.Millisecond,
+				perAttemptLatencies: a(10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond),
+				overallLatency:      100 * time.Millisecond,
 			},
 			{
 				numFailures:         5,
 				numAttempts:         5,
 				expectErr:           ErrServerBusy,
-				perAttemptLatencies: a(20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond, 20*time.Millisecond),
-				overallLatency:      200 * time.Millisecond,
+				perAttemptLatencies: a(10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond),
+				overallLatency:      100 * time.Millisecond,
 			},
 		}
 

--- a/tracereporter.go
+++ b/tracereporter.go
@@ -125,9 +125,9 @@ func (as *Annotations) AddBinaryAnnotation(key string, value interface{}) {
 	as.data.BinaryAnnotations = append(as.data.BinaryAnnotations, binaryAnnotation)
 }
 
-// AddAnnotation adds a standard annotation.
-func (as *Annotations) AddAnnotation(key AnnotationKey) {
-	annotation := Annotation{Key: key, Timestamp: as.timeNow()}
+// AddAnnotationAt adds a standard annotation with the specified time.
+func (as *Annotations) AddAnnotationAt(key AnnotationKey, ts time.Time) {
+	annotation := Annotation{Key: key, Timestamp: ts}
 	as.data.Annotations = append(as.data.Annotations, annotation)
 }
 

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -145,7 +145,7 @@ func TestTraceReportingEnabled(t *testing.T) {
 			serverOpts: traceReporterOpts,
 			expected: []Annotation{
 				{Key: "sr", Timestamp: initialTime.Add(2 * time.Second)},
-				{Key: "ss", Timestamp: initialTime.Add(4 * time.Second)},
+				{Key: "ss", Timestamp: initialTime.Add(3 * time.Second)},
 			},
 			fromServer: true,
 		},
@@ -154,7 +154,7 @@ func TestTraceReportingEnabled(t *testing.T) {
 			clientOpts: traceReporterOpts,
 			expected: []Annotation{
 				{Key: "cs", Timestamp: initialTime.Add(time.Second)},
-				{Key: "cr", Timestamp: initialTime.Add(7 * time.Second)},
+				{Key: "cr", Timestamp: initialTime.Add(6 * time.Second)},
 			},
 		},
 	}


### PR DESCRIPTION
Call timeNow as soon as handleCallReq/beginCall are entered.
Use this time to track when a request was started and for adding
annotations to the spans.
This reduces the number of times we call timeNow.

Inbound requests will now include the time it takes to start a goroutine
to process the incoming request. Before, the metrics emitted only
tracked the time from after the goroutine was started to when it
completed writing the response.

@akshayjshah 