### PR TITLE
Unblock on close

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -432,16 +432,14 @@ func TestCloseSendError(t *testing.T) {
 	clientCh := testutils.NewClient(t, nil)
 
 	// Create a connection that will be shared.
-	// Use PingLong here so that we have a context with a bigger timeout
-	require.NoError(t, testutils.PingLong(clientCh, serverCh), "Ping from client to server failed")
+	require.NoError(t, testutils.Ping(clientCh, serverCh), "Ping from client to server failed")
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			time.Sleep(time.Duration(rand.Intn(1000)) * time.Microsecond)
-			// Use CallEchoLong here so that we have a context with a bigger timeout
-			err := testutils.CallEchoLong(clientCh, serverCh, nil)
+			err := testutils.CallEcho(clientCh, serverCh, nil)
 			if err != nil && atomic.LoadUint32(&closed) == 0 {
 				t.Errorf("Call failed: %v", err)
 			}

--- a/connection.go
+++ b/connection.go
@@ -509,6 +509,15 @@ func (c *Connection) handleInitRes(frame *Frame) bool {
 	return false
 }
 
+// handleConnectionError handles a connection error coming back from the peer.
+func (c *Connection) handleConnectionError(err error) {
+	// stop all outbound exchanges
+	c.outbound.stopExchanges(err)
+
+	// stop all inbound outbound exchanges
+	c.inbound.stopExchanges(err)
+}
+
 // sendMessage sends a standalone message (typically a control message)
 func (c *Connection) sendMessage(msg message) error {
 	frame := c.framePool.Get()
@@ -664,6 +673,8 @@ func (c *Connection) readFrames(_ uint32) {
 		if err := frame.ReadIn(c.conn); err != nil {
 			if atomic.LoadInt32(&c.closeNetworkCalled) == 0 {
 				c.connectionError("read frames", err)
+				// @aravindv: call handleConnectionError to unblock all application callers
+				c.handleConnectionError(err)
 			} else {
 				c.log.Debugf("Ignoring error after connection was closed: %v", err)
 			}

--- a/connection.go
+++ b/connection.go
@@ -673,7 +673,7 @@ func (c *Connection) readFrames(_ uint32) {
 		if err := frame.ReadIn(c.conn); err != nil {
 			if atomic.LoadInt32(&c.closeNetworkCalled) == 0 {
 				c.connectionError("read frames", err)
-				// @aravindv: call handleConnectionError to unblock all application callers
+				// call handleConnectionError to unblock all application callers
 				c.handleConnectionError(err)
 			} else {
 				c.log.Debugf("Ignoring error after connection was closed: %v", err)

--- a/inbound.go
+++ b/inbound.go
@@ -211,8 +211,18 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 
 	// TODO(prashant): This is an expensive way to check for cancellation. Use a heap for timeouts.
 	go func() {
-		if <-call.mex.ctx.Done(); call.mex.ctx.Err() == context.DeadlineExceeded {
-			call.mex.inboundTimeout()
+		select {
+		case <-call.mex.ctx.Done():
+			if call.mex.ctx.Err() == context.DeadlineExceeded {
+				call.mex.inboundTimeout()
+			}
+		// If we see an error on the exchange, then we should exit immediately
+		case connErr := <-call.mex.errCh:
+			if c.log.Enabled(LogLevelDebug) {
+				c.log.Debugf("Got an error on the exchange: %v (unblock the application)", connErr)
+			}
+			call.Response().SendSystemError(connErr)
+			releaseFrame()
 		}
 	}()
 

--- a/outbound.go
+++ b/outbound.go
@@ -64,7 +64,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 
 	// Close may have been called between the time we checked the state and us creating the exchange.
 	if state := c.readState(); state != connectionStartClose && state != connectionActive {
-		mex.shutdown()
+		mex.shutdown(nil)
 		return nil, ErrConnectionClosed
 	}
 
@@ -356,5 +356,5 @@ func (response *OutboundCallResponse) doneReading(unexpected error) {
 		response.statsReporter.IncCounter("outbound.calls.success", response.commonStatsTags, 1)
 	}
 
-	response.mex.shutdown()
+	response.mex.shutdown(nil)
 }

--- a/reqres.go
+++ b/reqres.go
@@ -168,7 +168,7 @@ func (w *reqResWriter) failed(err error) error {
 		return w.err
 	}
 
-	w.mex.shutdown()
+	w.mex.shutdown(nil)
 	w.err = err
 	return w.err
 }
@@ -263,7 +263,7 @@ func (r *reqResReader) failed(err error) error {
 		return r.err
 	}
 
-	r.mex.shutdown()
+	r.mex.shutdown(nil)
 	r.err = err
 	return r.err
 }

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -29,23 +29,9 @@ import (
 	"github.com/uber/tchannel-go/raw"
 )
 
-// CallEchoLong calls the "echo" endpoint from the given src to target.
-func CallEchoLong(src, target *tchannel.Channel, args *raw.Args) error {
-	ctx, cancel := tchannel.NewContext(Timeout(30 * time.Second))
-	defer cancel()
-
-	if args == nil {
-		args = &raw.Args{}
-	}
-
-	peerInfo := target.PeerInfo()
-	_, _, _, err := raw.Call(ctx, src, peerInfo.HostPort, peerInfo.ServiceName, "echo", args.Arg2, args.Arg3)
-	return err
-}
-
 // CallEcho calls the "echo" endpoint from the given src to target.
 func CallEcho(src, target *tchannel.Channel, args *raw.Args) error {
-	ctx, cancel := tchannel.NewContext(Timeout(100 * time.Millisecond))
+	ctx, cancel := tchannel.NewContext(Timeout(10 * time.Second))
 	defer cancel()
 
 	if args == nil {
@@ -66,14 +52,6 @@ func RegisterEcho(src *tchannel.Channel, f func()) {
 		}
 		return &raw.Res{Arg2: args.Arg2, Arg3: args.Arg3}, nil
 	})
-}
-
-// PingLong sends a ping from src to target.
-func PingLong(src, target *tchannel.Channel) error {
-	ctx, cancel := tchannel.NewContext(Timeout(30 * time.Second))
-	defer cancel()
-
-	return src.Ping(ctx, target.PeerInfo().HostPort)
 }
 
 // Ping sends a ping from src to target.

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -29,6 +29,20 @@ import (
 	"github.com/uber/tchannel-go/raw"
 )
 
+// CallEchoLong calls the "echo" endpoint from the given src to target.
+func CallEchoLong(src, target *tchannel.Channel, args *raw.Args) error {
+	ctx, cancel := tchannel.NewContext(Timeout(30 * time.Second))
+	defer cancel()
+
+	if args == nil {
+		args = &raw.Args{}
+	}
+
+	peerInfo := target.PeerInfo()
+	_, _, _, err := raw.Call(ctx, src, peerInfo.HostPort, peerInfo.ServiceName, "echo", args.Arg2, args.Arg3)
+	return err
+}
+
 // CallEcho calls the "echo" endpoint from the given src to target.
 func CallEcho(src, target *tchannel.Channel, args *raw.Args) error {
 	ctx, cancel := tchannel.NewContext(Timeout(100 * time.Millisecond))
@@ -52,6 +66,14 @@ func RegisterEcho(src *tchannel.Channel, f func()) {
 		}
 		return &raw.Res{Arg2: args.Arg2, Arg3: args.Arg3}, nil
 	})
+}
+
+// PingLong sends a ping from src to target.
+func PingLong(src, target *tchannel.Channel) error {
+	ctx, cancel := tchannel.NewContext(Timeout(30 * time.Second))
+	defer cancel()
+
+	return src.Ping(ctx, target.PeerInfo().HostPort)
 }
 
 // Ping sends a ping from src to target.


### PR DESCRIPTION
@prashantv  - Now we should be against dev..

If we get a connection error, we need to make sure all the exchanges are stopped completely that way we can unblock any application callers.

This patch adds an error channel on an message exchange and makes sure we send the appropriate error code on this channel if we see a connection error on both the inbound and the outbound side.

Also update the unit test to use a longer context timeout and with this change we can run this one cleanly with no issues  (@samarabbas) .

