### PR TITLE
Unexport internal peer constructs like the peer heap

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -501,7 +501,7 @@ func (ch *Channel) exchangeUpdated(c *Connection) {
 
 // updatePeer updates the score of the peer and update it's position in heap as well.
 func (ch *Channel) updatePeer(p *Peer) {
-	ch.peers.UpdatePeer(p)
+	ch.peers.updatePeer(p)
 	ch.subChannels.updatePeer(p)
 	p.callOnUpdateComplete()
 }

--- a/introspection.go
+++ b/introspection.go
@@ -265,7 +265,7 @@ func (ch *Channel) handleIntrospection(arg3 []byte) interface{} {
 func (l *PeerList) IntrospectList(opts *IntrospectionOptions) []SubPeerScore {
 	var peers []SubPeerScore
 	l.RLock()
-	for _, ps := range l.peerHeap.PeerScores {
+	for _, ps := range l.peerHeap.peerScores {
 		peers = append(peers, SubPeerScore{
 			HostPort: ps.Peer.hostPort,
 			Score:    ps.score,

--- a/peer.go
+++ b/peer.go
@@ -54,7 +54,7 @@ type PeerList struct {
 
 	parent          *RootPeerList
 	peersByHostPort map[string]*peerScore
-	peerHeap        *PeerHeap
+	peerHeap        *peerHeap
 	scoreCalculator ScoreCalculator
 	lastSelected    uint64
 }
@@ -125,7 +125,7 @@ func (l *PeerList) choosePeer(prevSelected map[string]struct{}) *Peer {
 
 	size := l.peerHeap.Len()
 	for i := 0; i < size; i++ {
-		ps = l.peerHeap.PopPeer()
+		ps = l.peerHeap.popPeer()
 		if _, ok := prevSelected[ps.Peer.HostPort()]; !ok {
 			break
 		}
@@ -140,7 +140,7 @@ func (l *PeerList) choosePeer(prevSelected map[string]struct{}) *Peer {
 		return nil
 	}
 
-	l.peerHeap.PushPeer(ps)
+	l.peerHeap.pushPeer(ps)
 	atomic.AddUint64(&ps.chosenCount, 1)
 	return ps.Peer
 }
@@ -179,9 +179,9 @@ func (l *PeerList) exists(hostPort string) (*peerScore, uint64, bool) {
 	return ps, score, ok
 }
 
-// UpdatePeer is called when there is a change that may cause the peer's score to change.
+// updatePeer is called when there is a change that may cause the peer's score to change.
 // The new score is calculated, and the peer heap is updated with the new score if the score changes.
-func (l *PeerList) UpdatePeer(p *Peer) {
+func (l *PeerList) updatePeer(p *Peer) {
 	ps, psScore, ok := l.exists(p.hostPort)
 	if !ok {
 		return
@@ -194,7 +194,7 @@ func (l *PeerList) UpdatePeer(p *Peer) {
 
 	l.Lock()
 	ps.score = newScore
-	l.peerHeap.UpdatePeer(ps)
+	l.peerHeap.updatePeer(ps)
 	l.Unlock()
 }
 

--- a/peer_heap_test.go
+++ b/peer_heap_test.go
@@ -38,24 +38,24 @@ func TestPeerHeap(t *testing.T) {
 	peerScores := make([]*peerScore, numPeers)
 	minScore := uint64(math.MaxInt64)
 	for i := 0; i < numPeers; i++ {
-		peerScore := newPeerScore(&Peer{}, uint64(r.Intn(numPeers*5)))
-		peerScores[i] = peerScore
-		if peerScore.score < minScore {
-			minScore = peerScore.score
+		ps := newPeerScore(&Peer{}, uint64(r.Intn(numPeers*5)))
+		peerScores[i] = ps
+		if ps.score < minScore {
+			minScore = ps.score
 		}
 	}
 
 	for i := 0; i < numPeers; i++ {
-		peerHeap.PushPeer(peerScores[i])
+		peerHeap.pushPeer(peerScores[i])
 	}
 
 	assert.Equal(t, numPeers, peerHeap.Len(), "Incorrect peer heap numPeers")
-	assert.Equal(t, minScore, peerHeap.peek().score, "PeerHeap top peer is not minimum")
+	assert.Equal(t, minScore, peerHeap.peek().score, "peerHeap top peer is not minimum")
 
-	lastScore := peerHeap.PopPeer().score
+	lastScore := peerHeap.popPeer().score
 	for i := 1; i < numPeers; i++ {
 		assert.Equal(t, numPeers-i, peerHeap.Len(), "Incorrect peer heap numPeers")
-		score := peerHeap.PopPeer().score
+		score := peerHeap.popPeer().score
 		assert.True(t, score >= lastScore, "The order of the heap is invalid")
 		lastScore = score
 	}

--- a/subchannel.go
+++ b/subchannel.go
@@ -172,7 +172,7 @@ func (subChMap *subChannelMap) updatePeer(p *Peer) {
 	for _, subCh := range subChMap.subchannels {
 		if subCh.Isolated() {
 			subCh.RLock()
-			subCh.Peers().UpdatePeer(p)
+			subCh.Peers().updatePeer(p)
 			subCh.RUnlock()
 		}
 	}

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -62,7 +62,3 @@ func InboundConnection(call IncomingCall) (*Connection, net.Conn) {
 func NewSpan(traceID uint64, parentID uint64, spanID uint64) Span {
 	return Span{traceID: traceID, parentID: parentID, spanID: spanID, flags: defaultTracingFlags}
 }
-
-func (l *PeerList) GetHeap() *PeerHeap {
-	return l.peerHeap
-}


### PR DESCRIPTION
The peer heap is not part of the public interface, and shouldn't be exported. Fixes peer lint issues in #176

cc: @junchaowu 