### PR TITLE
Improve Hyperbahn client logging

### DIFF
--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -124,6 +124,9 @@ func (c *Client) initialAdvertise() error {
 			break
 		}
 
+		c.tchan.Logger().WithFields(tchannel.ErrField(err)).Info(
+			"Hyperbahn client initial registration failure, will retry")
+
 		// Back off for a while.
 		sleepFor := fuzzInterval(advertiseRetryInterval * time.Duration(1<<attempt))
 		timeSleep(sleepFor)


### PR DESCRIPTION
Don't log warnings as soon as an advertise fails, only log warnings if we've failed more than 5 times.