### PR TITLE
Introspection: Sort registered methods before returning

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -23,6 +23,7 @@ package tchannel
 import (
 	"encoding/json"
 	"runtime"
+	"sort"
 
 	"golang.org/x/net/context"
 )
@@ -237,6 +238,7 @@ func (subChMap *subChannelMap) IntrospectState(opts *IntrospectionOptions) map[s
 			for k := range hmap.handlers {
 				methods = append(methods, k)
 			}
+			sort.Strings(methods)
 			state.Handler.Methods = methods
 		} else {
 			state.Handler.Type = overrideHandler


### PR DESCRIPTION
TestNoLeakedState compares the introspected state between start and end.
Due to undefined map iteration order, the test saw different states and
failed. Sorting the methods avoids this issue

cc: @abhinav 