### PR TITLE
Hyperbahn client: Move time.Sleep stub into client-specific option

### DIFF
--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -41,9 +41,6 @@ const (
 	advertiseRetryInterval = 1 * time.Second
 )
 
-// timeSleep is a variable for stubbing in unit tests.
-var timeSleep = time.Sleep
-
 // ErrAdvertiseFailed is triggered when advertise fails.
 type ErrAdvertiseFailed struct {
 	// WillRetry is set to true if advertise will be retried.
@@ -84,7 +81,7 @@ func (c *Client) advertiseLoop() {
 	consecutiveFailures := uint(0)
 
 	for {
-		timeSleep(sleepFor)
+		c.sleep(sleepFor)
 		if c.IsClosed() {
 			c.tchan.Logger().Infof("Hyperbahn client closed")
 			return
@@ -129,7 +126,11 @@ func (c *Client) initialAdvertise() error {
 
 		// Back off for a while.
 		sleepFor := fuzzInterval(advertiseRetryInterval * time.Duration(1<<attempt))
-		timeSleep(sleepFor)
+		c.sleep(sleepFor)
 	}
 	return err
+}
+
+func (c *Client) sleep(d time.Duration) {
+	c.opts.TimeSleep(d)
 }

--- a/hyperbahn/client.go
+++ b/hyperbahn/client.go
@@ -86,6 +86,10 @@ type ClientOptions struct {
 	TimeoutPerAttempt time.Duration
 	Handler           Handler
 	FailStrategy      FailStrategy
+
+	// The following are variables for stubbing in unit tests.
+	// They are not part of the stable API and may change.
+	TimeSleep func(d time.Duration)
 }
 
 // NewClient creates a new Hyperbahn client using the given channel.
@@ -104,6 +108,9 @@ func NewClient(ch *tchannel.Channel, config Configuration, opts *ClientOptions) 
 	}
 	if client.opts.Handler == nil {
 		client.opts.Handler = nullHandler{}
+	}
+	if client.opts.TimeSleep == nil {
+		client.opts.TimeSleep = time.Sleep
 	}
 
 	if err := parseConfig(&config); err != nil {


### PR DESCRIPTION
This ensures that:
 - tests cannot impact either each other by stubbing the same sleep
   function
 - external packages can stub the time.Sleep call