### PR TITLE
Expose thrift.{Read,Write}Struct 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Changelog
 
 # 1.0.1
 
-* Expose thrift.ReadHeaders and thrift.WriteHEaders
+* Expose thrift encoding functions
+  (ReadHeaders, WriteHeaders, ReadStruct, WriteStruct)
 
 # 1.0.0
 

--- a/testutils/testwriter/limited.go
+++ b/testutils/testwriter/limited.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testwriter
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrOutOfSpace is returned by Limited reader when it is out of bytes.
+var ErrOutOfSpace = errors.New("out of space")
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (n int, err error) {
+	return f(p)
+}
+
+// Limited returns an io.Writer that will only accept n bytes.
+// All further calls will cause an error.
+func Limited(n int) io.Writer {
+	return writerFunc(func(p []byte) (int, error) {
+		if n < len(p) {
+			retN := n
+			n = 0
+			return retN, ErrOutOfSpace
+		}
+
+		n -= len(p)
+		return len(p), nil
+	})
+}

--- a/testutils/testwriter/limited_test.go
+++ b/testutils/testwriter/limited_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testwriter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimitedWriter(t *testing.T) {
+	tests := []struct {
+		limit      int
+		writeBytes []byte
+		wantErr    error
+		wantBytes  int
+	}{
+		{
+			limit:      1,
+			writeBytes: []byte{1},
+			wantBytes:  1,
+		},
+		{
+			limit:      1,
+			writeBytes: []byte{1, 2},
+			wantErr:    ErrOutOfSpace,
+			wantBytes:  1,
+		},
+		{
+			limit:      0,
+			writeBytes: nil,
+			wantBytes:  0,
+		},
+		{
+			limit:      5,
+			writeBytes: []byte{1, 2, 3, 4, 5, 6},
+			wantErr:    ErrOutOfSpace,
+			wantBytes:  5,
+		},
+	}
+
+	for _, tt := range tests {
+		writer := Limited(tt.limit)
+		n, err := writer.Write(tt.writeBytes)
+		if tt.wantErr != nil {
+			assert.Equal(t, tt.wantErr, err, "Write %v to Limited(%v) should fail", tt.writeBytes, tt.limit)
+		} else {
+			assert.NoError(t, err, "Write %v to Limited(%v) should not fail", tt.writeBytes, tt.limit)
+		}
+		assert.Equal(t, tt.wantBytes, n, "Unexpected number of bytes written to Limited(%v)", tt.limit)
+
+		n, err = writer.Write([]byte{2})
+		assert.Equal(t, ErrOutOfSpace, err, "Write should be out of space")
+		assert.Equal(t, 0, n, "Write should not write any bytes when it is out of space")
+	}
+}
+
+func TestLimitedWriter2(t *testing.T) {
+	writer := Limited(1)
+	n, err := writer.Write([]byte{1, 2})
+	assert.Equal(t, ErrOutOfSpace, err, "Write should fail")
+	assert.Equal(t, 1, n, "Write should only write one byte")
+
+	n, err = writer.Write([]byte{2})
+	assert.Equal(t, ErrOutOfSpace, err, "Write should be out of space")
+	assert.Equal(t, 0, n, "Write should not write any bytes when it is out of space")
+}

--- a/thrift/client.go
+++ b/thrift/client.go
@@ -77,12 +77,10 @@ func writeArgs(call *tchannel.OutboundCall, headers map[string]string, req thrif
 		return err
 	}
 
-	wp := getProtocolWriter(writer)
-	if err := req.Write(wp.protocol); err != nil {
-		thriftProtocolPool.Put(wp)
+	if err := WriteStruct(writer, req); err != nil {
 		return err
 	}
-	thriftProtocolPool.Put(wp)
+
 	return writer.Close()
 }
 
@@ -109,12 +107,10 @@ func readResponse(response *tchannel.OutboundCallResponse, resp thrift.TStruct) 
 		return headers, success, err
 	}
 
-	wp := getProtocolReader(reader)
-	if err := resp.Read(wp.protocol); err != nil {
-		thriftProtocolPool.Put(wp)
+	if err := ReadStruct(reader, resp); err != nil {
 		return headers, success, err
 	}
-	thriftProtocolPool.Put(wp)
+
 	return headers, success, reader.Close()
 }
 

--- a/thrift/struct.go
+++ b/thrift/struct.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"io"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// WriteStruct writes the given Thrift struct to a writer. It pools TProtocols.
+func WriteStruct(writer io.Writer, s thrift.TStruct) error {
+	wp := getProtocolWriter(writer)
+	err := s.Write(wp.protocol)
+	thriftProtocolPool.Put(wp)
+	return err
+}
+
+// ReadStruct reads the given Thrift struct. It pools TProtocols.
+func ReadStruct(reader io.Reader, s thrift.TStruct) error {
+	wp := getProtocolReader(reader)
+	err := s.Read(wp.protocol)
+	thriftProtocolPool.Put(wp)
+	return err
+}

