### PR TITLE
Remove high-priority string-munging logger methods

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -370,7 +370,10 @@ func (ch *Channel) serve() {
 				if max := 1 * time.Second; acceptBackoff > max {
 					acceptBackoff = max
 				}
-				ch.log.Warnf("accept error: %v; retrying in %v", err, acceptBackoff)
+				ch.log.WithFields(
+					LogField{"error", err.Error()},
+					LogField{"backoff", acceptBackoff},
+				).Warn("Accept error, will wait and retry.")
 				time.Sleep(acceptBackoff)
 				continue
 			} else {
@@ -378,7 +381,9 @@ func (ch *Channel) serve() {
 				if ch.State() >= ChannelStartClose {
 					return
 				}
-				ch.log.Fatalf("unrecoverable accept error: %v; closing server", err)
+				ch.log.WithFields(
+					LogField{"error", err.Error()},
+				).Fatal("Unrecoverable accept error, closing server.")
 				return
 			}
 		}
@@ -393,7 +398,9 @@ func (ch *Channel) serve() {
 		}
 		if _, err := ch.newInboundConnection(netConn, events); err != nil {
 			// Server is getting overloaded - begin rejecting new connections
-			ch.log.Errorf("could not create new TChannelConnection for incoming conn: %v", err)
+			ch.log.WithFields(
+				LogField{"error", err.Error()},
+			).Error("Couldn't create new TChannelConnection for incoming conn.")
 			netConn.Close()
 			continue
 		}

--- a/channel.go
+++ b/channel.go
@@ -371,7 +371,7 @@ func (ch *Channel) serve() {
 					acceptBackoff = max
 				}
 				ch.log.WithFields(
-					LogField{"error", err.Error()},
+					ErrField(err),
 					LogField{"backoff", acceptBackoff},
 				).Warn("Accept error, will wait and retry.")
 				time.Sleep(acceptBackoff)
@@ -381,9 +381,7 @@ func (ch *Channel) serve() {
 				if ch.State() >= ChannelStartClose {
 					return
 				}
-				ch.log.WithFields(
-					LogField{"error", err.Error()},
-				).Fatal("Unrecoverable accept error, closing server.")
+				ch.log.WithFields(ErrField(err)).Fatal("Unrecoverable accept error, closing server.")
 				return
 			}
 		}
@@ -398,9 +396,7 @@ func (ch *Channel) serve() {
 		}
 		if _, err := ch.newInboundConnection(netConn, events); err != nil {
 			// Server is getting overloaded - begin rejecting new connections
-			ch.log.WithFields(
-				LogField{"error", err.Error()},
-			).Error("Couldn't create new TChannelConnection for incoming conn.")
+			ch.log.WithFields(ErrField(err)).Error("Couldn't create new TChannelConnection for incoming conn.")
 			netConn.Close()
 			continue
 		}

--- a/connection.go
+++ b/connection.go
@@ -571,7 +571,7 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 		c.log.WithFields(
 			LogField{"remotePeer", c.remotePeerInfo},
 			LogField{"id", id},
-			LogField{"error", err.Error()},
+			ErrField(err),
 		).Warn("Couldn't create outbound frame.")
 		return fmt.Errorf("failed to create outbound error frame")
 	}
@@ -594,7 +594,7 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 		c.log.WithFields(
 			LogField{"remotePeer", c.remotePeerInfo},
 			LogField{"id", id},
-			LogField{"error", err.Error()},
+			ErrField(err),
 		).Warn("Couldn't send outbound frame.")
 		return fmt.Errorf("failed to send error frame, buffer full")
 	})
