### PR TITLE
Add ErrorHandlerFunc

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -279,7 +279,12 @@ func TestNoTimeout(t *testing.T) {
 
 func TestServerBusy(t *testing.T) {
 	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
-		ch.Register(raw.Wrap(newTestHandler(t)), "busy")
+		ch.Register(ErrorHandlerFunc(func(ctx context.Context, call *InboundCall) error {
+			if _, err := raw.ReadArgs(call); err != nil {
+				return err
+			}
+			return ErrServerBusy
+		}), "busy")
 
 		ctx, cancel := NewContext(time.Second)
 		defer cancel()

--- a/handlers.go
+++ b/handlers.go
@@ -33,9 +33,9 @@ type Handler interface {
 	Handle(ctx context.Context, call *InboundCall)
 }
 
-// A HandlerFunc is an adapter to allow the use of ordering functions as
-// Channel handlers.  If f is a function with the appropriate signature,
-// HandlerFunc(f) is a Hander object that calls f
+// A HandlerFunc is an adapter to allow the use of ordinary functions as
+// Channel handlers.  If f is a function with the appropriate signature, then
+// HandlerFunc(f) is a Handler object that calls f.
 type HandlerFunc func(ctx context.Context, call *InboundCall)
 
 // Handle calls f(ctx, call)


### PR DESCRIPTION
A simple corollary of HandlerFunc which allows the wrapped function to return
an error and handles returning a minimal error response.  

r @prashantv @akshayjshah 