### PR TITLE
SubChannel.SetHandler: override SubChannel Handlers

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -296,6 +296,13 @@ type Registrar interface {
 }
 
 // Register registers a handler for a method.
+//
+// The handler is registered with the service name used when the Channel was
+// created. To register a handler with a different service name, obtain a
+// SubChannel for that service with GetSubChannel, and Register a handler
+// under that. You may also use SetHandler on a SubChannel to set up a
+// catch-all Handler for that service. See the docs for SetHandler for more
+// information.
 func (ch *Channel) Register(h Handler, methodName string) {
 	ch.GetSubChannel(ch.PeerInfo().ServiceName).Register(h, methodName)
 }

--- a/channel.go
+++ b/channel.go
@@ -117,7 +117,6 @@ type Channel struct {
 	createdStack      string
 	commonStatsTags   map[string]string
 	connectionOptions ConnectionOptions
-	handlers          *handlerMap
 	peers             *PeerList
 
 	// mutable contains all the members of Channel which are mutable.
@@ -190,7 +189,6 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		},
 
 		connectionOptions: opts.DefaultConnectionOptions,
-		handlers:          &handlerMap{},
 	}
 	ch.peers = newRootPeerList(ch).newChild()
 
@@ -297,9 +295,9 @@ type Registrar interface {
 	Peers() *PeerList
 }
 
-// Register registers a handler for a service+method pair
+// Register registers a handler for a method.
 func (ch *Channel) Register(h Handler, methodName string) {
-	ch.handlers.register(h, ch.PeerInfo().ServiceName, methodName)
+	ch.GetSubChannel(ch.PeerInfo().ServiceName).Register(h, methodName)
 }
 
 // PeerInfo returns the current peer info for the channel

