### PR TITLE
Expose thrift.{Read,Write}Headers

### DIFF
--- a/testutils/testreader/chunk.go
+++ b/testutils/testreader/chunk.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testreader
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrUser is returned by ChunkReader when the user requests an error.
+var ErrUser = errors.New("error set by user")
+
+// ChunkReader returns a reader that returns chunks written to the control channel.
+// The caller should write byte chunks to return to the channel, or write nil if they
+// want the Reader to return an error. The control channel should be closed to signal EOF.
+func ChunkReader() (chan<- []byte, io.Reader) {
+	reader := &errorReader{
+		c: make(chan []byte, 100),
+	}
+	return reader.c, reader
+}
+
+type errorReader struct {
+	c         chan []byte
+	remaining []byte
+}
+
+func (r *errorReader) Read(bs []byte) (int, error) {
+	for len(r.remaining) == 0 {
+		var ok bool
+		r.remaining, ok = <-r.c
+		if !ok {
+			return 0, io.EOF
+		}
+		if r.remaining == nil {
+			return 0, ErrUser
+		}
+	}
+
+	n := copy(bs, r.remaining)
+	r.remaining = r.remaining[n:]
+	return n, nil
+}

--- a/testutils/testreader/chunk_test.go
+++ b/testutils/testreader/chunk_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testreader
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkReader(t *testing.T) {
+	writer, reader := ChunkReader()
+
+	writer <- []byte{1, 2}
+	writer <- []byte{3}
+	writer <- nil
+	writer <- []byte{4}
+	writer <- []byte{}
+	writer <- []byte{5}
+	writer <- []byte{}
+	writer <- []byte{6}
+	writer <- []byte{}
+	close(writer)
+
+	buf, err := ioutil.ReadAll(reader)
+	assert.Equal(t, ErrUser, err, "Expected error after initial bytes")
+	assert.Equal(t, []byte{1, 2, 3}, buf, "Unexpected bytes")
+
+	buf, err = ioutil.ReadAll(reader)
+	assert.NoError(t, err, "Reader shouldn't fail on second set of bytes")
+	assert.Equal(t, []byte{4, 5, 6}, buf, "Unexpected bytes")
+}

