### PR TITLE
Make TestPeerSelectionRanking deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ get_thrift:
 
 install:
 	GOPATH=$(GODEPS) go get github.com/tools/godep
-	GOPATH=$(GODEPS) godep restore
+	GOPATH=$(GODEPS) godep restore -v
 
 install_ci: get_thrift install
 	go get -u github.com/mattn/goveralls

--- a/peer_test.go
+++ b/peer_test.go
@@ -484,6 +484,8 @@ func TestPeerSelectionRanking(t *testing.T) {
 
 	for i := 0; i < numIterations; i++ {
 		ch := testutils.NewClient(t, nil)
+		ch.SetRandomSeed(int64(i * 100))
+
 		for i := 0; i < numPeers; i++ {
 			hp := fmt.Sprintf("127.0.0.1:60%v", i)
 			ch.Peers().Add(hp)
@@ -497,7 +499,7 @@ func TestPeerSelectionRanking(t *testing.T) {
 	}
 
 	for _, m := range selected {
-		testDistribution(t, m, 50, 180)
+		testDistribution(t, m, 50, 150)
 	}
 }
 
@@ -523,7 +525,7 @@ func createSubChannelWNewStrategy(ch *Channel, name string, initial, delta int64
 func testDistribution(t testing.TB, counts map[string]int, min, max float64) {
 	for k, v := range counts {
 		if float64(v) < min || float64(v) > max {
-			t.Errorf("Key %v has value %v which is out of range %v%v", k, v, min, max)
+			t.Errorf("Key %v has value %v which is out of range %v-%v", k, v, min, max)
 		}
 	}
 }

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -41,6 +41,16 @@ func (p *Peer) SetOnUpdate(f func(*Peer)) {
 	p.Unlock()
 }
 
+// SetRandomSeed seeds all the random number generators in the channel so that
+// tests will be deterministic for a given seed.
+func (ch *Channel) SetRandomSeed(seed int64) {
+	ch.Peers().peerHeap.rng.Seed(seed)
+	peerRng.Seed(seed)
+	for _, sc := range ch.subChannels.subchannels {
+		sc.peers.peerHeap.rng.Seed(seed + int64(len(sc.peers.peersByHostPort)))
+	}
+}
+
 // OutboundConnection returns the underlying connection for an outbound call.
 func OutboundConnection(call *OutboundCall) (*Connection, net.Conn) {
 	conn := call.conn


### PR DESCRIPTION
Seed the random number generators so that the test is deterministic
but still verifies that peer selection ranking is not biased.