### PR TITLE
Add relaying

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -64,6 +64,9 @@ type ChannelOptions struct {
 	// The logger to use for this channel
 	Logger Logger
 
+	// The host:port selection implementation to use for relaying.
+	RelayHosts RelayHosts
+
 	// The reporter to use for reporting stats for this channel.
 	StatsReporter StatsReporter
 
@@ -119,6 +122,7 @@ type Channel struct {
 	connectionOptions ConnectionOptions
 	handlers          *handlerMap
 	peers             *PeerList
+	relayHosts        RelayHosts
 
 	// mutable contains all the members of Channel which are mutable.
 	mutable struct {
@@ -191,6 +195,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 
 		connectionOptions: opts.DefaultConnectionOptions,
 		handlers:          &handlerMap{},
+		relayHosts:        opts.RelayHosts,
 	}
 	ch.peers = newRootPeerList(ch).newChild()
 
@@ -626,4 +631,9 @@ func (ch *Channel) Close() {
 		c.Close()
 	}
 	removeClosedChannel(ch)
+}
+
+// RelayHosts returns the channel's relay hosts, if any.
+func (ch *Channel) RelayHosts() RelayHosts {
+	return ch.relayHosts
 }

--- a/connection.go
+++ b/connection.go
@@ -152,6 +152,7 @@ type Connection struct {
 	nextMessageID   uint32
 	events          connectionEvents
 	commonStatsTags map[string]string
+	relay           *Relayer
 
 	// closeNetworkCalled is used to avoid errors from being logged
 	// when this side closes a connection.
@@ -264,6 +265,9 @@ func (ch *Channel) newConnection(conn net.Conn, initialState connectionState, ev
 	c.inbound.onAdded = c.onExchangeAdded
 	c.outbound.onAdded = c.onExchangeAdded
 
+	if ch.relayHosts != nil {
+		c.relay = NewRelayer(ch, c)
+	}
 	go c.readFrames(connID)
 	go c.writeFrames(connID)
 	return c
@@ -671,39 +675,84 @@ func (c *Connection) readFrames(_ uint32) {
 			return
 		}
 
-		// call req and call res messages may not want the frame released immediately.
-		releaseFrame := true
-		switch frame.Header.messageType {
-		case messageTypeCallReq:
-			releaseFrame = c.handleCallReq(frame)
-		case messageTypeCallReqContinue:
-			releaseFrame = c.handleCallReqContinue(frame)
-		case messageTypeCallRes:
-			releaseFrame = c.handleCallRes(frame)
-		case messageTypeCallResContinue:
-			releaseFrame = c.handleCallResContinue(frame)
-		case messageTypeInitReq:
-			c.handleInitReq(frame)
-		case messageTypeInitRes:
-			releaseFrame = c.handleInitRes(frame)
-		case messageTypePingReq:
-			c.handlePingReq(frame)
-		case messageTypePingRes:
-			releaseFrame = c.handlePingRes(frame)
-		case messageTypeError:
-			releaseFrame = c.handleError(frame)
-		default:
-			// TODO(mmihic): Log and close connection with protocol error
-			c.log.WithFields(
-				LogField{"header", frame.Header},
-				LogField{"remotePeer", c.remotePeerInfo},
-			).Error("Received unexpected frame.")
+		var releaseFrame bool
+		if c.relay == nil {
+			releaseFrame = c.readFrameNoRelay(frame)
+		} else {
+			releaseFrame = c.readFrameRelay(frame)
 		}
-
 		if releaseFrame {
 			c.framePool.Release(frame)
 		}
 	}
+}
+
+func (c *Connection) readFrameRelay(frame *Frame) bool {
+	releaseFrame := true
+
+	// call req and call res messages may not want the frame released immediately.
+	switch frame.Header.messageType {
+	case messageTypeCallReq, messageTypeCallReqContinue, messageTypeCallRes, messageTypeCallResContinue:
+		if err := c.relay.Relay(frame); err != nil {
+			c.log.WithFields(
+				LogField{"header", frame.Header},
+				LogField{"remotePeer", c.remotePeerInfo},
+			).Error("Failed to relay frame.")
+		}
+		releaseFrame = false
+	case messageTypeInitReq:
+		c.handleInitReq(frame)
+	case messageTypeInitRes:
+		releaseFrame = c.handleInitRes(frame)
+	case messageTypePingReq:
+		c.handlePingReq(frame)
+	case messageTypePingRes:
+		releaseFrame = c.handlePingRes(frame)
+	case messageTypeError:
+		c.handleError(frame)
+	default:
+		// TODO(mmihic): Log and close connection with protocol error
+		c.log.WithFields(
+			LogField{"header", frame.Header},
+			LogField{"remotePeer", c.remotePeerInfo},
+		).Error("Received unexpected frame.")
+	}
+
+	return releaseFrame
+}
+
+func (c *Connection) readFrameNoRelay(frame *Frame) bool {
+	releaseFrame := true
+
+	// call req and call res messages may not want the frame released immediately.
+	switch frame.Header.messageType {
+	case messageTypeCallReq:
+		releaseFrame = c.handleCallReq(frame)
+	case messageTypeCallReqContinue:
+		releaseFrame = c.handleCallReqContinue(frame)
+	case messageTypeCallRes:
+		releaseFrame = c.handleCallRes(frame)
+	case messageTypeCallResContinue:
+		releaseFrame = c.handleCallResContinue(frame)
+	case messageTypeInitReq:
+		c.handleInitReq(frame)
+	case messageTypeInitRes:
+		releaseFrame = c.handleInitRes(frame)
+	case messageTypePingReq:
+		c.handlePingReq(frame)
+	case messageTypePingRes:
+		releaseFrame = c.handlePingRes(frame)
+	case messageTypeError:
+		releaseFrame = c.handleError(frame)
+	default:
+		// TODO(mmihic): Log and close connection with protocol error
+		c.log.WithFields(
+			LogField{"header", frame.Header},
+			LogField{"remotePeer", c.remotePeerInfo},
+		).Error("Received unexpected frame.")
+	}
+
+	return releaseFrame
 }
 
 // writeFrames is the main loop that pulls frames from the send channel and

--- a/connection.go
+++ b/connection.go
@@ -677,9 +677,9 @@ func (c *Connection) readFrames(_ uint32) {
 
 		var releaseFrame bool
 		if c.relay == nil {
-			releaseFrame = c.readFrameNoRelay(frame)
+			releaseFrame = c.handleFrameNoRelay(frame)
 		} else {
-			releaseFrame = c.readFrameRelay(frame)
+			releaseFrame = c.handleFrameRelay(frame)
 		}
 		if releaseFrame {
 			c.framePool.Release(frame)
@@ -687,10 +687,7 @@ func (c *Connection) readFrames(_ uint32) {
 	}
 }
 
-func (c *Connection) readFrameRelay(frame *Frame) bool {
-	releaseFrame := true
-
-	// call req and call res messages may not want the frame released immediately.
+func (c *Connection) handleFrameRelay(frame *Frame) bool {
 	switch frame.Header.messageType {
 	case messageTypeCallReq, messageTypeCallReqContinue, messageTypeCallRes, messageTypeCallResContinue:
 		if err := c.relay.Relay(frame); err != nil {
@@ -699,29 +696,13 @@ func (c *Connection) readFrameRelay(frame *Frame) bool {
 				LogField{"remotePeer", c.remotePeerInfo},
 			).Error("Failed to relay frame.")
 		}
-		releaseFrame = false
-	case messageTypeInitReq:
-		c.handleInitReq(frame)
-	case messageTypeInitRes:
-		releaseFrame = c.handleInitRes(frame)
-	case messageTypePingReq:
-		c.handlePingReq(frame)
-	case messageTypePingRes:
-		releaseFrame = c.handlePingRes(frame)
-	case messageTypeError:
-		c.handleError(frame)
+		return false
 	default:
-		// TODO(mmihic): Log and close connection with protocol error
-		c.log.WithFields(
-			LogField{"header", frame.Header},
-			LogField{"remotePeer", c.remotePeerInfo},
-		).Error("Received unexpected frame.")
+		return c.handleFrameNoRelay(frame)
 	}
-
-	return releaseFrame
 }
 
-func (c *Connection) readFrameNoRelay(frame *Frame) bool {
+func (c *Connection) handleFrameNoRelay(frame *Frame) bool {
 	releaseFrame := true
 
 	// call req and call res messages may not want the frame released immediately.

--- a/connection.go
+++ b/connection.go
@@ -688,6 +688,7 @@ func (c *Connection) readFrames(_ uint32) {
 }
 
 func (c *Connection) handleFrameRelay(frame *Frame) bool {
+	// TODO: handle error frames.
 	switch frame.Header.messageType {
 	case messageTypeCallReq, messageTypeCallReqContinue, messageTypeCallRes, messageTypeCallResContinue:
 		if err := c.relay.Relay(frame); err != nil {

--- a/frame.go
+++ b/frame.go
@@ -167,6 +167,20 @@ func (f *Frame) SizedPayload() []byte {
 	return f.Payload[:f.Header.PayloadSize()]
 }
 
+// messageType returns the message type.
+func (f *Frame) messageType() messageType {
+	return f.Header.messageType
+}
+
+// Service returns the name of the destination service.
+func (f *Frame) Service() string {
+	// We can ignore the first 30 bytes of callReq:
+	// flags:1 ttl:4 tracing:25
+	// service~1
+	serviceLen := f.Payload[30]
+	return string(f.Payload[31 : 31+serviceLen])
+}
+
 func (f *Frame) write(msg message) error {
 	var wbuf typed.WriteBuffer
 	wbuf.Wrap(f.Payload[:])

--- a/peer.go
+++ b/peer.go
@@ -321,6 +321,28 @@ func (p *Peer) GetConnection(ctx context.Context) (*Connection, error) {
 	return c, nil
 }
 
+// GetRelayConnection returns an active connection for relaying to this peer.
+// Like GetConnection, if will create a new outbound connection if necessary.
+func (p *Peer) GetRelayConnection() (*Connection, error) {
+	p.RLock()
+	if len(p.inboundConnections)+len(p.outboundConnections) == 0 {
+		p.RUnlock()
+		ctx, cancel := NewContext(5 * time.Second)
+		defer cancel()
+		return p.GetConnection(ctx)
+	}
+
+	var conn *Connection
+	if len(p.outboundConnections) > 0 {
+		conn = randConn(p.outboundConnections)
+	} else {
+		conn = randConn(p.inboundConnections)
+	}
+
+	p.RUnlock()
+	return conn, nil
+}
+
 // AddInboundConnection adds an active inbound connection to the peer's connection list.
 // If a connection is not active, ErrInvalidConnectionState will be returned.
 func (p *Peer) AddInboundConnection(c *Connection) error {

--- a/relay.go
+++ b/relay.go
@@ -9,7 +9,7 @@ import (
 // relaying.
 type RelayHosts interface {
 	// Get returns the host:port of the best peer for the group.
-	Get(group string) string
+	Get(service string) string
 	// TODO: add MarkFailed and MarkOK to for feedback loop into peer selection.
 }
 
@@ -21,14 +21,13 @@ type relayItem struct {
 // A Relayer forwards frames.
 type Relayer struct {
 	sync.RWMutex
+
 	metrics StatsReporter
 	hosts   RelayHosts
 	items   map[uint32]relayItem
-
-	// Immutable
-	peers  *PeerList
-	conn   *Connection
-	logger Logger
+	peers   *PeerList
+	conn    *Connection
+	logger  Logger
 }
 
 // NewRelayer constructs a Relayer.
@@ -50,6 +49,10 @@ func (r *Relayer) Hosts() RelayHosts {
 
 // Relay forwards a frame.
 func (r *Relayer) Relay(f *Frame) error {
+	// TODO: remove relay items when we get a call req continue or call res
+	// continue frame without a continuation bit.
+	//
+	// TODO: remove relay items on timeout.
 	if f.messageType() != messageTypeCallReq {
 		r.RLock()
 		item, ok := r.items[f.Header.ID]

--- a/relay.go
+++ b/relay.go
@@ -1,0 +1,111 @@
+package tchannel
+
+import (
+	"errors"
+	"sync"
+)
+
+// RelayHosts allows external wrappers to inject peer selection logic for
+// relaying.
+type RelayHosts interface {
+	// Get returns the host:port of the best peer for the group.
+	Get(group string) string
+	// TODO: add MarkFailed and MarkOK to for feedback loop into peer selection.
+}
+
+type relayItem struct {
+	remapID     uint32
+	destination *Relayer
+}
+
+// A Relayer forwards frames.
+type Relayer struct {
+	sync.RWMutex
+	metrics StatsReporter
+	hosts   RelayHosts
+	items   map[uint32]relayItem
+
+	// Immutable
+	peers  *PeerList
+	conn   *Connection
+	logger Logger
+}
+
+// NewRelayer constructs a Relayer.
+func NewRelayer(ch *Channel, conn *Connection) *Relayer {
+	return &Relayer{
+		metrics: conn.statsReporter,
+		hosts:   ch.relayHosts,
+		items:   make(map[uint32]relayItem),
+		peers:   ch.Peers(),
+		conn:    conn,
+		logger:  ch.Logger(),
+	}
+}
+
+// Hosts returns the RelayHosts guiding peer selection.
+func (r *Relayer) Hosts() RelayHosts {
+	return r.hosts
+}
+
+// Relay forwards a frame.
+func (r *Relayer) Relay(f *Frame) error {
+	if f.messageType() != messageTypeCallReq {
+		r.RLock()
+		item, ok := r.items[f.Header.ID]
+		r.RUnlock()
+		if !ok {
+			return errors.New("non-callReq for inactive ID")
+		}
+		f.Header.ID = item.remapID
+		item.destination.Receive(f)
+		return nil
+	}
+
+	if _, ok := r.items[f.Header.ID]; ok {
+		return errors.New("callReq with already active ID")
+	}
+
+	// Get the destination
+	svc := f.Service()
+	hostPort := r.hosts.Get(svc)
+	if hostPort == "" {
+		return errors.New("no available peer for group")
+	}
+	peer := r.peers.GetOrAdd(hostPort)
+
+	c, err := peer.GetRelayConnection()
+	if err != nil {
+		r.logger.WithFields(
+			ErrField(err),
+			LogField{"hostPort", hostPort},
+		).Warn("Failed to connect to relay host.")
+		// TODO : return an error frame.
+		return nil
+	}
+
+	destinationID := c.NextMessageID()
+	c.relay.addRelayItem(destinationID, f.Header.ID, r)
+	r.metrics.IncCounter("relay", nil, 1)
+	relayToDest := r.addRelayItem(f.Header.ID, destinationID, c.relay)
+
+	f.Header.ID = destinationID
+	relayToDest.destination.Receive(f)
+	return nil
+}
+
+// Receive accepts a relayed frame.
+func (r *Relayer) Receive(f *Frame) {
+	r.conn.sendCh <- f
+}
+
+func (r *Relayer) addRelayItem(id, remapID uint32, destination *Relayer) relayItem {
+	item := relayItem{
+		remapID:     remapID,
+		destination: destination,
+	}
+	r.Lock()
+	r.items[id] = item
+	r.Unlock()
+	return item
+}

--- a/relay_benchmark_test.go
+++ b/relay_benchmark_test.go
@@ -1,0 +1,63 @@
+package tchannel_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	. "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+func BenchmarkRelay(b *testing.B) {
+	const (
+		numServers = 5
+		numClients = 5
+	)
+	data := testutils.RandBytes(1000)
+
+	ch, err := NewChannel("relay", &ChannelOptions{
+		RelayHosts: NewSimpleRelayHosts(map[string][]string{}),
+	})
+	require.NoError(b, err, "Failed to create relay")
+	require.NoError(b, ch.ListenAndServe("127.0.0.1:0"), "relay listen failed")
+
+	servers := make([]*Channel, numServers)
+	for i := 0; i < numServers; i++ {
+		servers[i] = testutils.NewServer(b, testutils.NewOpts().SetServiceName("test"))
+		servers[i].Register(raw.Wrap(newTestHandler(b)), "echo")
+		ch.RelayHosts().(*SimpleRelayHosts).Add("test", servers[i].PeerInfo().HostPort)
+	}
+
+	clients := make([]*Channel, numServers)
+	for i := 0; i < numClients; i++ {
+		clients[i] = testutils.NewClient(b, nil)
+		clients[i].Peers().Add(ch.PeerInfo().HostPort)
+	}
+
+	b.ResetTimer()
+
+	benchMore := testutils.Decrementor(b.N)
+
+	var wg sync.WaitGroup
+	wg.Add(numClients)
+	for i := 0; i < numClients; i++ {
+		go func(c *Channel) {
+			defer wg.Done()
+
+			sc := c.GetSubChannel("test")
+			for benchMore() {
+				ctx, cancel := NewContext(time.Second)
+				defer cancel()
+
+				_, _, _, err := raw.CallSC(ctx, sc, "echo", nil, data)
+				assert.NoError(b, err, "call failed")
+			}
+
+		}(clients[i])
+	}
+	wg.Wait()
+}

--- a/relay_stub_test.go
+++ b/relay_stub_test.go
@@ -22,11 +22,11 @@ func NewSimpleRelayHosts(peers map[string][]string) *SimpleRelayHosts {
 	}
 }
 
-func (rh *SimpleRelayHosts) Get(group string) string {
+func (rh *SimpleRelayHosts) Get(service string) string {
 	rh.RLock()
 	defer rh.RUnlock()
 
-	available, ok := rh.peers[group]
+	available, ok := rh.peers[service]
 	if !ok || len(available) == 0 {
 		return ""
 	}
@@ -34,9 +34,9 @@ func (rh *SimpleRelayHosts) Get(group string) string {
 	return available[i]
 }
 
-func (rh *SimpleRelayHosts) Add(group, hostPort string) {
+func (rh *SimpleRelayHosts) Add(service, hostPort string) {
 	rh.Lock()
-	rh.peers[group] = append(rh.peers[group], hostPort)
+	rh.peers[service] = append(rh.peers[service], hostPort)
 	rh.Unlock()
 }
 

--- a/relay_stub_test.go
+++ b/relay_stub_test.go
@@ -1,0 +1,51 @@
+package tchannel_test
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type SimpleRelayHosts struct {
+	sync.RWMutex
+	r     *rand.Rand
+	peers map[string][]string
+}
+
+func NewSimpleRelayHosts(peers map[string][]string) *SimpleRelayHosts {
+	// Use a known seed for repeatable tests.
+	return &SimpleRelayHosts{
+		r:     rand.New(rand.NewSource(1)),
+		peers: peers,
+	}
+}
+
+func (rh *SimpleRelayHosts) Get(group string) string {
+	rh.RLock()
+	defer rh.RUnlock()
+
+	available, ok := rh.peers[group]
+	if !ok || len(available) == 0 {
+		return ""
+	}
+	i := rh.r.Intn(len(available))
+	return available[i]
+}
+
+func (rh *SimpleRelayHosts) Add(group, hostPort string) {
+	rh.Lock()
+	rh.peers[group] = append(rh.peers[group], hostPort)
+	rh.Unlock()
+}
+
+func TestSimpleRelayHosts(t *testing.T) {
+	hosts := map[string][]string{
+		"foo":        {"1.1.1.1:1234", "1.1.1.1:1235"},
+		"foo-canary": {},
+	}
+	rh := NewSimpleRelayHosts(hosts)
+	assert.Equal(t, "", rh.Get("foo-canary"), "Expected no canary hosts.")
+	assert.Equal(t, "1.1.1.1:1235", rh.Get("foo"), "Unexpected peer chosen.")
+}

--- a/relay_test.go
+++ b/relay_test.go
@@ -1,0 +1,48 @@
+package tchannel_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	. "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+func TestRelay(t *testing.T) {
+	relay, err := NewChannel("relay", &ChannelOptions{
+		RelayHosts: NewSimpleRelayHosts(map[string][]string{}),
+	})
+	require.NoError(t, err, "Failed to create a relay channel.")
+	require.NoError(t, relay.ListenAndServe("127.0.0.1:0"), "Relay failed to listen.")
+	defer relay.Close()
+
+	data := []byte("fake-body")
+
+	server := testutils.NewServer(t, testutils.NewOpts().SetServiceName("test"))
+	defer server.Close()
+	server.Register(raw.Wrap(newTestHandler(t)), "echo")
+	relay.RelayHosts().(*SimpleRelayHosts).Add("test", server.PeerInfo().HostPort)
+
+	client := testutils.NewClient(t, nil)
+	client.Peers().Add(relay.PeerInfo().HostPort)
+	defer client.Close()
+
+	var wg sync.WaitGroup
+
+	defer func(c *Channel) {
+		sc := client.GetSubChannel("test")
+		ctx, cancel := NewContext(10 * time.Millisecond)
+		defer cancel()
+
+		arg2, arg3, _, err := raw.CallSC(ctx, sc, "echo", []byte("fake-header"), data)
+		require.NoError(t, err, "Relayed call failed.")
+		assert.Equal(t, "fake-header", string(arg2), "Header was mangled during relay.")
+		assert.Equal(t, "fake-body", string(arg3), "Body was mangled during relay.")
+	}(client)
+
+	wg.Wait()
+}

--- a/relay_test.go
+++ b/relay_test.go
@@ -35,7 +35,7 @@ func TestRelay(t *testing.T) {
 
 	defer func(c *Channel) {
 		sc := client.GetSubChannel("test")
-		ctx, cancel := NewContext(10 * time.Millisecond)
+		ctx, cancel := NewContext(time.Second)
 		defer cancel()
 
 		arg2, arg3, _, err := raw.CallSC(ctx, sc, "echo", []byte("fake-header"), data)

--- a/relay_test.go
+++ b/relay_test.go
@@ -18,31 +18,35 @@ func TestRelay(t *testing.T) {
 	})
 	require.NoError(t, err, "Failed to create a relay channel.")
 	require.NoError(t, relay.ListenAndServe("127.0.0.1:0"), "Relay failed to listen.")
-	defer relay.Close()
 
 	data := []byte("fake-body")
 
 	server := testutils.NewServer(t, testutils.NewOpts().SetServiceName("test"))
-	defer server.Close()
 	server.Register(raw.Wrap(newTestHandler(t)), "echo")
 	relay.RelayHosts().(*SimpleRelayHosts).Add("test", server.PeerInfo().HostPort)
 
 	client := testutils.NewClient(t, nil)
 	client.Peers().Add(relay.PeerInfo().HostPort)
-	defer client.Close()
 
 	var wg sync.WaitGroup
+	wg.Add(1)
 
-	defer func(c *Channel) {
+	go func(c *Channel) {
 		sc := client.GetSubChannel("test")
 		ctx, cancel := NewContext(time.Second)
 		defer cancel()
 
 		arg2, arg3, _, err := raw.CallSC(ctx, sc, "echo", []byte("fake-header"), data)
+		t.Log(string(arg3))
 		require.NoError(t, err, "Relayed call failed.")
 		assert.Equal(t, "fake-header", string(arg2), "Header was mangled during relay.")
 		assert.Equal(t, "fake-body", string(arg3), "Body was mangled during relay.")
+
+		wg.Done()
 	}(client)
 
 	wg.Wait()
+	client.Close()
+	relay.Close()
+	server.Close()
 }

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -141,6 +141,12 @@ func (o *ChannelOpts) AddLogFilter(filter string, maxCount uint, fields ...strin
 	return o
 }
 
+// SetRelayHosts sets the channel's relay hosts, which enables relaying.
+func (o *ChannelOpts) SetRelayHosts(rh tchannel.RelayHosts) *ChannelOpts {
+	o.ChannelOptions.RelayHosts = rh
+	return o
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue


### PR DESCRIPTION
This is mostly the same as @prashantv's relay branch, with a few small changes and a few more tests.

I *think* that this should let Muttley write peer selection logic that's shared between the HTTP and TChannel code, wrap it up into a `RelayHosts`, and inject it into a `tchannel.Channel`.