### PR TITLE
Detect if a handler returns a non-nil error type with nil value

### DIFF
--- a/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
+++ b/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
@@ -120,6 +120,9 @@ func (s *tchanAdminServer) handleClearAll(ctx thrift.Context, protocol athrift.T
 	if err != nil {
 		switch v := err.(type) {
 		case *NotAuthorized:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for notAuthorized returned non-nil error type *NotAuthorized but nil value")
+			}
 			res.NotAuthorized = v
 		default:
 			return false, nil, err
@@ -240,8 +243,14 @@ func (s *tchanKeyValueServer) handleGet(ctx thrift.Context, protocol athrift.TPr
 	if err != nil {
 		switch v := err.(type) {
 		case *KeyNotFound:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for notFound returned non-nil error type *KeyNotFound but nil value")
+			}
 			res.NotFound = v
 		case *InvalidKey:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for invalidKey returned non-nil error type *InvalidKey but nil value")
+			}
 			res.InvalidKey = v
 		default:
 			return false, nil, err
@@ -267,6 +276,9 @@ func (s *tchanKeyValueServer) handleSet(ctx thrift.Context, protocol athrift.TPr
 	if err != nil {
 		switch v := err.(type) {
 		case *InvalidKey:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for invalidKey returned non-nil error type *InvalidKey but nil value")
+			}
 			res.InvalidKey = v
 		default:
 			return false, nil, err

--- a/hyperbahn/gen-go/hyperbahn/tchan-hyperbahn.go
+++ b/hyperbahn/gen-go/hyperbahn/tchan-hyperbahn.go
@@ -100,8 +100,14 @@ func (s *tchanHyperbahnServer) handleDiscover(ctx thrift.Context, protocol athri
 	if err != nil {
 		switch v := err.(type) {
 		case *NoPeersAvailable:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for noPeersAvailable returned non-nil error type *NoPeersAvailable but nil value")
+			}
 			res.NoPeersAvailable = v
 		case *InvalidServiceName:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for invalidServiceName returned non-nil error type *InvalidServiceName but nil value")
+			}
 			res.InvalidServiceName = v
 		default:
 			return false, nil, err

--- a/thrift/gen-go/test/tchan-test.go
+++ b/thrift/gen-go/test/tchan-test.go
@@ -217,6 +217,9 @@ func (s *tchanSimpleServiceServer) handleSimple(ctx thrift.Context, protocol ath
 	if err != nil {
 		switch v := err.(type) {
 		case *SimpleErr:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for simpleErr returned non-nil error type *SimpleErr but nil value")
+			}
 			res.SimpleErr = v
 		default:
 			return false, nil, err

--- a/thrift/thrift-gen/tchannel-template.go
+++ b/thrift/thrift-gen/tchannel-template.go
@@ -162,6 +162,9 @@ func (s *{{ .ServerStruct }}) Handle(ctx {{ contextType }}, methodName string, p
 			switch v := err.(type) {
 				{{ range .Exceptions }}
 					case {{ .ArgType }}:
+						if v == nil {
+							return false, nil, fmt.Errorf("Handler for {{ .Name }} returned non-nil error type {{ .ArgType }} but nil value")
+						}
 						res.{{ .ArgStructName }} = v
 				{{ end }}
 					default:

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -151,6 +151,17 @@ func TestThriftError(t *testing.T) {
 	})
 }
 
+func TestThriftNilErr(t *testing.T) {
+	var thriftErr *gen.SimpleErr
+	withSetup(t, func(ctx Context, args testArgs) {
+		args.s1.On("Simple", ctxArg()).Return(thriftErr)
+		got := args.c1.Simple(ctx)
+		require.Error(t, got)
+		require.Contains(t, got.Error(), "non-nil error type")
+		require.Contains(t, got.Error(), "nil value")
+	})
+}
+
 func TestUnknownError(t *testing.T) {
 	withSetup(t, func(ctx Context, args testArgs) {
 		args.s1.On("Simple", ctxArg()).Return(errors.New("unexpected err"))


### PR DESCRIPTION
@abhinav: fyi, you might want to keep this in mind for yarpc/thriftrw.

Fixes #233