### PR TITLE
WIP: early share work towards experimental streaming support

### DIFF
--- a/examples/raw_stream/client/client.go
+++ b/examples/raw_stream/client/client.go
@@ -1,0 +1,370 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/jessevdk/go-flags"
+	tchannel "github.com/uber/tchannel-go"
+)
+
+var options = struct {
+	ServiceName string `short:"s" long:"service" default:"raw_keyvalue"`
+
+	HostPort string `long:"hostPort" required:"true" positional-arg-name:"hostPort"`
+}{}
+
+func parseArgs() {
+	var err error
+	if _, err = flags.Parse(&options); err != nil {
+		os.Exit(-1)
+	}
+
+	// Convert host port to a real host port.
+	host, port, err := net.SplitHostPort(options.HostPort)
+	if err != nil {
+		port = options.HostPort
+	}
+	if host == "" {
+		hostIP, err := tchannel.ListenIP()
+		if err != nil {
+			log.Printf("could not get ListenIP: %v, defaulting to 127.0.0.1", err)
+			host = "127.0.0.1"
+		} else {
+			host = hostIP.String()
+		}
+	}
+	options.HostPort = host + ":" + port
+}
+
+type keyValClient struct {
+	tchan       *tchannel.Channel
+	peer        string
+	serviceName string
+}
+
+func NewKeyValClient(serviceName string, peer string) (*keyValClient, error) {
+	// &tchannel.ChannelOptions{ Logger: tchannel.SimpleLogger, }
+	ch, err := tchannel.NewChannel(serviceName, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &keyValClient{
+		tchan:       ch,
+		peer:        peer,
+		serviceName: serviceName,
+	}
+	return client, nil
+}
+
+func (client *keyValClient) runRepl(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for {
+		fmt.Print("> ")
+		if !scanner.Scan() {
+			break
+		}
+
+		line := scanner.Text()
+		parts := strings.Split(line, " ")
+		cmd := strings.ToLower(strings.TrimSpace(parts[0]))
+		var cmdFunc func([]string) error
+		switch cmd {
+		case "get":
+			cmdFunc = client.replDoGet
+
+		case "set":
+			cmdFunc = client.replDoSet
+
+		case "multi_set":
+			cmdFunc = client.replDoMultiSet
+
+		case "watch":
+			cmdFunc = client.replDoWatch
+
+		case "":
+			continue
+
+		default:
+			fmt.Printf("ERROR: unsupported command %v\n", cmd)
+			continue
+		}
+
+		args := parts[1:]
+		if err := cmdFunc(args); err != nil {
+			fmt.Printf("ERROR: %v%#v failed: %v\n", cmd, args, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("scan failed: %v", err)
+	}
+}
+
+func (client *keyValClient) replDoSet(parts []string) error {
+	if len(parts) < 1 {
+		return fmt.Errorf("missing key argument to set")
+	}
+
+	// TODO: scan line value instead
+	if len(parts) < 2 {
+		return fmt.Errorf("missing value argument to set")
+	}
+
+	if len(parts) > 2 {
+		return client.replDoMultiSet(parts)
+	}
+
+	keyString := parts[0]
+	valString := parts[1]
+	fmt.Printf("setting %#v...", keyString)
+	err := client.SetKey(keyString, valString)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("done.\n")
+
+	return nil
+}
+
+func (client *keyValClient) replDoMultiSet(parts []string) error {
+	if len(parts) < 1 {
+		return fmt.Errorf("missing key argument to set")
+	}
+
+	keyString := parts[0]
+	valStrings := parts[1:]
+	fmt.Printf("multi setting %#v...", keyString)
+	err := client.MultiSetKey(keyString, valStrings)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("done.\n")
+
+	return nil
+}
+
+func (client *keyValClient) replDoGet(parts []string) error {
+	// TODO: bulk get and/or parallelize
+	for _, keyString := range parts {
+		fmt.Printf("getting %#v...", keyString)
+		valString, err := client.GetKey(keyString)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("got %#v.\n", valString)
+	}
+	return nil
+}
+
+func (client *keyValClient) replDoWatch(parts []string) error {
+	// TODO: create and register a replWatcher object so that they can be
+	// listed and canceled
+
+	for _, keyString := range parts {
+		fmt.Printf("watching %#v...", keyString)
+		updates, err := client.WatchKey(keyString)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("ok.\n")
+		go func(keyString string, updates <-chan string) {
+			for update := range updates {
+				fmt.Printf("WATCH[%#v] => %#v\n", keyString, update)
+			}
+		}(keyString, updates)
+	}
+
+	return nil
+}
+
+func (client *keyValClient) SetKey(keyString string, valString string) error {
+	ctx, cancelFunc := tchannel.NewContext(time.Second)
+	defer cancelFunc()
+
+	call, err := client.beginKeyValCall(ctx, "set", keyString, valString)
+	if err != nil {
+		return err
+	}
+
+	return tchannel.WithArg23(call.Response(), func(_, _ []byte) error {
+		// TODO: use response arg2/arg3?
+		return nil
+	})
+}
+
+func (client *keyValClient) MultiSetKey(keyString string, valStrings []string) error {
+	ctx, cancelFunc := tchannel.NewContext(time.Second)
+	defer cancelFunc()
+
+	valsString := strings.Join(valStrings, "\n")
+	call, err := client.beginKeyValCall(ctx, "multi_set", keyString, valsString)
+	if err != nil {
+		return err
+	}
+
+	return tchannel.WithArg23(call.Response(), func(_, _ []byte) error {
+		// TODO: use response arg2/arg3?
+		return nil
+	})
+}
+
+func (client *keyValClient) GetKey(keyString string) (string, error) {
+	ctx, cancelFunc := tchannel.NewContext(time.Second)
+	defer cancelFunc()
+
+	call, err := client.beginKeyValCall(ctx, "get", keyString, "")
+	if err != nil {
+		return "", err
+	}
+
+	var valString string
+	if err := tchannel.WithArg23(call.Response(), func(_, val []byte) error {
+		valString = string(val)
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return valString, nil
+}
+
+func (client *keyValClient) WatchKey(keyString string) (<-chan string, error) {
+	// TODO: rectify the streaming timeout scene:
+	// - set total stream timeout header for response stream...
+	// - lower context timeout, which should then apply only to the first frame
+	ctx, cancelFunc := tchannel.NewContext(time.Hour)
+
+	call, err := client.beginKeyValCall(ctx, "watch", keyString, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var updates chan string
+
+	if err := tchannel.WithArg2(call.Response(), func(_ []byte, arg3Reader tchannel.ArgReader) error {
+		updates = make(chan string, 2)
+
+		go func() {
+			defer cancelFunc() // XXX unclear if doing this right
+			defer func() {
+				close(updates)
+			}()
+
+			bufReader := bufio.NewReader(arg3Reader)
+
+			for {
+				valLengthString, err := bufReader.ReadString('\n')
+				if err != nil {
+					fmt.Printf("ERROR: watch(%#v) read error: %v\n", keyString, err)
+					return
+				}
+				valLengthString = valLengthString[:len(valLengthString)-1]
+
+				valLength, err := strconv.ParseUint(valLengthString, 10, 64)
+				if err != nil {
+					fmt.Printf("ERROR: watch(%#v) read error: %v\n", keyString, err)
+					return
+				}
+
+				valBytes := make([]byte, valLength)
+				if _, err := io.ReadFull(bufReader, valBytes); err != nil {
+					fmt.Printf("ERROR: watch(%#v) read error: %v\n", keyString, err)
+					return
+				}
+
+				valString := string(valBytes)
+				updates <- valString
+			}
+
+		}()
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return updates, nil
+}
+
+func (client *keyValClient) beginCall(ctx context.Context, methodName string) (*tchannel.OutboundCall, error) {
+	return client.tchan.BeginCall(ctx, client.peer, client.serviceName, methodName, nil)
+}
+
+func (client *keyValClient) beginKeyCall(ctx context.Context, methodName string, keyString string) (*tchannel.OutboundCall, error) {
+	call, err := client.beginCall(ctx, methodName)
+	if err != nil {
+		return nil, err
+	}
+	arg2Writer, err := call.Arg2Writer()
+	if err != nil {
+		return nil, err
+	}
+	key := []byte(keyString)
+	if _, err := arg2Writer.Write(key); err != nil {
+		return nil, err
+	}
+	if err := arg2Writer.Close(); err != nil {
+		return nil, err
+	}
+	return call, nil
+}
+
+func (client *keyValClient) beginKeyValCall(ctx context.Context, methodName string, keyString string, valString string) (*tchannel.OutboundCall, error) {
+	call, err := client.beginKeyCall(ctx, methodName, keyString)
+	if err != nil {
+		return nil, err
+	}
+	arg3Writer, err := call.Arg3Writer()
+	if err != nil {
+		return nil, err
+	}
+	if len(valString) > 0 {
+		val := []byte(valString)
+		if _, err := arg3Writer.Write(val); err != nil {
+			return nil, err
+		}
+	}
+	if err := arg3Writer.Close(); err != nil {
+		return nil, err
+	}
+	return call, nil
+}
+
+func main() {
+	parseArgs()
+
+	client, err := NewKeyValClient(options.ServiceName, options.HostPort)
+	if err != nil {
+		log.Fatalf("NewKeyValClient failed: %v", err)
+	}
+
+	client.runRepl(os.Stdin)
+}

--- a/examples/raw_stream/server/server.go
+++ b/examples/raw_stream/server/server.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/context"
+
+	tchannel "github.com/uber/tchannel-go"
+)
+
+type kvHandler struct {
+	sync.RWMutex
+
+	vals    map[string]string
+	watches map[string][]chan string
+}
+
+func (kvh *kvHandler) handleGet(ctx context.Context, call *tchannel.InboundCall) error {
+	return tchannel.WithArg23(call, func(key, _ []byte) error {
+		resp := call.Response()
+		if err := tchannel.NewArgWriter(resp.Arg2Writer()).Write(key); err != nil {
+			return err
+		}
+
+		keyString := string(key)
+		kvh.RLock()
+		valString := kvh.vals[keyString] // XXX exists
+		kvh.RUnlock()
+		val := []byte(valString)
+		fmt.Printf("GET(%#v) => %#v\n", keyString, valString)
+
+		if err := tchannel.NewArgWriter(resp.Arg3Writer()).Write(val); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (kvh *kvHandler) handleSet(ctx context.Context, call *tchannel.InboundCall) error {
+	return tchannel.WithArg23(call, func(key, val []byte) error {
+		resp := call.Response()
+		if err := tchannel.NewArgWriter(resp.Arg2Writer()).Write(key); err != nil {
+			return err
+		}
+
+		keyString := string(key)
+		valString := string(val)
+
+		kvh.Lock()
+		kvh.vals[keyString] = valString
+		watches, hasWatches := kvh.watches[keyString]
+		kvh.Unlock()
+		if hasWatches {
+			for _, watch := range watches {
+				watch <- valString
+			}
+		}
+		fmt.Printf("SET(%#v, %#v)\n", keyString, valString)
+
+		if err := tchannel.NewArgWriter(resp.Arg3Writer()).Write(val); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (kvh *kvHandler) handleMultiSet(ctx context.Context, call *tchannel.InboundCall) error {
+	return tchannel.WithArg23(call, func(key, val []byte) error {
+		resp := call.Response()
+		if err := tchannel.NewArgWriter(resp.Arg2Writer()).Write(key); err != nil {
+			return err
+		}
+
+		keyString := string(key)
+		valStrings := strings.Split(string(val), "\n")
+
+		for _, valString := range valStrings {
+			kvh.Lock()
+			kvh.vals[keyString] = valString
+			watches, hasWatches := kvh.watches[keyString]
+			kvh.Unlock()
+			if hasWatches {
+				for _, watch := range watches {
+					watch <- valString
+				}
+			}
+		}
+
+		fmt.Printf("MULTI_SET(%#v, %#v)\n", keyString, valStrings)
+
+		if err := tchannel.NewArgWriter(resp.Arg3Writer()).Write(val); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (kvh *kvHandler) handleWatch(ctx context.Context, call *tchannel.InboundCall) error {
+	return tchannel.WithArg23(call, func(key, _ []byte) error {
+		resp := call.Response()
+		if err := tchannel.NewArgWriter(resp.Arg2Writer()).Write(key); err != nil {
+			return err
+		}
+		arg3Writer, err := resp.Arg3Writer()
+		if err != nil {
+			return err
+		}
+
+		keyString := string(key)
+
+		kvh.Lock()
+		watch := make(chan string, 2)
+		watches := kvh.watches[keyString]
+		kvh.watches[keyString] = append(watches, watch)
+		valString, hasValue := kvh.vals[keyString] // XXX exists
+		kvh.Unlock()
+		fmt.Printf("WATCH(%#v)\n", keyString)
+
+		if hasValue {
+			fmt.Printf("WATCH(%#v): put current value %#v\n", keyString, valString)
+			watch <- valString
+		}
+
+		// TODO: set streaming response header (XXX should have that been set as a
+		// request header, and if not set then this endpoint should have returned a
+		// BadRequest or simply as much data as it currently had and then closed?)
+
+		// TODO: how handle connection close (ctx.Done() ?)
+
+		// TODO: worth it to spin out a tail goroutine (instead of just letting the
+		// handler goroutine be long-lived)?
+
+		sendVal := func(valString string) error {
+			val := []byte(valString)
+			fmt.Printf("WATCH(%#v): sending value %#v\n", keyString, valString)
+			_, err := fmt.Fprintf(arg3Writer, "%v\n%s", len(val), val)
+			return err
+		}
+
+		drain := func() error {
+			for {
+				select {
+				case valString, ok := <-watch:
+					if ok {
+						if err := sendVal(valString); err != nil {
+							return err
+						}
+						continue
+					}
+				default:
+				}
+				return arg3Writer.Flush()
+			}
+		}
+
+		// call drain once before we start the blocking loop so that we
+		// immediately flush a first response frame (with a maybe empty arg3 if
+		// the key is not yet set)
+		if err := drain(); err != nil {
+			return err
+		}
+
+		for valString := range watch {
+			if err := sendVal(valString); err != nil {
+				return err
+			}
+			if err := drain(); err != nil {
+				return err
+			}
+		}
+		if err := arg3Writer.Close(); err != nil {
+			return err
+		}
+
+		// TODO: remove watch from kvh.watches, maybe delet key
+
+		return nil
+	})
+}
+
+func main() {
+	ch, err := tchannel.NewChannel("raw_keyvalue", nil)
+	if err != nil {
+		log.Fatalf("Failed to create tchannel: %v", err)
+	}
+
+	kvh := &kvHandler{
+		vals:    make(map[string]string),
+		watches: make(map[string][]chan string),
+	}
+
+	ch.Register(tchannel.ErrorHandlerFunc(kvh.handleGet), "get")
+	ch.Register(tchannel.ErrorHandlerFunc(kvh.handleSet), "set")
+	ch.Register(tchannel.ErrorHandlerFunc(kvh.handleMultiSet), "multi_set")
+	ch.Register(tchannel.ErrorHandlerFunc(kvh.handleWatch), "watch")
+
+	ip, err := tchannel.ListenIP()
+	if err != nil {
+		log.Fatalf("Failed to find IP to Listen on: %v", err)
+	}
+	ch.ListenAndServe(fmt.Sprintf("%v:%v", ip, 4040))
+
+	log.Printf("test service has started on %v", ch.PeerInfo().HostPort)
+	select {}
+}

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -148,7 +148,7 @@ func (r *fragmentingReader) Read(b []byte) (int, error) {
 		r.curChunk = r.curChunk[n:]
 		b = b[n:]
 
-		if len(b) == 0 {
+		if len(b) == 0 || totalRead > 0 {
 			// There was enough data in the current chunk to
 			// satisfy the read.  Advance our place in the current
 			// chunk and be done

--- a/inbound.go
+++ b/inbound.go
@@ -297,6 +297,18 @@ func (call *InboundCall) Arg3Reader() (ArgReader, error) {
 	return call.arg3Reader()
 }
 
+// WithArg2 calls the provided function with all of arg2 as a byte buffer and
+// an arg3 reader.
+func (call *InboundCall) WithArg2(f func(arg2 []byte, arg3 io.ReadCloser) error) error {
+	return call.withArg2(f)
+}
+
+// WithArg23 calls the provided function with all of arg2 and arg3 as byte
+// buffers.
+func (call *InboundCall) WithArg23(f func(arg2, arg3 []byte) error) error {
+	return call.withArg23(f)
+}
+
 // Response provides access to the InboundCallResponse object which can be used
 // to write back to the calling peer
 func (call *InboundCall) Response() *InboundCallResponse {

--- a/inbound.go
+++ b/inbound.go
@@ -313,10 +313,11 @@ func (call *InboundCall) WithArg23(f func(arg2, arg3 []byte) error) error {
 // to write back to the calling peer
 func (call *InboundCall) Response() *InboundCallResponse {
 	if call.err != nil {
-		// While reading Thrift, we cannot distinguish between malformed Thrift and other errors,
-		// and so we may try to respond with a bad request. We should ensure that the response
-		// is marked as failed if the request has failed so that we don't try to shutdown the exchange
-		// a second time.
+		// While reading Thrift, we cannot distinguish between malformed Thrift
+		// and other errors, and so we may try to respond with a bad request.
+		// We should ensure that the response is marked as failed if the
+		// request has failed so that we don't try to shutdown the exchange a
+		// second time.
 		call.response.err = call.err
 	}
 	return call.response

--- a/outbound.go
+++ b/outbound.go
@@ -275,6 +275,27 @@ func (response *OutboundCallResponse) Arg3Reader() (ArgReader, error) {
 	return response.arg3Reader()
 }
 
+// WithArg2 calls the provided function with all of arg2 as a byte buffer and
+// an arg3 reader
+func (response *OutboundCallResponse) WithArg2(f func(arg2 []byte, arg3 io.ReadCloser) error) error {
+	var method []byte
+	if err := NewArgReader(response.arg1Reader()).Read(&method); err != nil {
+		return err
+	}
+
+	return response.withArg2(f)
+}
+
+// WithArg23 calls the provided function with all of arg2 and arg3 byte buffers.
+func (response *OutboundCallResponse) WithArg23(f func(arg2, arg3 []byte) error) error {
+	var method []byte
+	if err := NewArgReader(response.arg1Reader()).Read(&method); err != nil {
+		return err
+	}
+
+	return response.withArg23(f)
+}
+
 // handleError handles an error coming back from the peer. If the error is a
 // protocol level error, the entire connection will be closed.  If the error is
 // a request specific error, it will be written to the request's response


### PR DESCRIPTION
Much stil TODO:
- [ ] break out and regression test the partial read fix to fragmentingReader
- [ ] break out and finish the new ErrorHandlerFunc convenience
- [ ] refactor the `withArg2`/`withArg23` helpers added in client.go to be instead
      methods on `tchannel.OutboundCallResponse`
- [ ] refactor the `withArg2`/`withArg23` helpers added in server.go to be instead
      methods on `tchannel.InboundCall`
- [ ] implement response coalescing under the server watch handler
- [ ] implement error/cancellation support in the server watch handler
- [ ] implement finer grained streaming timeout support: the context timeout
  should apply to only the first frame of a stream, with a separate longer
  timeout for the lifetime of the entire streamed request and/or response
  expressed as a request header (and then maybe modified by the initial
  response frame?)

cc @prashantv @nomis52 