### PR TITLE
Make removeExchange defensive to avoid panics

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -146,8 +146,8 @@ type Connection struct {
 	sendCh          chan *Frame
 	state           connectionState
 	stateMut        sync.RWMutex
-	inbound         messageExchangeSet
-	outbound        messageExchangeSet
+	inbound         *messageExchangeSet
+	outbound        *messageExchangeSet
 	handlers        *handlerMap
 	nextMessageID   uint32
 	events          connectionEvents
@@ -245,23 +245,15 @@ func (ch *Channel) newConnection(conn net.Conn, initialState connectionState, ev
 	c := &Connection{
 		channelConnectionCommon: ch.channelConnectionCommon,
 
-		connID:        connID,
-		conn:          conn,
-		framePool:     framePool,
-		state:         initialState,
-		sendCh:        make(chan *Frame, sendBufferSize),
-		localPeerInfo: peerInfo,
-		checksumType:  checksumType,
-		inbound: messageExchangeSet{
-			name:      messageExchangeSetInbound,
-			log:       log.WithFields(LogField{"exchange", messageExchangeSetInbound}),
-			exchanges: make(map[uint32]*messageExchange),
-		},
-		outbound: messageExchangeSet{
-			name:      messageExchangeSetOutbound,
-			log:       log.WithFields(LogField{"exchange", messageExchangeSetOutbound}),
-			exchanges: make(map[uint32]*messageExchange),
-		},
+		connID:          connID,
+		conn:            conn,
+		framePool:       framePool,
+		state:           initialState,
+		sendCh:          make(chan *Frame, sendBufferSize),
+		localPeerInfo:   peerInfo,
+		checksumType:    checksumType,
+		inbound:         newMessageExchangeSet(log, messageExchangeSetInbound),
+		outbound:        newMessageExchangeSet(log, messageExchangeSetOutbound),
 		handlers:        ch.handlers,
 		events:          events,
 		commonStatsTags: ch.commonStatsTags,

--- a/inbound.go
+++ b/inbound.go
@@ -146,8 +146,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 // defragmentation
 func (c *Connection) handleCallReqContinue(frame *Frame) bool {
 	if err := c.inbound.forwardPeerFrame(frame); err != nil {
-		// If forward fails, it's due to a timeout.
-		c.inbound.timeoutExchange(frame.Header.ID)
+		// If forward fails, it's due to a timeout. We can free this frame.
 		return true
 	}
 	return false

--- a/logger.go
+++ b/logger.go
@@ -97,7 +97,13 @@ func (nullLogger) Info(msg string)                        {}
 func (nullLogger) Debugf(msg string, args ...interface{}) {}
 func (nullLogger) Debug(msg string)                       {}
 func (l nullLogger) Fields() LogFields                    { return l.fields }
-func (l nullLogger) WithFields(fields ...LogField) Logger { return nullLogger{fields} }
+
+func (l nullLogger) WithFields(fields ...LogField) Logger {
+	newFields := make([]LogField, len(l.Fields())+len(fields))
+	n := copy(newFields, l.Fields())
+	copy(newFields[n:], fields)
+	return nullLogger{newFields}
+}
 
 // SimpleLogger prints logging information to standard out.
 var SimpleLogger = NewLogger(os.Stdout)

--- a/mex.go
+++ b/mex.go
@@ -168,6 +168,15 @@ type messageExchangeSet struct {
 	exchanges map[uint32]*messageExchange
 }
 
+// newMessageExchangeSet creates a new messageExchangeSet with a given name.
+func newMessageExchangeSet(log Logger, name string) *messageExchangeSet {
+	return &messageExchangeSet{
+		name:      name,
+		log:       log.WithFields(LogField{"exchange", name}),
+		exchanges: make(map[uint32]*messageExchange),
+	}
+}
+
 // newExchange creates and adds a new message exchange to this set
 func (mexset *messageExchangeSet) newExchange(ctx context.Context, framePool FramePool,
 	msgType messageType, msgID uint32, bufferSize int) (*messageExchange, error) {

--- a/mex.go
+++ b/mex.go
@@ -197,19 +197,11 @@ func (mexset *messageExchangeSet) newExchange(ctx context.Context, framePool Fra
 
 	mexset.Lock()
 	if existingMex := mexset.exchanges[mex.msgID]; existingMex != nil {
-		if existingMex == mex {
-			mexset.log.WithFields(
-				LogField{"name", mexset.name},
-				LogField{"msgType", mex.msgType},
-				LogField{"msgID", mex.msgID},
-			).Warn("mex registered multiple times.")
-		} else {
-			mexset.log.WithFields(
-				LogField{"msgID", mex.msgID},
-				LogField{"existingType", existingMex.msgType},
-				LogField{"newType", mex.msgType},
-			).Warn("Duplicate msg ID for active and new mex.")
-		}
+		mexset.log.WithFields(
+			LogField{"msgID", mex.msgID},
+			LogField{"existingType", existingMex.msgType},
+			LogField{"newType", mex.msgType},
+		).Warn("Duplicate msg ID for active and new mex.")
 
 		mexset.Unlock()
 		return nil, errDuplicateMex


### PR DESCRIPTION
Currently, if `removeExchange` is called multiple times for the same `msgID`, it will decrement the `sendCh` wait group multiple times, and this will end up causing a panic.

Update `removeExchange` to be more defensive, and instead log an error if it detects that it's been called multiple times. This way, services will be more resilient and it'll be easier to understand these errors from logs.