### PR TITLE
Unblock calls on connection errors or if the stream has ended

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -414,7 +414,6 @@ func TestCloseOneSide(t *testing.T) {
 // TestCloseSendError tests that system errors are not attempted to be sent when
 // a connection is closed, and ensures there's no race conditions such as the error
 // frame being added to the channel just as it is closed.
-// TODO(prashant): This test is waiting for timeout, but socket close shouldn't wait for timeout.
 func TestCloseSendError(t *testing.T) {
 	closed := uint32(0)
 	counter := uint32(0)

--- a/connection.go
+++ b/connection.go
@@ -623,6 +623,10 @@ func (c *Connection) logConnectionError(site string, err error) error {
 func (c *Connection) connectionError(site string, err error) error {
 	err = c.logConnectionError(site, err)
 	c.Close()
+
+	// On any connection error, notify the exchanges of this error.
+	c.outbound.stopExchanges(err)
+	c.inbound.stopExchanges(err)
 	return err
 }
 

--- a/connection.go
+++ b/connection.go
@@ -601,6 +601,7 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 }
 
 func (c *Connection) logConnectionError(site string, err error) error {
+	errCode := ErrCodeNetwork
 	if err == io.EOF {
 		c.log.Debugf("Connection got EOF")
 	} else {
@@ -609,12 +610,13 @@ func (c *Connection) logConnectionError(site string, err error) error {
 			ErrField(err),
 		)
 		if se, ok := err.(SystemError); ok && se.Code() != ErrCodeNetwork {
+			errCode = se.Code()
 			logger.Error("Connection error.")
 		} else {
 			logger.Warn("Connection error.")
 		}
 	}
-	return NewWrappedSystemError(ErrCodeNetwork, err)
+	return NewWrappedSystemError(errCode, err)
 }
 
 // connectionError handles a connection level error

--- a/connection.go
+++ b/connection.go
@@ -600,8 +600,7 @@ func (c *Connection) SendSystemError(id uint32, span *Span, err error) error {
 	})
 }
 