--- a/channel_test.go
+++ b/channel_test.go
@@ -24,11 +24,9 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func toMap(fields LogFields) map[string]interface{} {
@@ -110,104 +108,4 @@ func TestIsolatedSubChannelsDontSharePeers(t *testing.T) {
 	assert.NotNil(t, ch.peers.peersByHostPort["127.0.0.1:3000"])
 	assert.NotNil(t, sub.peers.peersByHostPort["127.0.0.1:3000"])
 	assert.Nil(t, isolatedSub.peers.peersByHostPort["127.0.0.1:3000"])
-}
-
-func TestSetHandler(t *testing.T) {
-	// Generate a Handler that expects only the given methods to be called.
-	genHandler := func(methods ...string) Handler {
-		allowedMethods := make(map[string]struct{}, len(methods))
-		for _, m := range methods {
-			allowedMethods[m] = struct{}{}
-		}
-
-		return HandlerFunc(func(ctx context.Context, call *InboundCall) {
-			method := call.MethodString()
-			assert.Contains(t, allowedMethods, method, "unexpected call to %q", method)
-
-			resp := call.Response()
-			require.NoError(t, NewArgWriter(resp.Arg2Writer()).Write(nil))
-			require.NoError(t, NewArgWriter(resp.Arg3Writer()).Write([]byte(method)))
-		})
-	}
-
-	ch, err := NewChannel("svc1", &ChannelOptions{
-		Logger: NewLogger(ioutil.Discard),
-	})
-	require.NoError(t, err, "NewChannel failed")
-
-	// Catch-all handler for the main channel that accepts foo, bar, and baz,
-	// and a single registered handler for a different subchannel.
-	ch.GetSubChannel("svc1").SetHandler(genHandler("foo", "bar", "baz"))
-	ch.GetSubChannel("svc2").Register(genHandler("foo"), "foo")
-	require.NoError(t, ch.ListenAndServe("127.0.0.1:0"), "ListenAndServe failed")
-	defer ch.Close()
-
-	client, err := NewChannel("client", &ChannelOptions{
-		Logger: NewLogger(ioutil.Discard),
-	})
-	require.NoError(t, err, "NewChannel failed")
-	client.Peers().Add(ch.PeerInfo().HostPort)
-
-	tests := []struct {
-		Service    string
-		Method     string
-		ShouldFail bool
-	}{
-		{"svc1", "foo", false},
-		{"svc1", "bar", false},
-		{"svc1", "baz", false},
-
-		{"svc2", "foo", false},
-		{"svc2", "bar", true},
-	}
-
-	for _, tt := range tests {
-		c := client.GetSubChannel(tt.Service)
-
-		ctx, _ := NewContext(1 * time.Second)
-		call, err := c.BeginCall(ctx, tt.Method, nil)
-		require.NoError(t, err, "BeginCall failed")
-		require.NoError(t, NewArgWriter(call.Arg2Writer()).Write(nil))
-		require.NoError(t, NewArgWriter(call.Arg3Writer()).Write([]byte("irrelevant")))
-
-		var data []byte
-		resp := call.Response()
-		if tt.ShouldFail {
-			require.Error(t, NewArgReader(resp.Arg2Reader()).Read(&data))
-			require.Error(t, NewArgReader(resp.Arg3Reader()).Read(&data))
-		} else {
-			require.NoError(t, NewArgReader(resp.Arg2Reader()).Read(&data))
-			require.NoError(t, NewArgReader(resp.Arg3Reader()).Read(&data))
-			assert.Equal(t, tt.Method, string(data))
-		}
-	}
-
-	st := ch.IntrospectState(nil)
-	assert.Equal(t, "overriden", st.SubChannels["svc1"].Handler.Type.String())
-	assert.Nil(t, st.SubChannels["svc1"].Handler.Methods)
-
-	assert.Equal(t, "methods", st.SubChannels["svc2"].Handler.Type.String())
-	assert.Equal(t, []string{"foo"}, st.SubChannels["svc2"].Handler.Methods)
-}
-
-func TestCannotRegisterAfterSetHandler(t *testing.T) {
-	ch, err := NewChannel("svc", &ChannelOptions{
-		Logger: NewLogger(ioutil.Discard),
-	})
-	require.NoError(t, err, "NewChannel failed")
-
-	someHandler := HandlerFunc(func(ctx context.Context, call *InboundCall) {
-		panic("unexpected call")
-	})
-
-	anotherHandler := HandlerFunc(func(ctx context.Context, call *InboundCall) {
-		panic("unexpected call")
-	})
-
-	ch.GetSubChannel("foo").SetHandler(someHandler)
-
-	// Registering against the original service should not panic but
-	// registering against the "foo" service should panic.
-	assert.NotPanics(t, func() { ch.Register(anotherHandler, "bar") })
-	assert.Panics(t, func() { ch.GetSubChannel("foo").Register(anotherHandler, "bar") })
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -24,9 +24,11 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func toMap(fields LogFields) map[string]interface{} {
@@ -108,4 +110,97 @@ func TestIsolatedSubChannelsDontSharePeers(t *testing.T) {
 	assert.NotNil(t, ch.peers.peersByHostPort["127.0.0.1:3000"])
 	assert.NotNil(t, sub.peers.peersByHostPort["127.0.0.1:3000"])
 	assert.Nil(t, isolatedSub.peers.peersByHostPort["127.0.0.1:3000"])
+}
+
+func TestSetHandler(t *testing.T) {
+	// Generate a Handler that expects only the given methods to be called.
+	genHandler := func(methods ...string) Handler {
+		allowedMethods := make(map[string]struct{}, len(methods))
+		for _, m := range methods {
+			allowedMethods[m] = struct{}{}
+		}
+
+		return HandlerFunc(func(ctx context.Context, call *InboundCall) {
+			method := call.MethodString()
+			assert.Contains(t, allowedMethods, method, "unexpected call to %q", method)
+
+			resp := call.Response()
+			require.NoError(t, NewArgWriter(resp.Arg2Writer()).Write(nil))
+			require.NoError(t, NewArgWriter(resp.Arg3Writer()).Write([]byte(method)))
+		})
+	}
+
+	ch, err := NewChannel("svc1", &ChannelOptions{
+		Logger: NewLogger(ioutil.Discard),
+	})
+	require.NoError(t, err, "NewChannel failed")
+
+	// Catch-all handler for the main channel that accepts foo, bar, and baz,
+	// and a single registered handler for a different subchannel.
+	ch.GetSubChannel("svc1").SetHandler(genHandler("foo", "bar", "baz"))
+	ch.GetSubChannel("svc2").Register(genHandler("foo"), "foo")
+	require.NoError(t, ch.ListenAndServe("127.0.0.1:0"), "ListenAndServe failed")
+	defer ch.Close()
+
+	client, err := NewChannel("client", &ChannelOptions{
+		Logger: NewLogger(ioutil.Discard),
+	})
+	require.NoError(t, err, "NewChannel failed")
+	client.Peers().Add(ch.PeerInfo().HostPort)
+
+	tests := []struct {
+		Service    string
+		Method     string
+		ShouldFail bool
+	}{
+		{"svc1", "foo", false},
+		{"svc1", "bar", false},
+		{"svc1", "baz", false},
+
+		{"svc2", "foo", false},
+		{"svc2", "bar", true},
+	}
+
+	for _, tt := range tests {
+		c := client.GetSubChannel(tt.Service)
+
+		ctx, _ := NewContext(1 * time.Second)
+		call, err := c.BeginCall(ctx, tt.Method, nil)
+		require.NoError(t, err, "BeginCall failed")
+		require.NoError(t, NewArgWriter(call.Arg2Writer()).Write(nil))
+		require.NoError(t, NewArgWriter(call.Arg3Writer()).Write([]byte("irrelevant")))
+
+		var data []byte
+		resp := call.Response()
+		if tt.ShouldFail {
+			require.Error(t, NewArgReader(resp.Arg2Reader()).Read(&data))
+			require.Error(t, NewArgReader(resp.Arg3Reader()).Read(&data))
+		} else {
+			require.NoError(t, NewArgReader(resp.Arg2Reader()).Read(&data))
+			require.NoError(t, NewArgReader(resp.Arg3Reader()).Read(&data))
+			assert.Equal(t, tt.Method, string(data))
+		}
+	}
+}
+
+func TestCannotRegisterAfterSetHandler(t *testing.T) {
+	ch, err := NewChannel("svc", &ChannelOptions{
+		Logger: NewLogger(ioutil.Discard),
+	})
+	require.NoError(t, err, "NewChannel failed")
+
+	someHandler := HandlerFunc(func(ctx context.Context, call *InboundCall) {
+		panic("unexpected call")
+	})
+
+	anotherHandler := HandlerFunc(func(ctx context.Context, call *InboundCall) {
+		panic("unexpected call")
+	})
+
+	ch.GetSubChannel("foo").SetHandler(someHandler)
+
+	// Registering against the original service should not panic but
+	// registering against the "foo" service should panic.
+	assert.NotPanics(t, func() { ch.Register(anotherHandler, "bar") })
+	assert.Panics(t, func() { ch.GetSubChannel("foo").Register(anotherHandler, "bar") })
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -181,6 +181,13 @@ func TestSetHandler(t *testing.T) {
 			assert.Equal(t, tt.Method, string(data))
 		}
 	}
+
+	st := ch.IntrospectState(nil)
+	assert.Equal(t, "overriden", st.SubChannels["svc1"].Handler.Type.String())
+	assert.Nil(t, st.SubChannels["svc1"].Handler.Methods)
+
+	assert.Equal(t, "methods", st.SubChannels["svc2"].Handler.Type.String())
+	assert.Equal(t, []string{"foo"}, st.SubChannels["svc2"].Handler.Methods)
 }
 
 func TestCannotRegisterAfterSetHandler(t *testing.T) {

--- a/connection.go
+++ b/connection.go
@@ -148,7 +148,7 @@ type Connection struct {
 	stateMut        sync.RWMutex
 	inbound         *messageExchangeSet
 	outbound        *messageExchangeSet
-	handlers        *handlerMap
+	handler         Handler
 	nextMessageID   uint32
 	events          connectionEvents
 	commonStatsTags map[string]string
@@ -254,7 +254,7 @@ func (ch *Channel) newConnection(conn net.Conn, initialState connectionState, ev
 		checksumType:    checksumType,
 		inbound:         newMessageExchangeSet(log, messageExchangeSetInbound),
 		outbound:        newMessageExchangeSet(log, messageExchangeSetOutbound),
-		handlers:        ch.handlers,
+		handler:         channelHandler{ch},
 		events:          events,
 		commonStatsTags: ch.commonStatsTags,
 	}

--- a/fragmentation_test.go
+++ b/fragmentation_test.go
@@ -393,7 +393,7 @@ func (ch fragmentChannel) flushFragment(fragment *writableFragment) error {
 func (ch fragmentChannel) recvNextFragment(initial bool) (*readableFragment, error) {
 	rbuf := typed.NewReadBuffer(<-ch)
 	fragment := new(readableFragment)
-	fragment.done = func() {}
+	fragment.onDone = func() {}
 	fragment.flags = rbuf.ReadSingleByte()
 	fragment.checksumType = ChecksumType(rbuf.ReadSingleByte())
 	fragment.checksum = rbuf.ReadBytes(fragment.checksumType.ChecksumSize())

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -44,7 +44,16 @@ type readableFragment struct {
 	checksumType ChecksumType
 	checksum     []byte
 	contents     *typed.ReadBuffer
-	done         func()
+	onDone       func()
+	isDone       bool
+}
+
+func (f *readableFragment) done() {
+	if f.isDone {
+		return
+	}
+	f.onDone()
+	f.isDone = true
 }
 
 type fragmentReceiver interface {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -33,8 +33,6 @@ func (dummyHandler) Handle(ctx context.Context, call *InboundCall) {}
 
 func TestHandlers(t *testing.T) {
 	const (
-		s1 = "s1"
-		s2 = "s2"
 		m1 = "m1"
 		m2 = "m2"
 	)
@@ -48,17 +46,14 @@ func TestHandlers(t *testing.T) {
 		m2b = []byte(m2)
 	)
 
-	assert.Nil(t, hmap.find(s1, m1b))
-	assert.Nil(t, hmap.find(s2, m1b))
-	assert.Nil(t, hmap.find(s1, m2b))
+	assert.Nil(t, hmap.find(m1b))
+	assert.Nil(t, hmap.find(m2b))
 
-	hmap.register(h1, s1, m1)
-	assert.Equal(t, h1, hmap.find(s1, m1b))
-	assert.Nil(t, hmap.find(s2, m1b))
-	assert.Nil(t, hmap.find(s1, m2b))
+	hmap.register(h1, m1)
+	assert.Equal(t, h1, hmap.find(m1b))
+	assert.Nil(t, hmap.find(m2b))
 
-	hmap.register(h2, s2, m1)
-	assert.Equal(t, h1, hmap.find(s1, m1b))
-	assert.Equal(t, h2, hmap.find(s2, m1b))
-	assert.Nil(t, hmap.find(s1, m2b))
+	hmap.register(h2, m2)
+	assert.Equal(t, h1, hmap.find(m1b))
+	assert.Equal(t, h2, hmap.find(m2b))
 }

--- a/introspection.go
+++ b/introspection.go
@@ -86,8 +86,24 @@ type SubChannelRuntimeState struct {
 	Service  string `json:"service"`
 	Isolated bool   `json:"isolated"`
 	// IsolatedPeers is the list of all isolated peers for this channel.
-	IsolatedPeers []SubPeerScore `json:"isolatedPeers,omitempty"`
+	IsolatedPeers []SubPeerScore      `json:"isolatedPeers,omitempty"`
+	Handler       HandlerRuntimeState `json:"handler"`
 }
+
+// HandlerRuntimeState TODO
+type HandlerRuntimeState struct {
+	Type    handlerType `json:"type"`
+	Methods []string    `json:"methods,omitempty"`
+}
+
+type handlerType string
+
+func (h handlerType) String() string { return string(h) }
+
+const (
+	methodHandler   handlerType = "methods"
+	overrideHandler             = "overriden"
+)
 
 // SubPeerScore show the runtime state of a peer with score.
 type SubPeerScore struct {
@@ -214,6 +230,16 @@ func (subChMap *subChannelMap) IntrospectState(opts *IntrospectionOptions) map[s
 		}
 		if state.Isolated {
 			state.IsolatedPeers = sc.Peers().IntrospectList(opts)
+		}
+		if hmap, ok := sc.handler.(*handlerMap); ok {
+			state.Handler.Type = methodHandler
+			methods := make([]string, 0, len(hmap.handlers))
+			for k := range hmap.handlers {
+				methods = append(methods, k)
+			}
+			state.Handler.Methods = methods
+		} else {
+			state.Handler.Type = overrideHandler
 		}
 		m[k] = state
 	}

--- a/reqres.go
+++ b/reqres.go
@@ -274,7 +274,7 @@ func parseInboundFragment(framePool FramePool, frame *Frame, message message) (*
 	fragment.checksumType = ChecksumType(rbuf.ReadSingleByte())
 	fragment.checksum = rbuf.ReadBytes(fragment.checksumType.ChecksumSize())
 	fragment.contents = rbuf
-	fragment.done = func() {
+	fragment.onDone = func() {
 		framePool.Release(frame)
 	}
 	return fragment, rbuf.Err()

--- a/reqres.go
+++ b/reqres.go
@@ -184,6 +184,7 @@ type reqResReader struct {
 	state              reqResReaderState
 	messageForFragment messageForFragment
 	initialFragment    *readableFragment
+	previousFragment   *readableFragment
 	log                Logger
 	err                error
 }
@@ -224,6 +225,7 @@ func (r *reqResReader) recvNextFragment(initial bool) (*readableFragment, error)
 	if r.initialFragment != nil {
 		fragment := r.initialFragment
 		r.initialFragment = nil
+		r.previousFragment = fragment
 		return fragment, nil
 	}
 
@@ -247,7 +249,18 @@ func (r *reqResReader) recvNextFragment(initial bool) (*readableFragment, error)
 		return nil, r.failed(err)
 	}
 
+	r.previousFragment = fragment
 	return fragment, nil
+}
+
+// releasePreviousFrament releases the last fragment returned by the reader if
+// it's still around. This operation is idempotent.
+func (r *reqResReader) releasePreviousFragment() {
+	fragment := r.previousFragment
+	r.previousFragment = nil
+	if fragment != nil {
+		fragment.done()
+	}
 }
 
 // failed indicates the reader failed

--- a/subchannel.go
+++ b/subchannel.go
@@ -123,9 +123,7 @@ func (c *SubChannel) Register(h Handler, methodName string) {
 // SetHandler() will be forgotten. Further calls to Register() on this
 // SubChannel after SetHandler() is called will cause panics.
 func (c *SubChannel) SetHandler(h Handler) {
-	c.Lock()
 	c.handler = h
-	c.Unlock()
 }
 
 // Logger returns the logger for this subchannel.

--- a/subchannel.go
+++ b/subchannel.go
@@ -110,7 +110,8 @@ func (c *SubChannel) Register(h Handler, methodName string) {
 	handlers, ok := c.handler.(*handlerMap)
 	if !ok {
 		panic(fmt.Sprintf(
-			"handler for SubChannel(%v) was changed to disallow method registration", c.ServiceName,
+			"handler for SubChannel(%v) was changed to disallow method registration",
+			c.ServiceName(),
 		))
 	}
 	handlers.register(h, methodName)

--- a/subchannel.go
+++ b/subchannel.go
@@ -21,6 +21,7 @@
 package tchannel
 
 import (
+	"fmt"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -46,7 +47,7 @@ type SubChannel struct {
 	topChannel         *Channel
 	defaultCallOptions *CallOptions
 	peers              *PeerList
-	handlers           *handlerMap
+	handler            Handler
 	logger             Logger
 	statsReporter      StatsReporter
 }
@@ -63,7 +64,7 @@ func newSubChannel(serviceName string, ch *Channel) *SubChannel {
 		serviceName:   serviceName,
 		peers:         ch.peers,
 		topChannel:    ch,
-		handlers:      &handlerMap{},
+		handler:       &handlerMap{}, // use handlerMap by default
 		logger:        logger,
 		statsReporter: ch.StatsReporter(),
 	}
@@ -101,9 +102,29 @@ func (c *SubChannel) Isolated() bool {
 	return c.topChannel.Peers() != c.peers
 }
 
-// Register registers a handler on the subchannel for a service+method pair
+// Register registers a handler on the subchannel for a method.
+//
+// This function panics if the Handler for the SubChannel was overwritten.
 func (c *SubChannel) Register(h Handler, methodName string) {
-	c.handlers.register(h, c.ServiceName(), methodName)
+	handlers, ok := c.handler.(*handlerMap)
+	if !ok {
+		panic(fmt.Sprintf(
+			"handler for SubChannel(%v) was changed to disallow method registration", c.ServiceName,
+		))
+	}
+	handlers.register(h, methodName)
+}
+
+// SetHandler changes the SubChannel's underlying handler. This may be used to
+// set up a catch-all Handler for all requests received by this SubChannel.
+//
+// Methods registered on this SubChannel using Register() before calling
+// SetHandler() will be forgotten. Further calls to Register() on this
+// SubChannel after SetHandler() is called will cause panics.
+func (c *SubChannel) SetHandler(h Handler) {
+	c.Lock()
+	c.handler = h
+	c.Unlock()
 }
 
 // Logger returns the logger for this subchannel.
@@ -121,15 +142,6 @@ func (c *SubChannel) StatsTags() map[string]string {
 	tags := c.topChannel.StatsTags()
 	tags["subchannel"] = c.serviceName
 	return tags
-}
-
-// Find if a handler for the given service+method pair exists
-func (subChMap *subChannelMap) find(serviceName string, method []byte) Handler {
-	if sc, ok := subChMap.get(serviceName); ok {
-		return sc.handlers.find(serviceName, method)
-	}
-
-	return nil
 }
 
 // Register a new subchannel for the given serviceName

--- a/subchannel.go
+++ b/subchannel.go
@@ -102,9 +102,10 @@ func (c *SubChannel) Isolated() bool {
 	return c.topChannel.Peers() != c.peers
 }
 
-// Register registers a handler on the subchannel for a method.
+// Register registers a handler on the subchannel for the given method.
 //
-// This function panics if the Handler for the SubChannel was overwritten.
+// This function panics if the Handler for the SubChannel was overwritten with
+// SetHandler.
 func (c *SubChannel) Register(h Handler, methodName string) {
 	handlers, ok := c.handler.(*handlerMap)
 	if !ok {

--- a/subchannel_test.go
+++ b/subchannel_test.go
@@ -127,8 +127,7 @@ func TestSetHandler(t *testing.T) {
 	}
 
 	ch := testutils.NewServer(t, testutils.NewOpts().
-		AddLogFilter("Couldn't find handler", 1, "serviceName", "svc2", "method", "bar"),
-	)
+		AddLogFilter("Couldn't find handler", 1, "serviceName", "svc2", "method", "bar"))
 
 	// Catch-all handler for the main channel that accepts foo, bar, and baz,
 	// and a single registered handler for a different subchannel.
@@ -155,11 +154,8 @@ func TestSetHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		c := client.GetSubChannel(tt.Service)
-
 		ctx, _ := tchannel.NewContext(time.Second)
-		call, err := c.BeginCall(ctx, tt.Method, nil)
-		require.NoError(t, err, "BeginCall failed")
-		_, data, _, err := raw.WriteArgs(call, nil, []byte("irrelevant"))
+		_, data, _, err := raw.CallSC(ctx, c, tt.Method, nil, []byte("irrelevant"))
 
 		if tt.ShouldFail {
 			require.Error(t, err)


### PR DESCRIPTION
Added `SubChannel.SetHandler` which makes it possible to set a catch-all
Handler for all requests to a SubChannel. Using `SetHandler()` makes
`Register()` useless and will cause a panic.

As part of this change:

- Removed redundant `handlerMap` from Channel. Always use `SubChannel`'s handler
  instead.
- Changed `handlerMap` to be a map of method name to handler
  (`map[string]Handler`) rather than map of service name to map of method name
  to handler (`map[string]map[string]Handler`). `SubChannel` dispatch based on service name
  happens in `channelHandler` now.
- Made `readableFragment.done()` idempotent.
- Ensure that the read last fragment is released when
  `InboundCallResponse.SendSystemError()` is called.