### PR TITLE
Set timeout when using net.Dial

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -444,6 +444,15 @@ func (ch *Channel) ServiceName() string {
 	return ch.PeerInfo().ServiceName
 }
 
+func getTimeout(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return DefaultConnectTimeout
+	}
+
+	return deadline.Sub(time.Now())
+}
+
 // Connect connects the channel.
 func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, error) {
 	switch state := ch.State(); state {
@@ -461,7 +470,8 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, e
 		OnCloseStateChange: ch.connectionCloseStateChange,
 		OnExchangeUpdated:  ch.exchangeUpdated,
 	}
-	c, err := ch.newOutboundConnection(hostPort, events)
+
+	c, err := ch.newOutboundConnection(getTimeout(ctx), hostPort, events)
 	if err != nil {
 		return nil, err
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -524,3 +524,18 @@ func TestGracefulClose(t *testing.T) {
 		})
 	})
 }
+
+func TestNetDialTimeout(t *testing.T) {
+	// timeoutHostPort uses a blackholed address (RFC 6890) with a port
+	// reserved for documentation. This address should always cause a timeout.
+	const timeoutHostPort = "192.18.0.254:44444"
+
+	client := testutils.NewClient(t, nil)
+	defer client.Close()
+
+	ctx, cancel := NewContext(50 * time.Millisecond)
+	defer cancel()
+
+	err := client.Ping(ctx, timeoutHostPort)
+	assert.Equal(t, ErrTimeout, err, "Ping expected to fail with timeout")
+}


### PR DESCRIPTION
If an outbound call required a new connection, the timeout was ignored
when the connection is made (e.g. in net.Dial).

Use net.DialTimeout and set a default timeout to avoid hanging.

Fixes #194 