-// connectionError handles a connection level error
-func (c *Connection) connectionError(site string, err error) error {
+func (c *Connection) logConnectionError(site string, err error) error {
 	if err == io.EOF {
 		c.log.Debugf("Connection got EOF")
 	} else {
@@ -615,8 +614,14 @@ func (c *Connection) connectionError(site string, err error) error {
 			logger.Warn("Connection error.")
 		}
 	}
-	c.Close()
 	return NewWrappedSystemError(ErrCodeNetwork, err)
+}
+
+// connectionError handles a connection level error
+func (c *Connection) connectionError(site string, err error) error {
+	err = c.logConnectionError(site, err)
+	c.Close()
+	return err
 }
 
 func (c *Connection) protocolError(id uint32, err error) error {

--- a/errors.go
+++ b/errors.go
@@ -117,7 +117,7 @@ func NewWrappedSystemError(code SystemErrCode, wrapped error) error {
 		return se
 	}
 
-	return SystemError{code: code, msg: fmt.Sprintf("sys err %x: %s", code, wrapped.Error()), wrapped: wrapped}
+	return SystemError{code: code, msg: fmt.Sprint(wrapped), wrapped: wrapped}
 }
 
 // Error returns the code and message, conforming to the error interface

--- a/inbound.go
+++ b/inbound.go
@@ -75,7 +75,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 
 	// Close may have been called between the time we checked the state and us creating the exchange.
 	if c.readState() != connectionActive {
-		mex.shutdown(nil)
+		mex.shutdown()
 		return true
 	}
 
@@ -377,6 +377,6 @@ func (response *InboundCallResponse) doneSending() {
 
 	// The message exchange is still open if there are no errors, call shutdown.
 	if response.err == nil {
-		response.mex.shutdown(nil)
+		response.mex.shutdown()
 	}
 }

--- a/inbound.go
+++ b/inbound.go
@@ -75,7 +75,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 
 	// Close may have been called between the time we checked the state and us creating the exchange.
 	if c.readState() != connectionActive {
-		mex.shutdown()
+		mex.shutdown(nil)
 		return true
 	}
 
@@ -184,8 +184,15 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 
 	// TODO(prashant): This is an expensive way to check for cancellation. Use a heap for timeouts.
 	go func() {
-		if <-call.mex.ctx.Done(); call.mex.ctx.Err() == context.DeadlineExceeded {
-			call.mex.inboundTimeout()
+		select {
+		case <-call.mex.ctx.Done():
+			if call.mex.ctx.Err() == context.DeadlineExceeded {
+				call.mex.inboundTimeout()
+			}
+		case <-call.mex.errCh.c:
+			if c.log.Enabled(LogLevelDebug) {
+				c.log.Debugf("Wait for timeout/cancellation interrupted by error: %v", call.mex.errCh.err)
+			}
 		}
 	}()
 
@@ -370,6 +377,6 @@ func (response *InboundCallResponse) doneSending() {
 
 	// The message exchange is still open if there are no errors, call shutdown.
 	if response.err == nil {
-		response.mex.shutdown()
+		response.mex.shutdown(nil)
 	}
 }

--- a/mex.go
+++ b/mex.go
@@ -232,7 +232,7 @@ func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, er
 // exchange set so  that it cannot receive more messages from the peer.  The
 // receive channel remains open, however, in case there are concurrent
 // goroutines sending to it.
-func (mex *messageExchange) shutdown(err error) {
+func (mex *messageExchange) shutdown() {
 	// The reader and writer side can both hit errors and try to shutdown the mex,
 	// so we ensure that it's only shut down once.
 	if !atomic.CompareAndSwapUint32(&mex.shutdownAtomic, 0, 1) {

--- a/outbound.go
+++ b/outbound.go
@@ -64,7 +64,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 
 	// Close may have been called between the time we checked the state and us creating the exchange.
 	if state := c.readState(); state != connectionStartClose && state != connectionActive {
-		mex.shutdown(nil)
+		mex.shutdown()
 		return nil, ErrConnectionClosed
 	}
 
@@ -356,5 +356,5 @@ func (response *OutboundCallResponse) doneReading(unexpected error) {
 		response.statsReporter.IncCounter("outbound.calls.success", response.commonStatsTags, 1)
 	}
 
-	response.mex.shutdown(nil)
+	response.mex.shutdown()
 }

--- a/outbound.go
+++ b/outbound.go
@@ -64,7 +64,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 
 	// Close may have been called between the time we checked the state and us creating the exchange.
 	if state := c.readState(); state != connectionStartClose && state != connectionActive {
-		mex.shutdown()
+		mex.shutdown(nil)
 		return nil, ErrConnectionClosed
 	}
 
@@ -356,5 +356,5 @@ func (response *OutboundCallResponse) doneReading(unexpected error) {
 		response.statsReporter.IncCounter("outbound.calls.success", response.commonStatsTags, 1)
 	}
 
-	response.mex.shutdown()
+	response.mex.shutdown(nil)
 }

--- a/reqres.go
+++ b/reqres.go
@@ -162,7 +162,7 @@ func (w *reqResWriter) failed(err error) error {
 		return w.err
 	}
 
-	w.mex.shutdown()
+	w.mex.shutdown(nil)
 	w.err = err
 	return w.err
 }
@@ -270,7 +270,7 @@ func (r *reqResReader) failed(err error) error {
 		return r.err
 	}
 
-	r.mex.shutdown()
+	r.mex.shutdown(nil)
 	r.err = err
 	return r.err
 }

--- a/reqres.go
+++ b/reqres.go
@@ -164,7 +164,7 @@ func (w *reqResWriter) failed(err error) error {
 		return w.err
 	}
 
-	w.mex.shutdown(nil)
+	w.mex.shutdown()
 	w.err = err
 	return w.err
 }
@@ -272,7 +272,7 @@ func (r *reqResReader) failed(err error) error {
 		return r.err
 	}
 
-	r.mex.shutdown(nil)
+	r.mex.shutdown()
 	r.err = err
 	return r.err
 }


### PR DESCRIPTION
There are 2 main fixes in this PR:
 * Make sure calls readers/writers are unblocked when a connection is closed (due to EOF or network error)
 * If an outbound stream receives EOF on the response stream, make sure the request stream gets an error

This is similar to #231 but fixes some more corner cases.

cc: @aravindvs @nomis52