@@ -607,7 +607,7 @@ func (c *Connection) connectionError(site string, err error) error {
 	} else {
 		logger := c.log.WithFields(
 			LogField{"site", site},
-			LogField{"error", err.Error()},
+			ErrField(err),
 		)
 		if se, ok := err.(SystemError); ok && se.Code() != ErrCodeNetwork {
 			logger.Error("Connection error.")
@@ -620,7 +620,7 @@ func (c *Connection) connectionError(site string, err error) error {
 }
 
 func (c *Connection) protocolError(id uint32, err error) error {
-	c.log.WithFields(LogField{"error", err.Error()}).Warn("Protocol error.")
+	c.log.WithFields(ErrField(err)).Warn("Protocol error.")
 	sysErr := NewWrappedSystemError(ErrCodeProtocol, err)
 	c.SendSystemError(id, nil, sysErr)
 	// Don't close the connection until the error has been sent.
@@ -819,7 +819,7 @@ func (c *Connection) closeNetwork() {
 	if err := c.conn.Close(); err != nil {
 		c.log.WithFields(
 			LogField{"remotePeer", c.remotePeerInfo},
-			LogField{"error", err.Error()},
+			ErrField(err),
 		).Warn("Couldn't close connection to peer.")
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -429,7 +429,7 @@ func (c *Connection) ping(ctx context.Context) error {
 // handlePingRes calls registered ping handlers.
 func (c *Connection) handlePingRes(frame *Frame) bool {
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
-		c.log.Warnf("Got unexpected ping response: %+v", frame.Header)
+		c.log.WithFields(LogField{"response", frame.Header}).Warn("Unexpected ping response.")
 		return true
 	}
 	// ping req is waiting for this frame, and will release it.
@@ -568,8 +568,11 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 	}); err != nil {
 
 		// This shouldn't happen - it means writing the errorMessage is broken.
-		c.log.Warnf("Could not create outbound frame to %s for %d: %v",
-			c.remotePeerInfo, id, err)
+		c.log.WithFields(
+			LogField{"remotePeer", c.remotePeerInfo},
+			LogField{"id", id},
+			LogField{"error", err.Error()},
+		).Warn("Couldn't create outbound frame.")
 		return fmt.Errorf("failed to create outbound error frame")
 	}
 
@@ -588,8 +591,11 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 			return nil
 		default: // If the send buffer is full, log and return an error.
 		}
-		c.log.Warnf("Could not send error frame to %s for %d : %v",
-			c.remotePeerInfo, id, err)
+		c.log.WithFields(
+			LogField{"remotePeer", c.remotePeerInfo},
+			LogField{"id", id},
+			LogField{"error", err.Error()},
+		).Warn("Couldn't send outbound frame.")
 		return fmt.Errorf("failed to send error frame, buffer full")
 	})
 }
