### PR TITLE
Clean up RelayItems & handle connection close

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -775,6 +775,7 @@ func (c *Connection) writeFrames(_ uint32) {
 // checkExchanges is called whenever an exchange is removed, and when Close is called.
 func (c *Connection) checkExchanges() {
 	c.callOnExchangeChange()
+
 	moveState := func(fromState, toState connectionState) bool {
 		err := c.withStateLock(func() error {
 			if c.state != fromState {
@@ -788,6 +789,11 @@ func (c *Connection) checkExchanges() {
 
 	var updated connectionState
 	if c.readState() == connectionStartClose {
+		if c.relay != nil {
+			if !c.relay.canClose() {
+				return
+			}
+		}
 		if c.inbound.count() == 0 && moveState(connectionStartClose, connectionInboundClosed) {
 			updated = connectionInboundClosed
 		}

--- a/connection.go
+++ b/connection.go
@@ -789,10 +789,8 @@ func (c *Connection) checkExchanges() {
 
 	var updated connectionState
 	if c.readState() == connectionStartClose {
-		if c.relay != nil {
-			if !c.relay.canClose() {
-				return
-			}
+		if !c.relay.canClose() {
+			return
 		}
 		if c.inbound.count() == 0 && moveState(connectionStartClose, connectionInboundClosed) {
 			updated = connectionInboundClosed

--- a/frame.go
+++ b/frame.go
@@ -186,20 +186,6 @@ func (f *Frame) Service() string {
 	return string(f.Payload[_serviceNameIndex : _serviceNameIndex+l])
 }
 
-// isLast indicates whether the frame has the continuation bit set.
-// TODO: move to relay
-// DONTCOMMIT
-func (f *Frame) isLast() bool {
-	switch f.messageType() {
-	case messageTypeCallRes, messageTypeCallResContinue:
-		flags := f.Payload[_flagsIndex]
-		return flags&hasMoreFragmentsFlag == 0
-	default:
-		// This message type can't be continued.
-		return false
-	}
-}
-
 func (f *Frame) write(msg message) error {
 	var wbuf typed.WriteBuffer
 	wbuf.Wrap(f.Payload[:])

--- a/frame.go
+++ b/frame.go
@@ -187,9 +187,11 @@ func (f *Frame) Service() string {
 }
 
 // isLast indicates whether the frame has the continuation bit set.
+// TODO: move to relay
+// DONTCOMMIT
 func (f *Frame) isLast() bool {
 	switch f.messageType() {
-	case messageTypeCallReq, messageTypeCallRes, messageTypeCallResContinue, messageTypeCallReqContinue:
+	case messageTypeCallRes, messageTypeCallResContinue:
 		flags := f.Payload[_flagsIndex]
 		return flags&hasMoreFragmentsFlag == 0
 	default:

--- a/frame_test.go
+++ b/frame_test.go
@@ -162,30 +162,6 @@ func TestServiceCallReqTerrible(t *testing.T) {
 	assert.Equal(t, "bankmoji", f.Service(), "Failed to read service name from frame.")
 }
 
-func TestFrameFlags(t *testing.T) {
-	// TODO: Same as TestServiceCallReq, above.
-	tests := []struct {
-		flags  byte
-		isLast bool
-	}{
-		{0x00, true},
-		{0x01, false},
-		{0x02, true},
-		{0x03, false},
-		{0x04, true},
-	}
-	for _, tt := range tests {
-		f := NewFrame(100)
-		fh := fakeHeader()
-		f.Header = fh
-		fh.write(typed.NewWriteBuffer(f.headerBuffer))
-
-		payload := typed.NewWriteBuffer(f.Payload)
-		payload.WriteSingleByte(tt.flags)
-		assert.Equal(t, tt.isLast, f.isLast(), "Wrong isLast for flags %v", tt.flags)
-	}
-}
-
 func TestServiceOtherMessages(t *testing.T) {
 	msg := &initReq{initMessage{id: 1, Version: 0x1, initParams: initParams{
 		InitParamHostPort:    "0.0.0.0:0",

--- a/relay.go
+++ b/relay.go
@@ -77,11 +77,12 @@ func (r *Relayer) Receive(f *Frame) {
 
 func (r *Relayer) handleCallReq(f *Frame) error {
 	r.RLock()
-	if _, ok := r.items[f.Header.ID]; ok {
-		r.RUnlock()
+	_, ok := r.items[f.Header.ID]
+	r.RUnlock()
+
+	if ok {
 		return errors.New("callReq with already active ID")
 	}
-	r.RUnlock()
 
 	// Get the destination
 	svc := f.Service()
@@ -153,6 +154,9 @@ func (r *Relayer) removeRelayItem(id uint32) {
 }
 
 func (r *Relayer) canClose() bool {
+	if r == nil {
+		return true
+	}
 	return r.countPending() == 0
 }
 

--- a/relay.go
+++ b/relay.go
@@ -118,11 +118,12 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	if !ok {
 		return errors.New("non-callReq for inactive ID")
 	}
+	originalID := f.Header.ID
 	f.Header.ID = item.remapID
 	item.destination.Receive(f)
 
 	if finishesCall(f) {
-		r.removeRelayItem(f.Header.ID)
+		r.removeRelayItem(originalID)
 	}
 	return nil
 }

--- a/relay.go
+++ b/relay.go
@@ -72,9 +72,12 @@ func (r *Relayer) Receive(f *Frame) {
 }
 
 func (r *Relayer) handleCallReq(f *Frame) error {
+	r.RLock()
 	if _, ok := r.items[f.Header.ID]; ok {
+		r.RUnlock()
 		return errors.New("callReq with already active ID")
 	}
+	r.RUnlock()
 
 	// Get the destination
 	svc := f.Service()

--- a/relay.go
+++ b/relay.go
@@ -167,8 +167,7 @@ func finishesCall(f *Frame) bool {
 	case messageTypeCallRes, messageTypeCallResContinue:
 		flags := f.Payload[_flagsIndex]
 		return flags&hasMoreFragmentsFlag == 0
-	case messageTypeError:
-		return true
+	// TODO: errors should also terminate an RPC.
 	default:
 		return false
 	}

--- a/relay.go
+++ b/relay.go
@@ -63,10 +63,14 @@ func (r *Relayer) Receive(f *Frame) {
 	r.RLock()
 	_, ok := r.items[f.Header.ID]
 	r.RUnlock()
+	if !ok {
+		r.logger.WithFields(
+			LogField{"ID", f.Header.ID},
+		).Warn("Received a frame without a RelayItem.")
+	}
 
 	r.conn.sendCh <- f
-
-	if ok && finishesCall(f) {
+	if finishesCall(f) {
 		r.removeRelayItem(f.Header.ID)
 	}
 }

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -1,0 +1,47 @@
+package tchannel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/typed"
+)
+
+func TestFinishesCallResponses(t *testing.T) {
+	tests := []struct {
+		msgType      messageType
+		flags        byte
+		finishesCall bool
+	}{
+		{messageTypeCallRes, 0x00, true},
+		{messageTypeCallRes, 0x01, false},
+		{messageTypeCallRes, 0x02, true},
+		{messageTypeCallRes, 0x03, false},
+		{messageTypeCallRes, 0x04, true},
+		{messageTypeCallResContinue, 0x00, true},
+		{messageTypeCallResContinue, 0x01, false},
+		{messageTypeCallResContinue, 0x02, true},
+		{messageTypeCallResContinue, 0x03, false},
+		{messageTypeCallResContinue, 0x04, true},
+		// By definition, callreq should never terminate an RPC.
+		{messageTypeCallReq, 0x00, false},
+		{messageTypeCallReq, 0x01, false},
+		{messageTypeCallReq, 0x02, false},
+		{messageTypeCallReq, 0x03, false},
+		{messageTypeCallReq, 0x04, false},
+	}
+	for _, tt := range tests {
+		f := NewFrame(100)
+		fh := FrameHeader{
+			size:        uint16(0xFF34),
+			messageType: tt.msgType,
+			ID:          0xDEADBEEF,
+		}
+		f.Header = fh
+		fh.write(typed.NewWriteBuffer(f.headerBuffer))
+
+		payload := typed.NewWriteBuffer(f.Payload)
+		payload.WriteSingleByte(tt.flags)
+		assert.Equal(t, tt.finishesCall, finishesCall(f), "Wrong isLast for flags %v and message type %v", tt.flags, tt.msgType)
+	}
+}

--- a/relay_test.go
+++ b/relay_test.go
@@ -94,7 +94,7 @@ func TestRelayConnectionCloseDrainsRelayItems(t *testing.T) {
 		testutils.RegisterEcho(server, func() {
 			// Handler should close the connection to the relay.
 			conn, err := relay.Peers().GetOrAdd(clientHP).GetConnection(ctx)
-			require.NoError(t, err, "TODO")
+			require.NoError(t, err, "Unexpected failure getting a connection to the client.")
 			conn.Close()
 		})
 


### PR DESCRIPTION
Count in-progress RPCs on each side of a relayer, and make some attempt to avoid closing connections when RPCs are in progress. This is just step 1 - there are lots of situations that this simple code won't handle.