### PR TITLE
Fail lint when FIXMEs are left behind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ lint:
 	-go tool vet $(PKGS) 2>&1 | tee -a lint.log
 	@echo "Checking gofmt"
 	-[ $(GO_VERSION) != "go1.5" ] || gofmt -d . | tee -a lint.log
+	@echo "Checking for unresolved FIXMEs"
+	-git grep -i fixme | grep -v -e Godeps -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]
 
 thrift_example: thrift_gen


### PR DESCRIPTION
We typically use TODOs to track future work. While we're hacking,
though, it's helpful to cut some corners (error messages, comments, test
handling, etc). Now, we can mark those bits of code with a FIXME and be
sure that the branch won't be merged until they're fixed.