### PR TITLE
Fix golint in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: make install_ci
 script:
  - make test_ci
  - make cover_ci
- # Travis restores Godeps to the workspace, which we want to ignore.
- - rm -rf Godeps/_workspace
+ # Travis restores Godeps to the workspace, which we want to ignore from lint.
+ - rm -rf Godeps/_workspace/src
  - make lint
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ get_thrift:
 
 install:
 	GOPATH=$(GODEPS) go get github.com/tools/godep
-	GOPATH=$(GODEPS) go get github.com/golang/lint
+	GOPATH=$(GODEPS) go get github.com/golang/lint/golint
 	GOPATH=$(GODEPS) godep restore -v
 
 install_ci: get_thrift install

--- a/context_builder.go
+++ b/context_builder.go
@@ -97,6 +97,7 @@ func (cb *ContextBuilder) SetFormat(f Format) *ContextBuilder {
 	return cb
 }
 
+// SetRoutingDelegate sets the RoutingDelegate call options ("rd" transport header).
 func (cb *ContextBuilder) SetRoutingDelegate(rd string) *ContextBuilder {
 	if cb.CallOptions == nil {
 		cb.CallOptions = new(CallOptions)


### PR DESCRIPTION
The lint package was getting the library instead of the binary, and we were deleting the Godeps workspace which removed the binary.

Make sure "golint" runs on Travis, and fix minor lint issue.

cc @akshayjshah 