### PR TITLE
Reduce allocations when reading or writing Thrift structs

### DIFF
--- a/testutils/testreader/chunk.go
+++ b/testutils/testreader/chunk.go
@@ -53,6 +53,9 @@ func (r *errorReader) Read(bs []byte) (int, error) {
 		if r.remaining == nil {
 			return 0, ErrUser
 		}
+		if len(r.remaining) == 0 {
+			return 0, nil
+		}
 	}
 
 	n := copy(bs, r.remaining)

--- a/testutils/testreader/chunk_test.go
+++ b/testutils/testreader/chunk_test.go
@@ -21,11 +21,34 @@
 package testreader
 
 import (
+	"io"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestChunkReader0ByteRead(t *testing.T) {
+	writer, reader := ChunkReader()
+
+	writer <- []byte{}
+	writer <- []byte{'a'}
+	close(writer)
+
+	buf := make([]byte, 1)
+	n, err := reader.Read(buf)
+	assert.NoError(t, err, "Read should not fail")
+	assert.Equal(t, 0, n, "Read should not read any bytes")
+
+	n, err = reader.Read(buf)
+	assert.NoError(t, err, "Read should not fail")
+	assert.Equal(t, 1, n, "Read should read one byte")
+	assert.EqualValues(t, 'a', buf[0], "Read did not read correct byte")
+
+	n, err = reader.Read(buf)
+	assert.Equal(t, io.EOF, err, "Read should EOF")
+	assert.Equal(t, 0, n, "Read should not read any bytes")
+}
 
 func TestChunkReader(t *testing.T) {
 	writer, reader := ChunkReader()

--- a/thrift/struct_test.go
+++ b/thrift/struct_test.go
@@ -177,3 +177,24 @@ func TestParallelReadWrites(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func BenchmarkWriteStruct(b *testing.B) {
+	buf := &bytes.Buffer{}
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		WriteStruct(buf, structTest.s)
+	}
+}
+
+func BenchmarkReadStruct(b *testing.B) {
+	buf := bytes.NewReader(structTest.encoded)
+	var d test.Data
+
+	buf.Seek(0, 0)
+	assert.NoError(b, ReadStruct(buf, &d))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Seek(0, 0)
+		ReadStruct(buf, &d)
+	}
+}

--- a/thrift/transport_test.go
+++ b/thrift/transport_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/testutils/testreader"
+	"github.com/uber/tchannel-go/testutils/testwriter"
+)
+
+func writeByte(writer io.Writer, b byte) error {
+	protocol := getProtocolWriter(writer)
+	return protocol.transport.WriteByte(b)
+}
+
+func TestWriteByteSuccess(t *testing.T) {
+	writer := &bytes.Buffer{}
+	assert.NoError(t, writeByte(writer, 'a'), "WriteByte failed")
+	assert.NoError(t, writeByte(writer, 'b'), "WriteByte failed")
+	assert.NoError(t, writeByte(writer, 'c'), "WriteByte failed")
+	assert.Equal(t, []byte("abc"), writer.Bytes(), "Written bytes mismatch")
+}
+
+func TestWriteByteFailed(t *testing.T) {
+	buf := &bytes.Buffer{}
+	writer := io.MultiWriter(testwriter.Limited(2), buf)
+	assert.NoError(t, writeByte(writer, 'a'), "WriteByte failed")
+	assert.NoError(t, writeByte(writer, 'b'), "WriteByte failed")
+	assert.Error(t, writeByte(writer, 'c'), "WriteByte should fail due to lack of space")
+	assert.Equal(t, []byte("ab"), buf.Bytes(), "Written bytes mismatch")
+}
+
+func TestReadByte0Byte(t *testing.T) {
+	chunkWriter, chunkReader := testreader.ChunkReader()
+	reader := getProtocolReader(chunkReader)
+
+	chunkWriter <- []byte{}
+	chunkWriter <- []byte{}
+	chunkWriter <- []byte{}
+	chunkWriter <- []byte("abc")
+	close(chunkWriter)
+
+	b, err := reader.transport.ReadByte()
+	assert.NoError(t, err, "ReadByte should ignore 0 byte reads")
+	assert.EqualValues(t, 'a', b)
+
+	b, err = reader.transport.ReadByte()
+	assert.NoError(t, err, "ReadByte failed")
+	assert.EqualValues(t, 'b', b)
+
+	b, err = reader.transport.ReadByte()
+	assert.NoError(t, err, "ReadByte failed")
+	assert.EqualValues(t, 'c', b)
+
+	b, err = reader.transport.ReadByte()
+	assert.Equal(t, io.EOF, err, "ReadByte should EOF")
+}


### PR DESCRIPTION
Thrift has 2 levels of transports,
 - `TTransport` which is just the `Read` and `Write`
 - `TRichTransport` which is `TTransport` as well as `ReadByte`, `WriteByte`, and `WriteString`.

The protocols use a `TRichTransport`, so when you pass a `TTransport`, it wraps the transport using the `RichTransport` class:
https://godoc.org/github.com/apache/thrift/lib/go/thrift#RichTransport

The `RichTransport` implementations for `ReadByte` and `WriteByte` did allocations on every single call, and since every field requires these functions, it ended up causing a lot of allocations.

To reduce allocations, we implement `TRichTransport` in our internal `readerWriterTransport`, where we have our own `ReadByte` and `WriteByte` implementations that do not do allocations.

The added benchmark results go from:
```
BenchmarkWriteStruct-8   2000000               581 ns/op              96 B/op          6 allocs/op
BenchmarkReadStruct-8    2000000               633 ns/op              96 B/op          6 allocs/op
```
to
```
BenchmarkWriteStruct-8   5000000               351 ns/op               0 B/op          0 allocs/op
BenchmarkReadStruct-8    5000000               394 ns/op              16 B/op          1 allocs/op
```

cc @nomis52 @abhinav 