@@ -599,10 +605,14 @@ func (c *Connection) connectionError(site string, err error) error {
 	if err == io.EOF {
 		c.log.Debugf("Connection got EOF")
 	} else {
+		logger := c.log.WithFields(
+			LogField{"site", site},
+			LogField{"error", err.Error()},
+		)
 		if se, ok := err.(SystemError); ok && se.Code() != ErrCodeNetwork {
-			c.log.Errorf("Connection error at %v: %v", site, err)
+			logger.Error("Connection error.")
 		} else {
-			c.log.Warnf("Connection error at %v: %v", site, err)
+			logger.Warn("Connection error.")
 		}
 	}
 	c.Close()
@@ -610,7 +620,7 @@ func (c *Connection) connectionError(site string, err error) error {
 }
 
 func (c *Connection) protocolError(id uint32, err error) error {
-	c.log.Warnf("Protocol error: %v", err)
+	c.log.WithFields(LogField{"error", err.Error()}).Warn("Protocol error.")
 	sysErr := NewWrappedSystemError(ErrCodeProtocol, err)
 	c.SendSystemError(id, nil, sysErr)
 	// Don't close the connection until the error has been sent.
@@ -684,7 +694,10 @@ func (c *Connection) readFrames(_ uint32) {
 			releaseFrame = c.handleError(frame)
 		default:
 			// TODO(mmihic): Log and close connection with protocol error
-			c.log.Errorf("Received unexpected frame %s from %s", frame.Header, c.remotePeerInfo)
+			c.log.WithFields(
+				LogField{"header", frame.Header},
+				LogField{"remotePeer", c.remotePeerInfo},
+			).Error("Received unexpected frame.")
 		}
 
 		if releaseFrame {
@@ -804,6 +817,9 @@ func (c *Connection) closeNetwork() {
 	c.log.Debugf("Closing underlying network connection")
 	atomic.AddInt32(&c.closeNetworkCalled, 1)
 	if err := c.conn.Close(); err != nil {
-		c.log.Warnf("could not close connection to peer %s: %v", c.remotePeerInfo, err)
+		c.log.WithFields(
+			LogField{"remotePeer", c.remotePeerInfo},
+			LogField{"error", err.Error()},
+		).Warn("Couldn't close connection to peer.")
 	}
 }

--- a/examples/ping/main.go
+++ b/examples/ping/main.go
@@ -53,7 +53,7 @@ func pingOtherHandler(ctx json.Context, ping *Ping) (*Pong, error) {
 }
 
 func onError(ctx context.Context, err error) {
-	log.Fatalf("onError: %v", err)
+	log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("onError handler triggered.")
 }
 
 func listenAndHandle(s *tchannel.Channel, hostPort string) {
@@ -61,7 +61,10 @@ func listenAndHandle(s *tchannel.Channel, hostPort string) {
 
 	// If no error is returned, the listen was successful. Serving happens in the background.
 	if err := s.ListenAndServe(hostPort); err != nil {
-		log.Fatalf("Could not listen on %s: %v", hostPort, err)
+		log.WithFields(
+			tchannel.LogField{"hostPort", hostPort},
+			tchannel.LogField{"error", err.Error()},
+		).Fatal("Couldn't listen.")
 	}
 }
 
@@ -69,7 +72,7 @@ func main() {
 	// Create a new TChannel for handling requests
 	ch, err := tchannel.NewChannel("PingService", &tchannel.ChannelOptions{Logger: tchannel.SimpleLogger})
 	if err != nil {
-		log.Fatalf("Could not create new channel: %v", err)
+		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("Couldn't create new channel.")
 	}
 
 	// Register a handler for the ping message on the PingService
@@ -83,7 +86,7 @@ func main() {
 	// Create a new TChannel for sending requests.
 	client, err := tchannel.NewChannel("ping-client", nil)
 	if err != nil {
-		log.Fatalf("Could not create new client channel: %v", err)
+		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("Couldn't create new client channel.")
 	}
 
 	// Make a call to ourselves, with a timeout of 10s
@@ -94,7 +97,7 @@ func main() {
 
 	var pong Pong
 	if err := json.CallPeer(ctx, peer, "PingService", "ping", &Ping{"Hello World"}, &pong); err != nil {
-		log.Fatalf("json.Call failed: %v", err)
+		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("json.Call failed.")
 	}
 
 	log.Infof("Received pong: %s", pong.Message)
@@ -109,7 +112,7 @@ func main() {
 
 	// Try to send a message to the Service:Method pair for the subchannel
 	if err := json.CallPeer(ctx, peer, "PingServiceOther", "pingOther", &Ping{"Hello Other World"}, &pong); err != nil {
-		log.Fatalf("json.Call failed: %v", err)
+		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("json.Call failed.")
 	}
 
 	log.Infof("Received pong: %s", pong.Message)

--- a/examples/ping/main.go
+++ b/examples/ping/main.go
@@ -53,7 +53,7 @@ func pingOtherHandler(ctx json.Context, ping *Ping) (*Pong, error) {
 }
 
 func onError(ctx context.Context, err error) {
-	log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("onError handler triggered.")
+	log.WithFields(tchannel.ErrField(err)).Fatal("onError handler triggered.")
 }
 
 func listenAndHandle(s *tchannel.Channel, hostPort string) {
@@ -63,7 +63,7 @@ func listenAndHandle(s *tchannel.Channel, hostPort string) {
 	if err := s.ListenAndServe(hostPort); err != nil {
 		log.WithFields(
 			tchannel.LogField{"hostPort", hostPort},
-			tchannel.LogField{"error", err.Error()},
+			tchannel.ErrField(err),
 		).Fatal("Couldn't listen.")
 	}
 }
@@ -72,7 +72,7 @@ func main() {
 	// Create a new TChannel for handling requests
 	ch, err := tchannel.NewChannel("PingService", &tchannel.ChannelOptions{Logger: tchannel.SimpleLogger})
 	if err != nil {
-		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("Couldn't create new channel.")
+		log.WithFields(tchannel.ErrField(err)).Fatal("Couldn't create new channel.")
 	}
 
 	// Register a handler for the ping message on the PingService
@@ -86,7 +86,7 @@ func main() {
 	// Create a new TChannel for sending requests.
 	client, err := tchannel.NewChannel("ping-client", nil)
 	if err != nil {
-		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("Couldn't create new client channel.")
+		log.WithFields(tchannel.ErrField(err)).Fatal("Couldn't create new client channel.")
 	}
 
 	// Make a call to ourselves, with a timeout of 10s
@@ -97,7 +97,7 @@ func main() {
 
 	var pong Pong
 	if err := json.CallPeer(ctx, peer, "PingService", "ping", &Ping{"Hello World"}, &pong); err != nil {
-		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("json.Call failed.")
+		log.WithFields(tchannel.ErrField(err)).Fatal("json.Call failed.")
 	}
 
 	log.Infof("Received pong: %s", pong.Message)
@@ -112,7 +112,7 @@ func main() {
 
 	// Try to send a message to the Service:Method pair for the subchannel
 	if err := json.CallPeer(ctx, peer, "PingServiceOther", "pingOther", &Ping{"Hello Other World"}, &pong); err != nil {
-		log.WithFields(tchannel.LogField{"error", err.Error()}).Fatal("json.Call failed.")
+		log.WithFields(tchannel.ErrField(err)).Fatal("json.Call failed.")
 	}
 
 	log.Infof("Received pong: %s", pong.Message)

--- a/frame.go
+++ b/frame.go
@@ -21,6 +21,7 @@
 package tchannel
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -73,6 +74,15 @@ func (fh FrameHeader) FrameSize() uint16 {
 }
 
 func (fh FrameHeader) String() string { return fmt.Sprintf("%v[%d]", fh.messageType, fh.ID) }
+
+func (fh FrameHeader) MarshalJSON() ([]byte, error) {
+	s := struct {
+		ID      uint32
+		MsgType messageType
+		Size    uint16
+	}{fh.ID, fh.messageType, fh.size}
+	return json.Marshal(s)
+}
 
 func (fh *FrameHeader) read(r *typed.ReadBuffer) error {
 	fh.size = r.ReadUint16()

--- a/frame_test.go
+++ b/frame_test.go
@@ -22,6 +22,7 @@ package tchannel
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"testing"
 	"testing/iotest"
@@ -31,6 +32,22 @@ import (
 	"github.com/uber/tchannel-go/testutils/testreader"
 	"github.com/uber/tchannel-go/typed"
 )
+
+func TestFrameHeaderJSON(t *testing.T) {
+	fh := FrameHeader{
+		size:        uint16(0xFF34),
+		messageType: messageTypeCallReq,
+		ID:          0xDEADBEEF,
+	}
+	logged, err := json.Marshal(fh)
+	assert.NoError(t, err, "FrameHeader can't be marshalled to JSON")
+	assert.Equal(
+		t,
+		string(logged),
+		`{"ID":3735928559,"MsgType":3,"Size":65332}`,
+		"FrameHeader didn't marshal to JSON as expected",
+	)
+}
 
 func TestFraming(t *testing.T) {
 	fh := FrameHeader{

--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"math/rand"
 	"time"
+
+	"github.com/uber/tchannel-go"
 )
 
 const (
@@ -79,11 +81,12 @@ func (c *Client) advertiseLoop() {
 
 		if err := c.sendAdvertise(); err != nil {
 			consecutiveFailures++
+			errLogger := c.tchan.Logger().WithFields(tchannel.LogField{"error", err.Error()})
 			if consecutiveFailures >= maxAdvertiseFailures && c.opts.FailStrategy == FailStrategyFatal {
 				c.opts.Handler.OnError(ErrAdvertiseFailed{Cause: err, WillRetry: false})
-				c.tchan.Logger().Fatalf("Hyperbahn client registration failed: %v", err)
+				errLogger.Fatal("Hyperbahn client registration failed.")
 			}
-			c.tchan.Logger().Warnf("Hyperbahn client registration failed (will retry): %v", err)
+			errLogger.Warn("Hyperbahn client registration failed, will retry.")
 			c.opts.Handler.OnError(ErrAdvertiseFailed{Cause: err, WillRetry: true})
 
 			// Even after many failures, cap backoff.

--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -81,7 +81,7 @@ func (c *Client) advertiseLoop() {
 
 		if err := c.sendAdvertise(); err != nil {
 			consecutiveFailures++
-			errLogger := c.tchan.Logger().WithFields(tchannel.LogField{"error", err.Error()})
+			errLogger := c.tchan.Logger().WithFields(tchannel.ErrField(err))
 			if consecutiveFailures >= maxAdvertiseFailures && c.opts.FailStrategy == FailStrategyFatal {
 				c.opts.Handler.OnError(ErrAdvertiseFailed{Cause: err, WillRetry: false})
 				errLogger.Fatal("Hyperbahn client registration failed.")

--- a/inbound.go
+++ b/inbound.go
@@ -55,7 +55,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 		// TODO(mmihic): Probably want to treat this as a protocol error
 		c.log.WithFields(
 			LogField{"header", frame.Header},
-			LogField{"error", err.Error()},
+			ErrField(err),
 		).Error("Couldn't decode initial fragment.")
 		return true
 	}
@@ -177,7 +177,7 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 	if err := call.readMethod(); err != nil {
 		c.log.WithFields(
 			LogField{"remotePeer", c.remotePeerInfo},
-			LogField{"error", err.Error()},
+			ErrField(err),
 		).Error("Couldn't read method.")
 		releaseFrame()
 		return

--- a/inbound.go
+++ b/inbound.go
@@ -53,7 +53,10 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	initialFragment, err := parseInboundFragment(c.framePool, frame, callReq)
 	if err != nil {
 		// TODO(mmihic): Probably want to treat this as a protocol error
-		c.log.Errorf("could not decode %s: %v", frame.Header, err)
+		c.log.WithFields(
+			LogField{"header", frame.Header},
+			LogField{"error", err.Error()},
+		).Error("Couldn't decode initial fragment.")
 		return true
 	}
 
@@ -66,7 +69,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 		if err == errDuplicateMex {
 			err = errInboundRequestAlreadyActive
 		}
-		c.log.Errorf("could not register exchange for %s", frame.Header)
+		c.log.WithFields(LogField{"header", frame.Header}).Error("Couldn't register exchange.")
 		c.protocolError(frame.Header.ID, errInboundRequestAlreadyActive)
 		return true
 	}
@@ -172,7 +175,10 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 	}
 
 	if err := call.readMethod(); err != nil {
-		c.log.Errorf("Could not read method from %s: %v", c.remotePeerInfo, err)
+		c.log.WithFields(
+			LogField{"remotePeer", c.remotePeerInfo},
+			LogField{"error", err.Error()},
+		).Error("Couldn't read method.")
 		releaseFrame()
 		return
 	}
@@ -195,7 +201,10 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 		h = c.subChannels.find(call.ServiceName(), call.Method())
 	}
 	if h == nil {
-		c.log.Errorf("Could not find handler for %s:%s", call.ServiceName(), call.Method())
+		c.log.WithFields(
+			LogField{"serviceName", call.ServiceName()},
+			LogField{"method", call.Method()},
+		).Error("Couldn't find handler.")
 		call.Response().SendSystemError(
 			NewSystemError(ErrCodeBadRequest, "no handler for service %q and method %q", call.ServiceName(), call.Method()))
 		releaseFrame()

--- a/init_test.go
+++ b/init_test.go
@@ -233,8 +233,14 @@ func TestInitReqGetsError(t *testing.T) {
 	expectedErr := NewSystemError(ErrCodeBadRequest, "invalid host:port")
 	assert.Equal(t, expectedErr, err, "Error mismatch")
 	assert.Contains(t, logOut.String(),
-		"[E] Connection error at receive init res: tchannel error ErrCodeBadRequest: invalid host:port",
+		"[E] Connection error.",
+		"Message should be logged")
+	assert.Contains(t, logOut.String(),
+		"tchannel error ErrCodeBadRequest: invalid host:port",
 		"Error should be logged")
+	assert.Contains(t, logOut.String(),
+		"site receive init res",
+		"Site should be logged")
 	close(connectionComplete)
 
 	<-listenerComplete

--- a/logger.go
+++ b/logger.go
@@ -39,20 +39,11 @@ type Logger interface {
 	// Enabled returns whether the given level is enabled.
 	Enabled(level LogLevel) bool
 
-	// Fatalf logs a message, then exits with os.Exit(1).
-	Fatalf(msg string, args ...interface{})
-
 	// Fatal logs a message, then exits with os.Exit(1).
 	Fatal(msg string)
 
-	// Errorf logs a message at error priority.
-	Errorf(msg string, args ...interface{})
-
 	// Error logs a message at error priority.
 	Error(msg string)
-
-	// Warnf logs a message at warning priority.
-	Warnf(msg string, args ...interface{})
 
 	// Warn logs a message at warning priority.
 	Warn(msg string)
@@ -91,11 +82,8 @@ var NullLogger Logger = nullLogger{}
 type nullLogger struct{}
 
 func (nullLogger) Enabled(_ LogLevel) bool                { return false }
-func (nullLogger) Fatalf(msg string, arg ...interface{})  { os.Exit(1) }
 func (nullLogger) Fatal(msg string)                       { os.Exit(1) }
-func (nullLogger) Errorf(msg string, args ...interface{}) {}
 func (nullLogger) Error(msg string)                       {}
-func (nullLogger) Warnf(msg string, args ...interface{})  {}
 func (nullLogger) Warn(msg string)                        {}
 func (nullLogger) Infof(msg string, args ...interface{})  {}
 func (nullLogger) Info(msg string)                        {}
@@ -119,20 +107,13 @@ func NewLogger(writer io.Writer, fields ...LogField) Logger {
 	return &writerLogger{writer, fields}
 }
 
-func (l writerLogger) Fatalf(msg string, args ...interface{}) {
-	l.printfn("F", msg, args...)
-	os.Exit(1)
-}
-
 func (l writerLogger) Fatal(msg string) {
 	l.printfn("F", msg)
 	os.Exit(1)
 }
 
 func (l writerLogger) Enabled(_ LogLevel) bool                { return true }
-func (l writerLogger) Errorf(msg string, args ...interface{}) { l.printfn("E", msg, args...) }
 func (l writerLogger) Error(msg string)                       { l.printfn("E", msg) }
-func (l writerLogger) Warnf(msg string, args ...interface{})  { l.printfn("W", msg, args...) }
 func (l writerLogger) Warn(msg string)                        { l.printfn("W", msg) }
 func (l writerLogger) Infof(msg string, args ...interface{})  { l.printfn("I", msg, args...) }
 func (l writerLogger) Info(msg string)                        { l.printfn("I", msg) }
@@ -181,33 +162,15 @@ func (l levelLogger) Enabled(level LogLevel) bool {
 	return l.level <= level
 }
 
-func (l levelLogger) Fatalf(msg string, args ...interface{}) {
-	if l.level <= LogLevelFatal {
-		l.logger.Fatalf(msg, args...)
-	}
-}
-
 func (l levelLogger) Fatal(msg string) {
 	if l.level <= LogLevelFatal {
 		l.logger.Fatal(msg)
 	}
 }
 
-func (l levelLogger) Errorf(msg string, args ...interface{}) {
-	if l.level <= LogLevelError {
-		l.logger.Errorf(msg, args...)
-	}
-}
-
 func (l levelLogger) Error(msg string) {
 	if l.level <= LogLevelError {
 		l.logger.Error(msg)
-	}
-}
-
-func (l levelLogger) Warnf(msg string, args ...interface{}) {
-	if l.level <= LogLevelWarn {
-		l.logger.Warnf(msg, args...)
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -73,6 +73,10 @@ type LogField struct {
 	Value interface{}
 }
 
+func ErrField(err error) LogField {
+	return LogField{"error", err.Error()}
+}
+
 // LogFields is a list of LogFields used to pass additional information to the logger.
 type LogFields []LogField
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -22,12 +22,17 @@ package tchannel_test
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	. "github.com/uber/tchannel-go"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestErrField(t *testing.T) {
+	assert.Equal(t, LogField{"error", "foo"}, ErrField(errors.New("foo")))
+}
 
 func TestWriterLogger(t *testing.T) {
 	var buf bytes.Buffer

--- a/logger_test.go
+++ b/logger_test.go
@@ -35,8 +35,6 @@ func TestWriterLogger(t *testing.T) {
 
 	debugf := func(logger Logger, msg string, args ...interface{}) { logger.Debugf(msg, args...) }
 	infof := func(logger Logger, msg string, args ...interface{}) { logger.Infof(msg, args...) }
-	warnf := func(logger Logger, msg string, args ...interface{}) { logger.Warnf(msg, args...) }
-	errorf := func(logger Logger, msg string, args ...interface{}) { logger.Errorf(msg, args...) }
 
 	levels := []struct {
 		levelFunc   func(logger Logger, msg string, args ...interface{})
@@ -44,8 +42,6 @@ func TestWriterLogger(t *testing.T) {
 	}{
 		{debugf, "D"},
 		{infof, "I"},
-		{warnf, "W"},
-		{errorf, "E"},
 	}
 
 	for _, level := range levels {
@@ -125,7 +121,14 @@ func TestLevelLogger(t *testing.T) {
 	var buf bytes.Buffer
 	var bufLogger = NewLogger(&buf)
 
-	expectedLines := 0
+	expectedLines := map[LogLevel]int{
+		LogLevelAll:   6,
+		LogLevelDebug: 6,
+		LogLevelInfo:  4,
+		LogLevelWarn:  2,
+		LogLevelError: 1,
+		LogLevelFatal: 0,
+	}
 	for level := LogLevelFatal; level >= LogLevelAll; level-- {
 		buf.Reset()
 		levelLogger := NewLevelLogger(bufLogger, level)
@@ -139,13 +142,8 @@ func TestLevelLogger(t *testing.T) {
 		levelLogger.Info("info")
 		levelLogger.Infof("inf%v", "o")
 		levelLogger.Warn("warn")
-		levelLogger.Warnf("war%v", "n")
 		levelLogger.Error("error")
-		levelLogger.Errorf("erro%v", "r")
 
-		assert.Equal(t, expectedLines, bytes.Count(buf.Bytes(), []byte{'\n'}))
-		if expectedLines < 8 {
-			expectedLines = expectedLines + 2
-		}
+		assert.Equal(t, expectedLines[level], bytes.Count(buf.Bytes(), []byte{'\n'}))
 	}
 }

--- a/outbound.go
+++ b/outbound.go
@@ -290,7 +290,7 @@ func (c *Connection) handleError(frame *Frame) bool {
 	if err := errMsg.read(rbuf); err != nil {
 		c.log.WithFields(
 			LogField{"remotePeer", c.remotePeerInfo},
-			LogField{"error", err.Error()},
+			ErrField(err),
 		).Warn("Unable to read error frame.")
 		c.connectionError("parsing error frame", err)
 		return true

--- a/outbound.go
+++ b/outbound.go
@@ -288,13 +288,19 @@ func (c *Connection) handleError(frame *Frame) bool {
 	}
 	rbuf := typed.NewReadBuffer(frame.SizedPayload())
 	if err := errMsg.read(rbuf); err != nil {
-		c.log.Warnf("Unable to read Error frame from %s: %v", c.remotePeerInfo, err)
+		c.log.WithFields(
+			LogField{"remotePeer", c.remotePeerInfo},
+			LogField{"error", err.Error()},
+		).Warn("Unable to read error frame.")
 		c.connectionError("parsing error frame", err)
 		return true
 	}
 
 	if errMsg.errCode == ErrCodeProtocol {
-		c.log.Warnf("Peer %s reported protocol error: %s", c.remotePeerInfo, errMsg.message)
+		c.log.WithFields(
+			LogField{"remotePeer", c.remotePeerInfo},
+			LogField{"error", errMsg.message},
+		).Warn("Peer reported protocol error.")
 		c.connectionError("received protocol error", errMsg.AsSystemError())
 		return true
 	}

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -42,7 +42,9 @@ func Register(registrar tchannel.Registrar) {
 	handler := func(ctx context.Context, call *tchannel.InboundCall) {
 		req, err := thttp.ReadRequest(call)
 		if err != nil {
-			registrar.Logger().Warnf("Failed to read HTTP request: %v", err)
+			registrar.Logger().WithFields(
+				tchannel.LogField{"err", err.Error()},
+			).Warn("Failed to read HTTP request.")
 			return
 		}
 

--- a/root_peer_list.go
+++ b/root_peer_list.go
@@ -92,7 +92,7 @@ func (l *RootPeerList) onConnChange(peer *Peer) {
 	hostPort := peer.HostPort()
 	p, ok := l.Get(hostPort)
 	if !ok {
-		l.channel.Logger().Errorf("got connection state change for a peer not in the root peer list")
+		l.channel.Logger().Error("got connection state change for a peer not in the root peer list")
 		return
 	}
 

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -81,7 +81,7 @@ type rawFuncHandler struct {
 func (h rawFuncHandler) OnError(ctx context.Context, err error) {
 	h.ch.Logger().WithFields(
 		tchannel.LogField{"context", ctx},
-		tchannel.LogField{"error", err.Error()},
+		tchannel.ErrField(err),
 	).Error("simpleHandler OnError.")
 }
 

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -79,7 +79,10 @@ type rawFuncHandler struct {
 }
 
 func (h rawFuncHandler) OnError(ctx context.Context, err error) {
-	h.ch.Logger().Errorf("simpleHandler OnError: %v %v", ctx, err)
+	h.ch.Logger().WithFields(
+		tchannel.LogField{"context", ctx},
+		tchannel.LogField{"error", err.Error()},
+	).Error("simpleHandler OnError.")
 }
 
 func (h rawFuncHandler) Handle(ctx context.Context, args *raw.Args) (*raw.Res, error) {

--- a/testutils/logger.go
+++ b/testutils/logger.go
@@ -66,17 +66,17 @@ func (l errorLogger) checkErr(msg string, args ...interface{}) {
 
 func (l errorLogger) Fatalf(msg string, args ...interface{}) {
 	l.checkErr("[Fatal] "+msg, args...)
-	l.Logger.Fatalf(msg, args...)
+	l.Logger.Fatal(fmt.Sprintf(msg, args...))
 }
 
 func (l errorLogger) Errorf(msg string, args ...interface{}) {
 	l.checkErr("[Error] "+msg, args...)
-	l.Logger.Errorf(msg, args...)
+	l.Logger.Error(fmt.Sprintf(msg, args...))
 }
 
 func (l errorLogger) Warnf(msg string, args ...interface{}) {
 	l.checkErr("[Warn] "+msg, args...)
-	l.Logger.Warnf(msg, args...)
+	l.Logger.Warn(fmt.Sprintf(msg, args...))
 }
 
 func (l errorLogger) WithFields(fields ...tchannel.LogField) tchannel.Logger {

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -90,7 +90,7 @@ func (s *Server) onError(err error) {
 	if tchannel.GetSystemErrorCode(err) == tchannel.ErrCodeTimeout {
 		s.log.Debugf("thrift Server timeout: %v", err)
 	} else {
-		s.log.Errorf("thrift Server error: %v", err)
+		s.log.WithFields(tchannel.LogField{"error", err.Error()}).Error("Thrift server error.")
 	}
 }
 

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -90,7 +90,7 @@ func (s *Server) onError(err error) {
 	if tchannel.GetSystemErrorCode(err) == tchannel.ErrCodeTimeout {
 		s.log.Debugf("thrift Server timeout: %v", err)
 	} else {
-		s.log.WithFields(tchannel.LogField{"error", err.Error()}).Error("Thrift server error.")
+		s.log.WithFields(tchannel.ErrField(err)).Error("Thrift server error.")
 	}
 }
 

--- a/trace/reporter.go
+++ b/trace/reporter.go
@@ -55,7 +55,9 @@ func NewTCollectorReporter(ch *tc.Channel) *TCollectorReporter {
 
 	curHostIP, err := tc.ListenIP()
 	if err != nil {
-		ch.Logger().Warnf("tcollector TraceReporter failed to get IP: %v", err)
+		ch.Logger().WithFields(
+			tc.LogField{"error", err.Error()},
+		).Warn("TCollector TraceReporter failed to get IP.")
 		curHostIP = net.IPv4(0, 0, 0, 0)
 	}
 

--- a/trace/reporter.go
+++ b/trace/reporter.go
@@ -55,9 +55,7 @@ func NewTCollectorReporter(ch *tc.Channel) *TCollectorReporter {
 
 	curHostIP, err := tc.ListenIP()
 	if err != nil {
-		ch.Logger().WithFields(
-			tc.LogField{"error", err.Error()},
-		).Warn("TCollector TraceReporter failed to get IP.")
+		ch.Logger().WithFields(tc.ErrField(err)).Warn("TCollector TraceReporter failed to get IP.")
 		curHostIP = net.IPv4(0, 0, 0, 0)
 	}
 


### PR DESCRIPTION
Resolves #76.

Migrates all Sentry-able logging to use fields and a constant message, and then removes `logger.Warnf`, `logger.Errorf`, and `logger.Panicf`.