### PR TITLE
Repro for a stuck RPC during a streaming call

### DIFF
--- a/mex.go
+++ b/mex.go
@@ -40,7 +40,7 @@ const (
 	messageExchangeSetOutbound = "outbound"
 
 	// mexChannelBufferSize is the size of the message exchange channel buffer.
-	mexChannelBufferSize = 2
+	mexChannelBufferSize = 10
 )
 
 // A messageExchange tracks this Connections's side of a message exchange with a


### PR DESCRIPTION
See commit messages for more information on why this happens. There is no good fix for this issue, so opening this to get some ideas.

Possible ideas:
 - Increase buffer size to something larger to avoid this
   - Doesn't really fix the issue since the remote side could send enough frames to fill the buffer
   - Larger channel means more memory usage for an exchange that will rarely be used
   - We could pool `recvCh` to reduce the impact of ^

- Resizable buffer for `recvCh`
  - Will have to implement our own resizable channel (more code, more likely to have bugs and will need a lot of testing)
  - Complicates the standard RPC flow and may have a performance impact
  - Unbounded memory pressure could have other problems

- Fast path vs slow path (have a separate path for streaming calls)
   - Similar to above, but could avoid impacting the standard RPC flow

- Clients should not make RPC calls in their streaming read handler
   - No performance impact, or code complexity impact in library
   - Simplest fix, but pushes some complexity to the user

cc @akshayjshah