### PR TITLE
Make Peer.BeginCall and Connection.beginCall consistent

### DIFF
--- a/outbound.go
+++ b/outbound.go
@@ -33,7 +33,7 @@ import (
 const maxOperationSize = 16 * 1024
 
 // beginCall begins an outbound call on the connection
-func (c *Connection) beginCall(ctx context.Context, serviceName string, callOptions *CallOptions, operation string) (*OutboundCall, error) {
+func (c *Connection) beginCall(ctx context.Context, serviceName, operationName string, callOptions *CallOptions) (*OutboundCall, error) {
 	now := c.timeNow()
 
 	switch state := c.readState(); state {
@@ -87,7 +87,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 		TimeToLive: timeToLive,
 	}
 	call.statsReporter = c.statsReporter
-	call.createStatsTags(c.commonStatsTags, callOptions, operation)
+	call.createStatsTags(c.commonStatsTags, callOptions, operationName)
 	call.log = c.log.WithFields(LogField{"Out-Call", requestID})
 
 	// TODO(mmihic): It'd be nice to do this without an fptr
@@ -124,7 +124,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 				HostPort:    c.remotePeerInfo.HostPort,
 				ServiceName: serviceName,
 			},
-			Method: operation,
+			Method: operationName,
 		},
 		binaryAnnotationsBacking: [2]BinaryAnnotation{
 			{Key: "cn", Value: call.callReq.Headers[CallerName]},
@@ -151,7 +151,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 
 	call.response = response
 
-	if err := call.writeOperation([]byte(operation)); err != nil {
+	if err := call.writeOperation([]byte(operationName)); err != nil {
 		return nil, err
 	}
 	return call, nil

--- a/peer.go
+++ b/peer.go
@@ -385,7 +385,7 @@ func (p *Peer) Connect(ctx context.Context) (*Connection, error) {
 
 // BeginCall starts a new call to this specific peer, returning an OutboundCall that can
 // be used to write the arguments of the call.
-func (p *Peer) BeginCall(ctx context.Context, serviceName string, operationName string, callOptions *CallOptions) (*OutboundCall, error) {
+func (p *Peer) BeginCall(ctx context.Context, serviceName, operationName string, callOptions *CallOptions) (*OutboundCall, error) {
 	if callOptions == nil {
 		callOptions = defaultCallOptions
 	}
@@ -399,7 +399,7 @@ func (p *Peer) BeginCall(ctx context.Context, serviceName string, operationName 
 	if callOptions == nil {
 		callOptions = defaultCallOptions
 	}
-	call, err := conn.beginCall(ctx, serviceName, callOptions, operationName)
+	call, err := conn.beginCall(ctx, serviceName, operationName, callOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
No behaviour changes, just a clean up.