### PR TITLE
Refactor raw args read helpers

### DIFF
--- a/raw/call.go
+++ b/raw/call.go
@@ -30,7 +30,7 @@ import (
 // ErrAppError is returned if the application sets an error response.
 var ErrAppError = errors.New("application error")
 
-// ReadArgsV2 reads arg2 and arg3 from a reader.
+// ReadArgsV2 reads arg2 and arg3 from an ArgReadable.
 func ReadArgsV2(r tchannel.ArgReadable) ([]byte, []byte, error) {
 	var arg2, arg3 []byte
 

--- a/raw/call.go
+++ b/raw/call.go
@@ -31,8 +31,9 @@ import (
 // ErrAppError is returned if the application sets an error response.
 var ErrAppError = errors.New("application error")
 
-// ReadArgsV2 reads arg2 and arg3 from an ArgReadable.
-func ReadArgsV2(r tchannel.ArgReadable) ([]byte, []byte, error) {
+// ReadJustArg2 reads all of arg2 into a byte buffer, and returns the arg3
+// reader (as a convenience so that caller can decide how to read it).
+func ReadJustArg2(r tchannel.ArgReadable) ([]byte, tchannel.ArgReader, error) {
 	arg2Reader, err := r.Arg2Reader()
 	if err != nil {
 		return nil, nil, err
@@ -48,6 +49,16 @@ func ReadArgsV2(r tchannel.ArgReadable) ([]byte, []byte, error) {
 	}
 
 	arg3Reader, err := r.Arg3Reader()
+	if err != nil {
+		return arg2, nil, err
+	}
+
+	return arg2, arg3Reader, nil
+}
+
+// ReadArgsV2 reads arg2 and arg3 from an ArgReadable.
+func ReadArgsV2(r tchannel.ArgReadable) ([]byte, []byte, error) {
+	arg2, arg3Reader, err := ReadJustArg2(r)
 	if err != nil {
 		return arg2, nil, err
 	}

--- a/raw/call.go
+++ b/raw/call.go
@@ -22,6 +22,7 @@ package raw
 
 import (
 	"errors"
+	"io/ioutil"
 
 	"github.com/uber/tchannel-go"
 	"golang.org/x/net/context"
@@ -32,13 +33,31 @@ var ErrAppError = errors.New("application error")
 
 // ReadArgsV2 reads arg2 and arg3 from an ArgReadable.
 func ReadArgsV2(r tchannel.ArgReadable) ([]byte, []byte, error) {
-	var arg2, arg3 []byte
-
-	if err := tchannel.NewArgReader(r.Arg2Reader()).Read(&arg2); err != nil {
+	arg2Reader, err := r.Arg2Reader()
+	if err != nil {
 		return nil, nil, err
 	}
 
-	if err := tchannel.NewArgReader(r.Arg3Reader()).Read(&arg3); err != nil {
+	arg2, err := ioutil.ReadAll(arg2Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := arg2Reader.Close(); err != nil {
+		return nil, nil, err
+	}
+
+	arg3Reader, err := r.Arg3Reader()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	arg3, err := ioutil.ReadAll(arg3Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := arg3Reader.Close(); err != nil {
 		return nil, nil, err
 	}
 

--- a/raw/call.go
+++ b/raw/call.go
@@ -40,25 +40,25 @@ func ReadArgsV2(r tchannel.ArgReadable) ([]byte, []byte, error) {
 
 	arg2, err := ioutil.ReadAll(arg2Reader)
 	if err != nil {
-		return nil, nil, err
+		return arg2, nil, err
 	}
 
 	if err := arg2Reader.Close(); err != nil {
-		return nil, nil, err
+		return arg2, nil, err
 	}
 
 	arg3Reader, err := r.Arg3Reader()
 	if err != nil {
-		return nil, nil, err
+		return arg2, nil, err
 	}
 
 	arg3, err := ioutil.ReadAll(arg3Reader)
 	if err != nil {
-		return nil, nil, err
+		return arg2, arg3, err
 	}
 
 	if err := arg3Reader.Close(); err != nil {
-		return nil, nil, err
+		return arg2, arg3, err
 	}
 
 	return arg2, arg3, nil

--- a/raw/call.go
+++ b/raw/call.go
@@ -56,17 +56,8 @@ func WriteArgs(call *tchannel.OutboundCall, arg2, arg3 []byte) ([]byte, []byte, 
 	}
 
 	resp := call.Response()
-	var respArg2 []byte
-	if err := tchannel.NewArgReader(resp.Arg2Reader()).Read(&respArg2); err != nil {
-		return nil, nil, nil, err
-	}
-
-	var respArg3 []byte
-	if err := tchannel.NewArgReader(resp.Arg3Reader()).Read(&respArg3); err != nil {
-		return nil, nil, nil, err
-	}
-
-	return respArg2, respArg3, resp, nil
+	respArg2, respArg3, err := ReadArgsV2(resp)
+	return respArg2, respArg3, resp, err
 }
 
 // Call makes a call to the given hostPort with the given arguments and returns the response args.


### PR DESCRIPTION
- refactored `ReadArgsV2` to not use the arg reader helpers
- modified to return any partially read buffer(s) throughout
- factored out half of `ReadArgsV2` into a new helper that could be used to stream arg3 (or otherwise scan, or progressively read arg3 like the thrift and json modules do)

r @prashantv 