### PR TITLE
Use our wrappers for all atomic operations

### DIFF
--- a/atomic/atomic.go
+++ b/atomic/atomic.go
@@ -27,6 +27,11 @@ import "sync/atomic"
 // Int32 is an atomic wrapper around an int32.
 type Int32 struct{ int32 }
 
+// NewInt32 creates an Int32.
+func NewInt32(i int32) *Int32 {
+	return &Int32{i}
+}
+
 // Load atomically loads the wrapped value.
 func (i *Int32) Load() int32 {
 	return atomic.LoadInt32(&i.int32)
@@ -64,6 +69,11 @@ func (i *Int32) Swap(n int32) int32 {
 
 // Int64 is an atomic wrapper around an int64.
 type Int64 struct{ int64 }
+
+// NewInt64 creates an Int64.
+func NewInt64(i int64) *Int64 {
+	return &Int64{i}
+}
 
 // Load atomically loads the wrapped value.
 func (i *Int64) Load() int64 {
@@ -103,6 +113,11 @@ func (i *Int64) Swap(n int64) int64 {
 // Uint32 is an atomic wrapper around an uint32.
 type Uint32 struct{ uint32 }
 
+// NewUint32 creates a Uint32.
+func NewUint32(i uint32) *Uint32 {
+	return &Uint32{i}
+}
+
 // Load atomically loads the wrapped value.
 func (i *Uint32) Load() uint32 {
 	return atomic.LoadUint32(&i.uint32)
@@ -140,6 +155,11 @@ func (i *Uint32) Swap(n uint32) uint32 {
 
 // Uint64 is an atomic wrapper around a uint64.
 type Uint64 struct{ uint64 }
+
+// NewUint64 creates a Uint64.
+func NewUint64(i uint64) *Uint64 {
+	return &Uint64{i}
+}
 
 // Load atomically loads the wrapped value.
 func (i *Uint64) Load() uint64 {

--- a/atomic/atomic_test.go
+++ b/atomic/atomic_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestInt32(t *testing.T) {
-	atom := &Int32{42}
+	atom := NewInt32(42)
 
 	require.Equal(t, int32(42), atom.Load(), "Load didn't work.")
 	require.Equal(t, int32(44), atom.Add(2), "Add didn't work.")
@@ -45,7 +45,7 @@ func TestInt32(t *testing.T) {
 }
 
 func TestInt64(t *testing.T) {
-	atom := &Int64{42}
+	atom := NewInt64(42)
 
 	require.Equal(t, int64(42), atom.Load(), "Load didn't work.")
 	require.Equal(t, int64(44), atom.Add(2), "Add didn't work.")
@@ -63,7 +63,7 @@ func TestInt64(t *testing.T) {
 }
 
 func TestUint32(t *testing.T) {
-	atom := &Uint32{42}
+	atom := NewUint32(42)
 
 	require.Equal(t, uint32(42), atom.Load(), "Load didn't work.")
 	require.Equal(t, uint32(44), atom.Add(2), "Add didn't work.")
@@ -81,7 +81,7 @@ func TestUint32(t *testing.T) {
 }
 
 func TestUint64(t *testing.T) {
-	atom := &Uint64{42}
+	atom := NewUint64(42)
 
 	require.Equal(t, uint64(42), atom.Load(), "Load didn't work.")
 	require.Equal(t, uint64(44), atom.Add(2), "Add didn't work.")

--- a/examples/bench/client/client.go
+++ b/examples/bench/client/client.go
@@ -42,7 +42,7 @@ var (
 	getToSetRatio = flag.Int("getToSetRatio", 1, "The number of Gets to do per Set call")
 
 	// counter tracks the total number of requests completed in the past second.
-	counter = &atomic.Int64{}
+	counter = atomic.Int64{}
 )
 
 func main() {

--- a/examples/bench/client/client.go
+++ b/examples/bench/client/client.go
@@ -26,10 +26,10 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"runtime"
-	"sync/atomic"
 	"time"
 
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
 	"github.com/uber/tchannel-go/raw"
 	"golang.org/x/net/context"
 )
@@ -42,7 +42,7 @@ var (
 	getToSetRatio = flag.Int("getToSetRatio", 1, "The number of Gets to do per Set call")
 
 	// counter tracks the total number of requests completed in the past second.
-	counter int64
+	counter = &atomic.Int64{}
 )
 
 func main() {
@@ -70,7 +70,7 @@ func main() {
 func requestCountReporter() {
 	for {
 		time.Sleep(time.Second)
-		cur := atomic.SwapInt64(&counter, int64(0))
+		cur := counter.Swap(0)
 		log.Printf("%v requests", cur)
 	}
 }
@@ -82,14 +82,14 @@ func worker(ch *tchannel.Channel) {
 			log.Fatalf("set failed: %v", err)
 			continue
 		}
-		atomic.AddInt64(&counter, 1)
+		counter.Inc()
 
 		for i := 0; i < *getToSetRatio; i++ {
 			_, err := getRequest(ch, "key")
 			if err != nil {
 				log.Fatalf("get failed: %v", err)
 			}
-			atomic.AddInt64(&counter, 1)
+			counter.Inc()
 		}
 	}
 }

--- a/frame_pool_b_test.go
+++ b/frame_pool_b_test.go
@@ -33,7 +33,7 @@ func benchmarkUsing(b *testing.B, pool FramePool) {
 	const numGoroutines = 1000
 	const maxHoldFrames = 1000
 
-	gotFrames := &atomic.Uint64{}
+	gotFrames := atomic.Uint64{}
 
 	var wg sync.WaitGroup
 	for i := 0; i < numGoroutines; i++ {

--- a/frame_pool_b_test.go
+++ b/frame_pool_b_test.go
@@ -23,17 +23,17 @@ package tchannel_test
 import (
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	. "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
 )
 
 func benchmarkUsing(b *testing.B, pool FramePool) {
 	const numGoroutines = 1000
 	const maxHoldFrames = 1000
 
-	var gotFrames uint64
+	gotFrames := &atomic.Uint64{}
 
 	var wg sync.WaitGroup
 	for i := 0; i < numGoroutines; i++ {
@@ -41,12 +41,12 @@ func benchmarkUsing(b *testing.B, pool FramePool) {
 		go func() {
 
 			for {
-				if atomic.LoadUint64(&gotFrames) > uint64(b.N) {
+				if gotFrames.Load() > uint64(b.N) {
 					break
 				}
 
 				framesToHold := rand.Intn(maxHoldFrames)
-				atomic.AddUint64(&gotFrames, uint64(framesToHold))
+				gotFrames.Add(uint64(framesToHold))
 
 				frames := make([]*Frame, framesToHold)
 				for i := 0; i < framesToHold; i++ {

--- a/introspection.go
+++ b/introspection.go
@@ -268,7 +268,7 @@ func (p *Peer) IntrospectState(opts *IntrospectionOptions) PeerRuntimeState {
 		HostPort:            p.hostPort,
 		InboundConnections:  getConnectionRuntimeState(p.inboundConnections, opts),
 		OutboundConnections: getConnectionRuntimeState(p.outboundConnections, opts),
-		ChosenCount:         p.chosenCount,
+		ChosenCount:         p.chosenCount.Load(),
 		SCCount:             p.scCount,
 	}
 }

--- a/peer.go
+++ b/peer.go
@@ -24,8 +24,9 @@ import (
 	"container/heap"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"github.com/uber/tchannel-go/atomic"
 
 	"golang.org/x/net/context"
 )
@@ -178,7 +179,7 @@ func (l *PeerList) choosePeer(prevSelected map[string]struct{}, avoidHost bool) 
 	}
 
 	l.peerHeap.pushPeer(ps)
-	atomic.AddUint64(&ps.chosenCount, 1)
+	ps.chosenCount.Inc()
 	return ps.Peer
 }
 
@@ -267,7 +268,7 @@ type Peer struct {
 	// connections are mutable, and are protected by the mutex.
 	inboundConnections  []*Connection
 	outboundConnections []*Connection
-	chosenCount         uint64
+	chosenCount         atomic.Uint64
 
 	// onUpdate is a test-only hook.
 	onUpdate func(*Peer)

--- a/peer_heap.go
+++ b/peer_heap.go
@@ -23,15 +23,15 @@ package tchannel
 import (
 	"container/heap"
 	"math/rand"
-	"sync/atomic"
 	"time"
 )
 
-// peerHeap maintains a min-heap of peers based on the peers' score.
+// peerHeap maintains a min-heap of peers based on the peers' score. All method
+// calls must be serialized externally.
 type peerHeap struct {
 	peerScores []*peerScore
 	rng        *rand.Rand
-	order      uint64 // atomic
+	order      uint64
 }
 
 func newPeerHeap() *peerHeap {
@@ -88,7 +88,8 @@ func (ph *peerHeap) popPeer() *peerScore {
 
 // pushPeer pushes the new peer into the heap.
 func (ph *peerHeap) pushPeer(peerScore *peerScore) {
-	newOrder := atomic.AddUint64(&ph.order, 1)
+	ph.order++
+	newOrder := ph.order
 	// randRange will affect the deviation of peer's chosenCount
 	randRange := ph.Len()/2 + 1
 	peerScore.order = newOrder + uint64(ph.rng.Intn(randRange))

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -23,10 +23,11 @@ package testutils
 import (
 	"fmt"
 	"net"
-	"sync/atomic"
 
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
 	"github.com/uber/tchannel-go/raw"
+
 	"golang.org/x/net/context"
 )
 
@@ -59,7 +60,7 @@ func NewServerChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 	return ch, nil
 }
 
-var totalClients uint32
+var totalClients = &atomic.Uint32{}
 
 // NewClientChannel creates a TChannel that is not listening.
 func NewClientChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
@@ -67,7 +68,7 @@ func NewClientChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 		opts = &ChannelOpts{}
 	}
 
-	clientNum := atomic.AddUint32(&totalClients, 1)
+	clientNum := totalClients.Inc()
 	serviceName := defaultString(opts.ServiceName, DefaultClientName)
 	opts.ProcessName = defaultString(opts.ProcessName, serviceName+"-"+fmt.Sprint(clientNum))
 	return tchannel.NewChannel(serviceName, getChannelOptions(opts))

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -60,7 +60,7 @@ func NewServerChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 	return ch, nil
 }
 
-var totalClients = &atomic.Uint32{}
+var totalClients = atomic.Uint32{}
 
 // NewClientChannel creates a TChannel that is not listening.
 func NewClientChannel(opts *ChannelOpts) (*tchannel.Channel, error) {

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
 )
 
 var connectionLog = flag.Bool("connectionLog", false, "Enables connection logging in tests")
@@ -172,6 +173,6 @@ func DefaultOpts(opts *ChannelOpts) *ChannelOpts {
 // WrapLogger wraps the given logger with extra verification.
 func (v *LogVerification) WrapLogger(t testing.TB, l tchannel.Logger) tchannel.Logger {
 	return errorLogger{l, t, v, &errorLoggerState{
-		matchCount: make([]uint32, len(v.Filters)),
+		matchCount: make([]atomic.Uint32, len(v.Filters)),
 	}}
 }

--- a/testutils/counter.go
+++ b/testutils/counter.go
@@ -22,16 +22,16 @@ package testutils
 
 import (
 	"sync"
-	"sync/atomic"
+
+	"github.com/uber/tchannel-go/atomic"
 )
 
 // Decrementor returns a function that can be called from multiple goroutines and ensures
 // it will only return true n times.
 func Decrementor(n int) func() bool {
-	n64 := int64(n)
+	n64 := atomic.NewInt64(int64(n))
 	return func() bool {
-		newN := atomic.AddInt64(&n64, -1)
-		return newN >= 0
+		return n64.Dec() >= 0
 	}
 }
 

--- a/testutils/logger.go
+++ b/testutils/logger.go
@@ -23,10 +23,10 @@ package testutils
 import (
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
 )
 
 // Matches returns true if the message and fields match the filter.
@@ -61,7 +61,7 @@ func (f LogFilter) Matches(msg string, fields tchannel.LogFields) bool {
 }
 
 type errorLoggerState struct {
-	matchCount []uint32
+	matchCount []atomic.Uint32
 }
 
 type errorLogger struct {
@@ -84,7 +84,7 @@ func (l errorLogger) checkFilters(msg string) bool {
 		return false
 	}
 
-	matchCount := atomic.AddUint32(&l.s.matchCount[match], 1)
+	matchCount := l.s.matchCount[match].Inc()
 	return uint(matchCount) <= l.v.Filters[match].Count
 }
 func (l errorLogger) checkErr(prefix, msg string) {

--- a/testutils/relay.go
+++ b/testutils/relay.go
@@ -22,12 +22,13 @@ package testutils
 
 import (
 	"net"
-	"sync/atomic"
 	"testing"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
 )
 
 type frameRelay struct {
@@ -37,7 +38,7 @@ type frameRelay struct {
 }
 
 func (r frameRelay) listen() (listenHostPort string, cancel func()) {
-	closed := uint32(0)
+	closed := &atomic.Uint32{}
 
 	conn, err := net.Listen("tcp", ":0")
 	require.NoError(r.t, err, "net.Listen failed")
@@ -46,7 +47,7 @@ func (r frameRelay) listen() (listenHostPort string, cancel func()) {
 		for {
 			c, err := conn.Accept()
 			if err != nil {
-				if atomic.LoadUint32(&closed) == 0 {
+				if closed.Load() == 0 {
 					r.t.Errorf("Accept failed: %v", err)
 				}
 				return
@@ -57,7 +58,7 @@ func (r frameRelay) listen() (listenHostPort string, cancel func()) {
 	}()
 
 	return conn.Addr().String(), func() {
-		atomic.AddUint32(&closed, 1)
+		closed.Inc()
 		conn.Close()
 	}
 }

--- a/testutils/relay.go
+++ b/testutils/relay.go
@@ -38,7 +38,7 @@ type frameRelay struct {
 }
 
 func (r frameRelay) listen() (listenHostPort string, cancel func()) {
-	closed := &atomic.Uint32{}
+	closed := atomic.Uint32{}
 
 	conn, err := net.Listen("tcp", ":0")
 	require.NoError(r.t, err, "net.Listen failed")

--- a/thrift/thrift_bench_test.go
+++ b/thrift/thrift_bench_test.go
@@ -30,16 +30,17 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
 	"github.com/uber/tchannel-go/hyperbahn"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/thrift"
 	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
+
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -121,7 +122,7 @@ func BenchmarkInboundSerial(b *testing.B) {
 }
 
 func BenchmarkInboundParallel(b *testing.B) {
-	var reqCount int32
+	var reqCounter = &atomic.Int32{}
 	serverAddr, err := setupBenchServer()
 	require.NoError(b, err, "setupBenchServer failed")
 
@@ -135,7 +136,7 @@ func BenchmarkInboundParallel(b *testing.B) {
 
 		for pb.Next() {
 			client.CallAndWait()
-			atomic.AddInt32(&reqCount, int32(1))
+			reqCounter.Inc()
 		}
 		fmt.Println("Successful requests", client.numTimes, "Mean", client.mean)
 		for err, count := range client.errors {
@@ -144,7 +145,8 @@ func BenchmarkInboundParallel(b *testing.B) {
 	})
 
 	duration := time.Since(started)
-	fmt.Println("Requests", reqCount, "RPS: ", float64(reqCount)/duration.Seconds())
+	reqs := reqCounter.Load()
+	fmt.Println("Requests", reqs, "RPS: ", float64(reqs)/duration.Seconds())
 }
 
 type benchSecondHandler struct{}


### PR DESCRIPTION
This PR makes it harder for us to unwittingly introduce races. Rather than using `sync/atomic` directly, which requires remembering which variables are atomic and which aren't, use `tchannel-go/atomic` for all atomic operations.

Fixes #152.