--- a/thrift/struct_test.go
+++ b/thrift/struct_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"sync"
+	"testing"
+
+	"github.com/uber/tchannel-go/testutils/testreader"
+	"github.com/uber/tchannel-go/testutils/testwriter"
+	. "github.com/uber/tchannel-go/thrift"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/thrift/gen-go/test"
+)
+
+var structTest = struct {
+	s       thrift.TStruct
+	encoded []byte
+}{
+	s: &test.Data{
+		B1: true,
+		S2: "S2",
+		I3: 3,
+	},
+	encoded: []byte{
+		0x2,      // bool
+		0x0, 0x1, // field 1
+		0x1,      // true
+		0xb,      // string
+		0x0, 0x2, // field 2
+		0x0, 0x0, 0x0, 0x2, // length of string "S2"
+		'S', '2', // string "S2"
+		0x8,      // i32
+		0x0, 0x3, // field 3
+		0x0, 0x0, 0x0, 0x3, // i32 3
+		0x0, // end of struct
+	},
+}
+
+func TestReadStruct(t *testing.T) {
+	appendBytes := func(bs []byte, append []byte) []byte {
+		b := make([]byte, len(bs)+len(append))
+		n := copy(b, bs)
+		copy(b[n:], append)
+		return b
+	}
+
+	tests := []struct {
+		s        thrift.TStruct
+		encoded  []byte
+		wantErr  bool
+		leftover []byte
+	}{
+		{
+			s:       structTest.s,
+			encoded: structTest.encoded,
+		},
+		{
+			s: &test.Data{
+				B1: true,
+				S2: "S2",
+			},
+			// Missing field 3.
+			encoded: structTest.encoded[:len(structTest.encoded)-8],
+			wantErr: true,
+		},
+		{
+			s:        structTest.s,
+			encoded:  appendBytes(structTest.encoded, []byte{1, 2, 3, 4}),
+			leftover: []byte{1, 2, 3, 4},
+		},
+	}
+
+	for _, tt := range tests {
+		reader := bytes.NewReader(tt.encoded)
+		var s thrift.TStruct = &test.Data{}
+		err := ReadStruct(reader, s)
+		assert.Equal(t, tt.wantErr, err != nil, "Unexpected error: %v", err)
+
+		// Even if there's an error, the struct will be partially filled.
+		assert.Equal(t, tt.s, s, "Unexpected struct")
+
+		leftover, err := ioutil.ReadAll(reader)
+		if assert.NoError(t, err, "Read leftover bytes failed") {
+			// ReadAll always returns a non-nil byte slice.
+			if tt.leftover == nil {
+				tt.leftover = make([]byte, 0)
+			}
+			assert.Equal(t, tt.leftover, leftover, "Leftover bytes mismatch")
+		}
+	}
+}
+
+func TestReadStructErr(t *testing.T) {
+	writer, reader := testreader.ChunkReader()
+	writer <- structTest.encoded[:10]
+	writer <- nil
+	close(writer)
+
+	s := &test.Data{}
+	err := ReadStruct(reader, s)
+	if assert.Error(t, err, "ReadStruct should fail") {
+		// Apache Thrift just prepends the error message, and doesn't give us access
+		// to the underlying error, so we can't check the underlying error exactly.
+		assert.Contains(t, err.Error(), testreader.ErrUser.Error(), "Underlying error missing")
+	}
+}
+
+func TestWriteStruct(t *testing.T) {
+	tests := []struct {
+		s       thrift.TStruct
+		encoded []byte
+		wantErr bool
+	}{
+		{
+			s:       structTest.s,
+			encoded: structTest.encoded,
+		},
+	}
+
+	for _, tt := range tests {
+		buf := &bytes.Buffer{}
+		err := WriteStruct(buf, tt.s)
+		assert.Equal(t, tt.wantErr, err != nil, "Unexpected err: %v", err)
+		if err != nil {
+			continue
+		}
+
+		assert.Equal(t, tt.encoded, buf.Bytes(), "Encoded data mismatch")
+	}
+}
+
+func TestWriteStructErr(t *testing.T) {
+	writer := testwriter.Limited(10)
+	err := WriteStruct(writer, structTest.s)
+	if assert.Error(t, err, "WriteStruct should fail") {
+		// Apache Thrift just prepends the error message, and doesn't give us access
+		// to the underlying error, so we can't check the underlying error exactly.
+		assert.Contains(t, err.Error(), testwriter.ErrOutOfSpace.Error(), "Underlying error missing")
+	}
+}
+
+func TestParallelReadWrites(t *testing.T) {
+	var wg sync.WaitGroup
+	testBG := func(f func(t *testing.T)) {
+		wg.Add(1)
+		go func() {
+			f(t)
+			wg.Done()
+		}()
+	}
+	for i := 0; i < 50; i++ {
+		testBG(TestReadStruct)
+		testBG(TestWriteStruct)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Expose thrift struct reading and writing so callers can read and write Thrift structs as encoded by TChannel without using thrift.Client.

Ånother required to allow streaming Thrift to be built as a separate library.

cc @jcorbin 