### PR TITLE
Improve GetConnection to avoid allocating a temporary slice

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -289,28 +289,52 @@ func (p *Peer) HostPort() string {
 	return p.hostPort
 }
 
-// getActive returns a list of active connections.
-// TODO(prashant): Should we clear inactive connections?
-func (p *Peer) getActive() []*Connection {
-	var active []*Connection
-	p.runWithConnections(func(c *Connection) {
-		if c.IsActive() {
-			active = append(active, c)
-		}
-	})
-	return active
+// getConn treats inbound and outbound connections as a single virtual list
+// that can be indexed. The peer must be read-locked.
+func (p *Peer) getConn(i int) *Connection {
+	inboundLen := len(p.inboundConnections)
+	if i < inboundLen {
+		return p.inboundConnections[i]
+	}
+
+	return p.outboundConnections[i-inboundLen]
 }
 
-func randConn(conns []*Connection) *Connection {
-	return conns[peerRng.Intn(len(conns))]
+func (p *Peer) getActiveConnLocked() (*Connection, bool) {
+	allConns := len(p.inboundConnections) + len(p.outboundConnections)
+	if allConns == 0 {
+		return nil, false
+	}
+
+	// We cycle through the connection list, starting at a random point
+	// to avoid always choosing the same connection.
+	startOffset := peerRng.Intn(allConns)
+	for i := 0; i < allConns; i++ {
+		connIndex := (i + startOffset) % allConns
+		if conn := p.getConn(connIndex); conn.IsActive() {
+			return conn, true
+		}
+	}
+
+	return nil, false
+}
+
+// getActiveConn will randomly select an active connection.
+// TODO(prashant): Should we clear inactive connections?
+// TODO(prashant): Do we want some sort of scoring for connections?
+func (p *Peer) getActiveConn() (*Connection, bool) {
+	p.RLock()
+	conn, ok := p.getActiveConnLocked()
+	p.RUnlock()
+
+	return conn, ok
 }
 
 // GetConnection returns an active connection to this peer. If no active connections
 // are found, it will create a new outbound connection and return it.
 func (p *Peer) GetConnection(ctx context.Context) (*Connection, error) {
-	// TODO(prashant): Use some sort of scoring to pick a connection.
-	if activeConns := p.getActive(); len(activeConns) > 0 {
-		return randConn(activeConns), nil
+	if activeConn, ok := p.getActiveConn(); ok {
+		return activeConn, nil
 	}
 
 	// No active connections, make a new outgoing connection.

--- a/peer_bench_test.go
+++ b/peer_bench_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/uber/tchannel-go"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+func benchmarkGetConnection(b *testing.B, numIncoming, numOutgoing int) {
+	ctx, cancel := NewContext(10 * time.Second)
+	defer cancel()
+
+	s1 := testutils.NewServer(b, nil)
+	s2 := testutils.NewServer(b, nil)
+	defer s1.Close()
+	defer s2.Close()
+
+	for i := 0; i < numOutgoing; i++ {
+		_, err := s1.Connect(ctx, s2.PeerInfo().HostPort)
+		require.NoError(b, err, "Connect from s1 -> s2 failed")
+	}
+	for i := 0; i < numIncoming; i++ {
+		_, err := s2.Connect(ctx, s1.PeerInfo().HostPort)
+		require.NoError(b, err, "Connect from s2 -> s1 failed")
+	}
+
+	peer := s1.Peers().GetOrAdd(s2.PeerInfo().HostPort)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		peer.GetConnection(ctx)
+	}
+}
+
+func BenchmarkGetConnection0In1Out(b *testing.B) { benchmarkGetConnection(b, 0, 1) }
+func BenchmarkGetConnection1In0Out(b *testing.B) { benchmarkGetConnection(b, 1, 0) }
+func BenchmarkGetConnection5In5Out(b *testing.B) { benchmarkGetConnection(b, 5, 5) }


### PR DESCRIPTION
`GetConnection` was creating a temporary slice with all active connections, then picking one of these randomly. Instead, we can iterate through the connections starting at a random index and pick the first active connection we find.