### PR TITLE
Run linters only on Go 1.5.x and 1.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ go:
   - 1.4
   - 1.5
   - 1.6
-  # Don't test on tip until Go 1.7 is in feature freeze (Jul 01 2016)
-  # - tip
+  - tip
 install: make install_ci
 script:
  - make test_ci
  - make cover_ci
- # Travis restores Godeps to the workspace, which we want to ignore from lint.
- - rm -rf Godeps/_workspace/src
  - make lint
 

--- a/Makefile
+++ b/Makefile
@@ -95,18 +95,18 @@ cover_ci: cover_profile
 	goveralls -coverprofile=$(BUILD)/coverage.out -service=travis-ci
 
 
-FILTER := grep -v -e '_string.go' -e '/gen-go/' -e '/mocks/'
+FILTER := grep -v -e '_string.go' -e '/gen-go/' -e '/mocks/' -e 'Godeps/' -e 'vendor/'
 lint:
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 	@echo "Linters are enabled on Go version" $(GO_VERSION)
 	@echo "Running golint"
 	-golint ./... | $(FILTER) | tee lint.log
 	@echo "Running go vet"
-	-go tool vet $(PKGS) 2>&1 | tee -a lint.log
+	-go tool vet $(PKGS) 2>&1 | $(FILTER) | tee -a lint.log
 	@echo "Checking gofmt"
 	-[ $(GO_VERSION) != "go1.5" ] || gofmt -d . | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs"
-	-git grep -i fixme | grep -v -e Godeps -e vendor -e Makefile | tee -a lint.log
+	-git grep -i fixme | $(FILTER) | grep -v -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]
 else
 	@echo "Not running linters on Go version" $(GO_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GODEPS := $(shell pwd)/Godeps/_workspace
 GO_VERSION := $(shell go version | awk '{ print $$3 }')
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
 LINTABLE_MINOR_VERSIONS := 5 6
+FMTABLE_MINOR_VERSION := 5
 OLDGOPATH := $(GOPATH)
 PATH := $(GODEPS)/bin:$(PATH)
 EXAMPLES=./examples/bench/server ./examples/bench/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server
@@ -104,7 +105,7 @@ ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 	@echo "Running go vet"
 	-go tool vet $(PKGS) 2>&1 | $(FILTER) | tee -a lint.log
 	@echo "Checking gofmt"
-	-[ $(GO_VERSION) != "go1.5" ] || gofmt -d . | tee -a lint.log
+	-[ $(GO_MINOR_VERSION) != $(FMTABLE_MINOR_VERSION) ] || gofmt -d . | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs"
 	-git grep -i fixme | $(FILTER) | grep -v -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ ifdef SHOULD_LINT
 	-go vet $(PKGS) 2>&1 | tee -a lint.log
 ifdef SHOULD_LINT_FMT
 	@echo "Checking gofmt"
-	-gofmt -l -s . | $(FILTER) | tee -a lint.log
+	-gofmt -l . | $(FILTER) | tee -a lint.log
 else
 	@echo "Not checking gofmt on" $(GO_VERSION)
 endif

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,12 @@ get_thrift:
 
 install:
 	GOPATH=$(GODEPS) go get github.com/tools/godep
-	GOPATH=$(GODEPS) go get github.com/golang/lint/golint
 	GOPATH=$(GODEPS) godep restore -v
+ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
+	GOPATH=$(GODEPS) go get github.com/golang/lint/golint
+else
+	@echo "Not installing golint, since we don't lint on" $(GO_VERSION)
+endif
 
 install_ci: get_thrift install
 	go get -u github.com/mattn/goveralls
@@ -110,7 +114,7 @@ ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 	-git grep -i fixme | $(FILTER) | grep -v -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]
 else
-	@echo "Not running linters on Go version" $(GO_VERSION)
+	@echo "Skipping linters on Go version" $(GO_VERSION)
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 GODEPS := $(shell pwd)/Godeps/_workspace
 GO_VERSION := $(shell go version | awk '{ print $$3 }')
+GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
+LINTABLE_MINOR_VERSIONS := 5 6
 OLDGOPATH := $(GOPATH)
 PATH := $(GODEPS)/bin:$(PATH)
 EXAMPLES=./examples/bench/server ./examples/bench/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server
@@ -95,6 +97,8 @@ cover_ci: cover_profile
 
 FILTER := grep -v -e '_string.go' -e '/gen-go/' -e '/mocks/'
 lint:
+ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
+	@echo "Linters are enabled on Go version" $(GO_VERSION)
 	@echo "Running golint"
 	-golint ./... | $(FILTER) | tee lint.log
 	@echo "Running go vet"
@@ -104,6 +108,10 @@ lint:
 	@echo "Checking for unresolved FIXMEs"
 	-git grep -i fixme | grep -v -e Godeps -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]
+else
+	@echo "Not running linters on Go version" $(GO_VERSION)
+endif
+
 
 thrift_example: thrift_gen
 	go build -o $(BUILD)/examples/thrift       ./examples/thrift/main.go

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 	@echo "Running go vet"
 	-go tool vet $(PKGS) 2>&1 | $(FILTER) | tee -a lint.log
 	@echo "Checking gofmt"
-	-[ $(GO_MINOR_VERSION) != $(FMTABLE_MINOR_VERSION) ] || gofmt -d . | tee -a lint.log
+	-[ $(GO_MINOR_VERSION) != $(FMTABLE_MINOR_VERSION) ] || gofmt -l -s . | $(FILTER) | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs"
 	-git grep -i fixme | $(FILTER) | grep -v -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GODEPS := $(shell pwd)/Godeps/_workspace
 GO_VERSION := $(shell go version | awk '{ print $$3 }')
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
 LINTABLE_MINOR_VERSIONS := 5 6
-FMTABLE_MINOR_VERSION := 5
+FMTABLE_MINOR_VERSIONS := 5
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif
@@ -115,7 +115,7 @@ ifdef SHOULD_LINT
 	@echo "Running golint"
 	-golint ./... | $(FILTER) | tee lint.log
 	@echo "Running go vet"
-	-go tool vet $(PKGS) 2>&1 | $(FILTER) | tee -a lint.log
+	-go vet $(PKGS) 2>&1 | tee -a lint.log
 ifdef SHOULD_LINT_FMT
 	@echo "Checking gofmt"
 	-gofmt -l -s . | $(FILTER) | tee -a lint.log

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GODEPS := $(shell pwd)/Godeps/_workspace
 GO_VERSION := $(shell go version | awk '{ print $$3 }')
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
 LINTABLE_MINOR_VERSIONS := 5 6
-FMTABLE_MINOR_VERSIONS := 5
+FMTABLE_MINOR_VERSIONS := 6
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif

--- a/connection_test.go
+++ b/connection_test.go
@@ -555,7 +555,7 @@ func TestReadTimeout(t *testing.T) {
 		AddLogFilter("Connection error", 1, "site", "read frames").
 		AddLogFilter("Connection error", 1, "site", "write frames").
 		AddLogFilter("simpleHandler OnError", 1,
-		"error", "failed to send error frame, connection state connectionClosed")
+			"error", "failed to send error frame, connection state connectionClosed")
 	WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 		for i := 0; i < 10; i++ {
 			ctx, cancel := NewContext(time.Second)

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -88,8 +88,8 @@ func TestRetryRequest(t *testing.T) {
 		count := 0
 		args.s1.On("Simple", ctxArg()).Return(tchannel.ErrServerBusy).
 			Run(func(args mock.Arguments) {
-			count++
-		})
+				count++
+			})
 		require.Error(t, args.c1.Simple(ctx), "Simple expected to fail")
 		assert.Equal(t, 5, count, "Expected Simple to be retried 5 times")
 	})


### PR DESCRIPTION
With some Make-fu, we can run the linters only if we're using Go 1.5.x or Go 1.6.x. This allows us to continue running the test suite on Go 1.4 and tip.

This diff also expands our lint filters to hide errors in dependencies, which should let us remove the hack that deletes vendored code before linting.