### PR TITLE
Add changelog helper script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 Changelog
 =========
 
-# 1.0.1
-
-* Expose thrift encoding functions
-  (ReadHeaders, WriteHeaders, ReadStruct, WriteStruct)
-
 # 1.0.0
 
 * First stable release.

--- a/scripts/changelog_halp.sh
+++ b/scripts/changelog_halp.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+LAST=$(grep '^# [0-9]' CHANGELOG.md | head -n1 | cut -d' ' -f2)
+
+{
+    echo Changelog
+    echo =========
+    echo
+
+    echo '# <INSERT NEXT VERSION HERE>'
+    echo
+    echo "Merged pull requests since ${LAST}:"
+    echo
+
+    # -e '/Merge pull request/d' \
+
+    git log --first-parent "v${LAST}.." | grep -A4 '^Date:' | sed \
+        -e '/^ *$/d' \
+        -e '/^Date:/d' \
+        -e '/^commit /d' \
+        -e '/^--/d' \
+        -e '/Merge pull request/d' \
+        -e '/^    / s/^    /* /'
+
+    # TODO: augmenting with PR links should be straight forward, and useful to
+    # the reviewer
+    #     -e '/Merge pull request/ { s~^.*#\([0-9][0-9]*\).*$~https://github.com/uber/tchannel-go/pull/\1~; h; d; }' \
+    #     -e '/^    / { s/^    /* /; G; }'
+
+    echo
+    echo '# -- NEW ABOVE, OLD BELOW --'
+    echo
+
+    tail -n+4 CHANGELOG.md
+} > CHANGELOG.md.new
+mv -vf CHANGELOG.md.new CHANGELOG.md


### PR DESCRIPTION
- rolled back prior post 1.0.0 `CHANGELOG.md` changes since this script will
  capture them at release time
- added a script adapted from https://github.com/uber/tchannel-node/blob/master/scripts/changelog_halp.sh


Here's an example of its use on current master:

```bash
$ ./scripts/changelog_halp.sh
CHANGELOG.md.new -> CHANGELOG.md

$ git diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index f853d78..e9e79a1 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Changelog
 =========

+# <INSERT NEXT VERSION HERE>
+
+Merged pull requests since 1.0.0:
+
+* Unify ArgReadable and ArgWritable interfaces out of the raw and http sub-packages
+* Fix a few go lint exceptions
+* Cleanup and unify ArgReader and ArgWriter interfaces
+* Expose thrift.{Read,Write}Struct
+* Update changelog and version
+* Expose thrift.{Read,Write}Headers
+
+# -- NEW ABOVE, OLD BELOW --
+
 # 1.0.0

 * First stable release.
```

I almost got PR url augmentation working, but my sed-fu was not strong enough
to get things nicely on one line, so I left it commented out ;-)

r @prashantv @akshayjshah 