### PR TITLE
Shuffle peer ordering when adding new peers

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -97,7 +97,7 @@ func (l *PeerList) Add(hostPort string) *Peer {
 	ps := newPeerScore(p, l.scoreCalculator.GetScore(p))
 
 	l.peersByHostPort[hostPort] = ps
-	l.peerHeap.PushPeer(ps)
+	l.peerHeap.addPeer(ps)
 	return p
 }
 

--- a/peer_heap.go
+++ b/peer_heap.go
@@ -95,6 +95,25 @@ func (ph *PeerHeap) PushPeer(peerScore *peerScore) {
 	heap.Push(ph, peerScore)
 }
 
+func (ph *PeerHeap) swapOrder(i, j int) {
+	if i == j {
+		return
+	}
+
+	ph.PeerScores[i].order, ph.PeerScores[j].order = ph.PeerScores[j].order, ph.PeerScores[i].order
+	heap.Fix(ph, i)
+	heap.Fix(ph, j)
+}
+
+// AddPeer adds a peer to the peer heap.
+func (ph *PeerHeap) addPeer(peerScore *peerScore) {
+	ph.PushPeer(peerScore)
+
+	// Pick a random element, and swap the order with that peerScore.
+	r := ph.rng.Intn(ph.Len())
+	ph.swapOrder(peerScore.index, r)
+}
+
 // Exposed for testing purposes.
 func (ph *PeerHeap) peek() *peerScore {
 	return ph.PeerScores[0]


### PR DESCRIPTION
This avoids any bias on the first few requests preferring the earlier peers.

Fixes #181

@akshayjshah @junchaowu 