--- a/thrift/client.go
+++ b/thrift/client.go
@@ -65,7 +65,7 @@ func writeArgs(call *tchannel.OutboundCall, headers map[string]string, req thrif
 	if err != nil {
 		return err
 	}
-	if err := writeHeaders(writer, headers); err != nil {
+	if err := WriteHeaders(writer, headers); err != nil {
 		return err
 	}
 	if err := writer.Close(); err != nil {
@@ -94,7 +94,7 @@ func readResponse(response *tchannel.OutboundCallResponse, resp thrift.TStruct) 
 		return nil, false, err
 	}
 
-	headers, err := readHeaders(reader)
+	headers, err := ReadHeaders(reader)
 	if err != nil {
 		return nil, false, err
 	}

--- a/thrift/headers.go
+++ b/thrift/headers.go
@@ -23,7 +23,6 @@ package thrift
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/uber/tchannel-go/typed"
 )
@@ -56,7 +55,8 @@ func WriteHeaders(w io.Writer, headers map[string]string) error {
 
 	// Safety check to ensure the bytes written calculation is correct.
 	if writeBuffer.BytesWritten() != size {
-		return fmt.Errorf("writeHeaders size calculation wrong, expected to write %v bytes, only wrote %v bytes",
+		return fmt.Errorf(
+			"writeHeaders size calculation wrong, expected to write %v bytes, only wrote %v bytes",
 			size, writeBuffer.BytesWritten())
 	}
 
@@ -64,25 +64,27 @@ func WriteHeaders(w io.Writer, headers map[string]string) error {
 	return err
 }
 
-// ReadHeaders reads key-value pairs encoded using WriteHeaders.
-func ReadHeaders(r io.Reader) (map[string]string, error) {
-	// TODO(prashant): Allow typed.ReadBuffer to read directly from the reader.
-	bs, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-
-	buffer := typed.NewReadBuffer(bs)
-	numHeaders := buffer.ReadUint16()
+func readHeaders(reader *typed.Reader) (map[string]string, error) {
+	numHeaders := reader.ReadUint16()
 	if numHeaders == 0 {
-		return nil, buffer.Err()
+		return nil, reader.Err()
 	}
 
 	headers := make(map[string]string, numHeaders)
-	for i := 0; i < int(numHeaders) && buffer.Err() == nil; i++ {
-		k := buffer.ReadLen16String()
-		v := buffer.ReadLen16String()
+	for i := 0; i < int(numHeaders) && reader.Err() == nil; i++ {
+		k := reader.ReadLen16String()
+		v := reader.ReadLen16String()
 		headers[k] = v
 	}
-	return headers, buffer.Err()
+
+	return headers, reader.Err()
+}
+
+// ReadHeaders reads key-value pairs encoded using WriteHeaders.
+func ReadHeaders(r io.Reader) (map[string]string, error) {
+	reader := typed.NewReader(r)
+	m, err := readHeaders(reader)
+	reader.Release()
+
+	return m, err
 }

--- a/thrift/headers.go
+++ b/thrift/headers.go
@@ -28,8 +28,13 @@ import (
 	"github.com/uber/tchannel-go/typed"
 )
 
-// TODO(prashant): Use a small buffer and then flush it when it's full.
-func writeHeaders(w io.Writer, headers map[string]string) error {
+// WriteHeaders writes the given key-value pairs using the following encoding:
+// len~2 (k~4 v~4)~len
+func WriteHeaders(w io.Writer, headers map[string]string) error {
+	// TODO(prashant): Since we are not writing length-prefixed data here,
+	// we can write out to the buffer, and if it fills up, flush it.
+	// Right now, we calculate the size of the required buffer and write it out.
+
 	// Calculate the size of the buffer that we need.
 	size := 2
 	for k, v := range headers {
@@ -59,8 +64,9 @@ func writeHeaders(w io.Writer, headers map[string]string) error {
 	return err
 }
 
-// TODO(prashant): Allow typed.ReadBuffer to read directly from the reader.
-func readHeaders(r io.Reader) (map[string]string, error) {
+// ReadHeaders reads key-value pairs encoded using WriteHeaders.
+func ReadHeaders(r io.Reader) (map[string]string, error) {
+	// TODO(prashant): Allow typed.ReadBuffer to read directly from the reader.
 	bs, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err

--- a/thrift/headers_test.go
+++ b/thrift/headers_test.go
@@ -43,18 +43,19 @@ var headers = map[string]string{
 
 func BenchmarkWriteHeaders(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		writeHeaders(ioutil.Discard, headers)
+		WriteHeaders(ioutil.Discard, headers)
 	}
 }
 
 func BenchmarkReadHeaders(b *testing.B) {
 	buf := &bytes.Buffer{}
-	assert.NoError(b, writeHeaders(buf, headers))
+	assert.NoError(b, WriteHeaders(buf, headers))
 	bs := buf.Bytes()
+	reader := bytes.NewReader(bs)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		reader := bytes.NewReader(bs)
-		readHeaders(reader)
+		reader.Seek(0, 0)
+		ReadHeaders(reader)
 	}
 }

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -99,7 +99,7 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 	if err != nil {
 		return err
 	}
-	headers, err := readHeaders(reader)
+	headers, err := ReadHeaders(reader)
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 		return err
 	}
 
-	if err := writeHeaders(writer, ctx.ResponseHeaders()); err != nil {
+	if err := WriteHeaders(writer, ctx.ResponseHeaders()); err != nil {
 		return err
 	}
 	if err := writer.Close(); err != nil {

--- a/typed/reader.go
+++ b/typed/reader.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package typed
+
+import (
+	"encoding/binary"
+	"io"
+	"sync"
+)
+
+const maxPoolStringLen = 32
+
+// Reader is a reader that reads typed values from an io.Reader.
+type Reader struct {
+	reader io.Reader
+	err    error
+	buf    [maxPoolStringLen]byte
+}
+
+var readerPool = sync.Pool{
+	New: func() interface{} {
+		return &Reader{}
+	},
+}
+
+// NewReader returns a reader that reads typed values from the reader.
+func NewReader(reader io.Reader) *Reader {
+	r := readerPool.Get().(*Reader)
+	r.reader = reader
+	r.err = nil
+	return r
+}
+
+// ReadUint16 reads a uint16.
+func (r *Reader) ReadUint16() uint16 {
+	if r.err != nil {
+		return 0
+	}
+
+	buf := r.buf[:2]
+
+	var readN int
+	readN, r.err = io.ReadFull(r.reader, buf)
+	if readN < 2 {
+		return 0
+	}
+	return binary.BigEndian.Uint16(buf)
+}
+
+// ReadString reads a string of length n.
+func (r *Reader) ReadString(n int) string {
+	if r.err != nil {
+		return ""
+	}
+
+	var buf []byte
+	if n <= maxPoolStringLen {
+		buf = r.buf[:n]
+	} else {
+		buf = make([]byte, n)
+	}
+
+	var readN int
+	readN, r.err = io.ReadFull(r.reader, buf)
+	if readN < n {
+		return ""
+	}
+	s := string(buf)
+
+	return s
+}
+
+// ReadLen16String reads a uint16-length prefixed string.
+func (r *Reader) ReadLen16String() string {
+	len := r.ReadUint16()
+	return r.ReadString(int(len))
+}
+
+// Err returns any errors hit while reading from the underlying reader.
+func (r *Reader) Err() error {
+	return r.err
+}
+
+// Release puts the Reader back in the pool.
+func (r *Reader) Release() {
+	readerPool.Put(r)
+}

--- a/typed/reader_test.go
+++ b/typed/reader_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package typed
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/testutils/testreader"
+)
+
+func nString(n int) []byte {
+	buf := make([]byte, n)
+	reader := testreader.Looper([]byte{'a', 'b', 'c', 'd', 'e'})
+	io.ReadFull(reader, buf)
+	return buf
+}
+
+func TestReader(t *testing.T) {
+	s1 := nString(10)
+	s2 := nString(800)
+
+	var buf []byte
+	buf = append(buf, 0, 1)       // uint16, 1
+	buf = append(buf, 0xff, 0xff) // uint16, 65535
+	buf = append(buf, 0, 10)      // uint16, 10
+	buf = append(buf, s1...)      // string, 10 bytes
+	buf = append(buf, 3, 32)      // uint16, 800
+	buf = append(buf, s2...)      // string, 800 bytes
+	buf = append(buf, 0, 10)      // uint16, 10
+
+	reader := NewReader(bytes.NewReader(buf))
+
+	assert.Equal(t, uint16(1), reader.ReadUint16())
+	assert.Equal(t, uint16(65535), reader.ReadUint16())
+	assert.Equal(t, string(s1), reader.ReadLen16String())
+	assert.Equal(t, string(s2), reader.ReadLen16String())
+	assert.Equal(t, uint16(10), reader.ReadUint16())
+}
+
+func TestReaderErr(t *testing.T) {
+	tests := []struct {
+		chunks     [][]byte
+		validation func(reader *Reader)
+	}{
+		{
+			chunks: [][]byte{
+				[]byte{0, 1},
+				nil,
+				[]byte{2, 3},
+			},
+			validation: func(reader *Reader) {
+				assert.Equal(t, uint16(1), reader.ReadUint16(), "Read unexpected value")
+				assert.Equal(t, uint16(0), reader.ReadUint16(), "Expected default value")
+			},
+		},
+		{
+			chunks: [][]byte{
+				[]byte{0, 4},
+				[]byte("test"),
+				nil,
+				[]byte{'A', 'b'},
+			},
+			validation: func(reader *Reader) {
+				assert.Equal(t, "test", reader.ReadLen16String(), "Read unexpected value")
+				assert.Equal(t, "", reader.ReadString(2), "Expected default value")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		writer, chunkReader := testreader.ChunkReader()
+		reader := NewReader(chunkReader)
+		defer reader.Release()
+
+		for _, chunk := range tt.chunks {
+			writer <- chunk
+		}
+		close(writer)
+
+		tt.validation(reader)
+		// Once there's an error, all further calls should fail.
+		assert.Equal(t, testreader.ErrUser, reader.Err(), "Unexpected error")
+		assert.Equal(t, uint16(0), reader.ReadUint16(), "Expected default value")
+		assert.Equal(t, "", reader.ReadString(1), "Expected default value")
+		assert.Equal(t, "", reader.ReadLen16String(), "Expected default value")
+		assert.Equal(t, testreader.ErrUser, reader.Err(), "Unexpected error")
+	}
+}


### PR DESCRIPTION
Expose thrift header reading and writing functionality so callers can read/write Thrift encoded arguments without using the thrift.Client.

Since it's exposed, `thrift.ReadHeaders` has been rewritten to avoid consuming the whole `io.Reader`.

This is one of the changes required to allow streaming Thrift to be built as a separate library.

cc @jcorbin 