### PR TITLE
Cleanup and unify ArgReader and ArgWriter interfaces

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -31,6 +31,16 @@ import (
 // OutboundCallResponse and an InboundCall
 type ArgReader io.ReadCloser
 
+// ArgWriter is the interface for the arg2 and arg3 streams on an OutboundCall
+// and an InboundCallResponse
+type ArgWriter interface {
+	io.WriteCloser
+
+	// Flush flushes the currently written bytes without waiting for the frame
+	// to be filled.
+	Flush() error
+}
+
 // ArgReadHelper providers a simpler interface to reading arguments.
 type ArgReadHelper struct {
 	reader ArgReader

--- a/arguments.go
+++ b/arguments.go
@@ -27,15 +27,19 @@ import (
 	"io/ioutil"
 )
 
+// ArgReader is the interface for the arg2 and arg3 streams on an
+// OutboundCallResponse and an InboundCall
+type ArgReader io.ReadCloser
+
 // ArgReadHelper providers a simpler interface to reading arguments.
 type ArgReadHelper struct {
-	reader io.ReadCloser
+	reader ArgReader
 	err    error
 }
 
 // NewArgReader wraps the result of calling ArgXReader to provide a simpler
 // interface for reading arguments.
-func NewArgReader(reader io.ReadCloser, err error) ArgReadHelper {
+func NewArgReader(reader ArgReader, err error) ArgReadHelper {
 	return ArgReadHelper{reader, err}
 }
 

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -91,9 +91,9 @@ func newFragmentingReader(logger Logger, receiver fragmentReceiver) *fragmenting
 	}
 }
 
-// ArgReader returns an io.ReadCloser to read an argument. The ReadCloser will handle
-// fragmentation as needed. Once the argument has been read, the ReadCloser must be closed.
-func (r *fragmentingReader) ArgReader(last bool) (io.ReadCloser, error) {
+// The ArgReader will handle fragmentation as needed. Once the argument has
+// been read, the ArgReader must be closed.
+func (r *fragmentingReader) ArgReader(last bool) (ArgReader, error) {
 	if err := r.BeginArgument(last); err != nil {
 		return nil, err
 	}

--- a/fragmenting_writer.go
+++ b/fragmenting_writer.go
@@ -23,7 +23,6 @@ package tchannel
 import (
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/uber/tchannel-go/typed"
 )
@@ -38,14 +37,6 @@ const (
 	chunkHeaderSize      = 2    // each chunk is a uint16
 	hasMoreFragmentsFlag = 0x01 // flags indicating there are more fragments coming
 )
-
-// ArgWriter is the interface returned by ArgXWriter.
-type ArgWriter interface {
-	io.WriteCloser
-
-	// Flush flushes the currently written bytes without waiting for the frame to be filled.
-	Flush() error
-}
 
 // A writableFragment is a fragment that can be written to, containing a buffer
 // for contents, a running checksum, and placeholders for the fragment flags

--- a/http/args.go
+++ b/http/args.go
@@ -20,11 +20,8 @@
 
 package http
 
-import (
-	"io"
+import "github.com/uber/tchannel-go"
 
-	"github.com/uber/tchannel-go"
-)
 
 type argWriter interface {
 	Arg2Writer() (tchannel.ArgWriter, error)
@@ -32,6 +29,6 @@ type argWriter interface {
 }
 
 type argReader interface {
-	Arg2Reader() (io.ReadCloser, error)
-	Arg3Reader() (io.ReadCloser, error)
+	Arg2Reader() (tchannel.ArgReader, error)
+	Arg3Reader() (tchannel.ArgReader, error)
 }

--- a/inbound.go
+++ b/inbound.go
@@ -23,7 +23,6 @@ package tchannel
 import (
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"golang.org/x/net/context"
@@ -286,15 +285,15 @@ func (call *InboundCall) readMethod() error {
 	return nil
 }
 
-// Arg2Reader returns an io.ReadCloser to read the second argument.
+// Arg2Reader returns an ArgReader to read the second argument.
 // The ReadCloser must be closed once the argument has been read.
-func (call *InboundCall) Arg2Reader() (io.ReadCloser, error) {
+func (call *InboundCall) Arg2Reader() (ArgReader, error) {
 	return call.arg2Reader()
 }
 
-// Arg3Reader returns an io.ReadCloser to read the last argument.
+// Arg3Reader returns an ArgReader to read the last argument.
 // The ReadCloser must be closed once the argument has been read.
-func (call *InboundCall) Arg3Reader() (io.ReadCloser, error) {
+func (call *InboundCall) Arg3Reader() (ArgReader, error) {
 	return call.arg3Reader()
 }
 

--- a/outbound.go
+++ b/outbound.go
@@ -22,7 +22,6 @@ package tchannel
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/uber/tchannel-go/typed"
@@ -259,9 +258,9 @@ func (response *OutboundCallResponse) Format() Format {
 	return Format(response.callRes.Headers[ArgScheme])
 }
 
-// Arg2Reader returns an io.ReadCloser to read the second argument.
+// Arg2Reader returns an ArgReader to read the second argument.
 // The ReadCloser must be closed once the argument has been read.
-func (response *OutboundCallResponse) Arg2Reader() (io.ReadCloser, error) {
+func (response *OutboundCallResponse) Arg2Reader() (ArgReader, error) {
 	var method []byte
 	if err := NewArgReader(response.arg1Reader()).Read(&method); err != nil {
 		return nil, err
@@ -270,9 +269,9 @@ func (response *OutboundCallResponse) Arg2Reader() (io.ReadCloser, error) {
 	return response.arg2Reader()
 }
 
-// Arg3Reader returns an io.ReadCloser to read the last argument.
+// Arg3Reader returns an ArgReader to read the last argument.
 // The ReadCloser must be closed once the argument has been read.
-func (response *OutboundCallResponse) Arg3Reader() (io.ReadCloser, error) {
+func (response *OutboundCallResponse) Arg3Reader() (ArgReader, error) {
 	return response.arg3Reader()
 }
 

--- a/raw/call.go
+++ b/raw/call.go
@@ -22,7 +22,6 @@ package raw
 
 import (
 	"errors"
-	"io"
 
 	"github.com/uber/tchannel-go"
 	"golang.org/x/net/context"
@@ -33,8 +32,8 @@ var ErrAppError = errors.New("application error")
 
 // Readable is the interface for something that can be read.
 type Readable interface {
-	Arg2Reader() (io.ReadCloser, error)
-	Arg3Reader() (io.ReadCloser, error)
+	Arg2Reader() (tchannel.ArgReader, error)
+	Arg3Reader() (tchannel.ArgReader, error)
 }
 
 // ReadArgsV2 reads arg2 and arg3 from a reader.
@@ -102,7 +101,7 @@ func CallSC(ctx context.Context, sc *tchannel.SubChannel, method string, arg2, a
 
 // CArgs are the call arguments passed to CallV2.
 type CArgs struct {
-	Method   string
+	Method      string
 	Arg2        []byte
 	Arg3        []byte
 	CallOptions *tchannel.CallOptions

--- a/reqres.go
+++ b/reqres.go
@@ -22,7 +22,6 @@ package tchannel
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/uber/tchannel-go/typed"
 )
@@ -189,24 +188,24 @@ type reqResReader struct {
 	err                error
 }
 
-// arg1Reader returns an io.ReadCloser to read arg1.
-func (r *reqResReader) arg1Reader() (io.ReadCloser, error) {
+// arg1Reader returns an ArgReader to read arg1.
+func (r *reqResReader) arg1Reader() (ArgReader, error) {
 	return r.argReader(false /* last */, reqResReaderPreArg1, reqResReaderPreArg2)
 }
 
-// arg2Reader returns an io.ReadCloser to read arg2.
-func (r *reqResReader) arg2Reader() (io.ReadCloser, error) {
+// arg2Reader returns an ArgReader to read arg2.
+func (r *reqResReader) arg2Reader() (ArgReader, error) {
 	return r.argReader(false /* last */, reqResReaderPreArg2, reqResReaderPreArg3)
 }
 
-// arg3Reader returns an io.ReadCloser to read arg3.
-func (r *reqResReader) arg3Reader() (io.ReadCloser, error) {
+// arg3Reader returns an ArgReader to read arg3.
+func (r *reqResReader) arg3Reader() (ArgReader, error) {
 	return r.argReader(true /* last */, reqResReaderPreArg3, reqResReaderComplete)
 }
 
-// argReader returns an io.ReadCloser that can be used to read an argument. The ReadCloser
-// must be closed once the argument has been read.
-func (r *reqResReader) argReader(last bool, inState reqResReaderState, outState reqResReaderState) (io.ReadCloser, error) {
+// argReader returns an ArgReader that can be used to read an argument. The
+// ReadCloser must be closed once the argument has been read.
+func (r *reqResReader) argReader(last bool, inState reqResReaderState, outState reqResReaderState) (ArgReader, error) {
 	if r.state != inState {
 		return nil, r.failed(errReqResReaderStateMismatch{state: r.state, expectedState: inState})
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -137,7 +137,7 @@ func streamPartialHandler(t *testing.T) HandlerFunc {
 	}
 }
 
-func testStreamArg(t *testing.T, f func(argWriter ArgWriter, argReader io.ReadCloser)) {
+func testStreamArg(t *testing.T, f func(argWriter ArgWriter, argReader ArgReader)) {
 	defer testutils.SetTimeout(t, 2*time.Second)()
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
@@ -187,7 +187,7 @@ func testStreamArg(t *testing.T, f func(argWriter ArgWriter, argReader io.ReadCl
 }
 
 func TestStreamPartialArg(t *testing.T) {
-	testStreamArg(t, func(argWriter ArgWriter, argReader io.ReadCloser) {
+	testStreamArg(t, func(argWriter ArgWriter, argReader ArgReader) {
 		require.NoError(t, argWriter.Close(), "arg3 close failed")
 
 		// Once closed, we expect the reader to return EOF
@@ -199,7 +199,7 @@ func TestStreamPartialArg(t *testing.T) {
 }
 
 func TestStreamSendError(t *testing.T) {
-	testStreamArg(t, func(argWriter ArgWriter, argReader io.ReadCloser) {
+	testStreamArg(t, func(argWriter ArgWriter, argReader ArgReader) {
 		// Send the magic number to request an error.
 		_, err := argWriter.Write([]byte{streamRequestError})
 		require.NoError(t, err, "arg3 write failed")


### PR DESCRIPTION
- use ArgReader instead of io.ReadCloser
- define both in the arguments.go file

r @prashantv