### PR TITLE
Add test to trigger data races during test and fix races

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -21,6 +21,7 @@
 package tchannel_test
 
 import (
+	"log"
 	"math/rand"
 	"sync"
 	"testing"
@@ -98,6 +99,65 @@ func TestCloseAfterTimeout(t *testing.T) {
 		// Unblock the testHandler so that a goroutine isn't leaked.
 		<-testHandler.blockErr
 	})
+}
+
+func TestRaceExchangesWithClose(t *testing.T) {
+	log.SetFlags(log.Lmicroseconds)
+
+	var wg sync.WaitGroup
+
+	ctx, cancel := NewContext(testutils.Timeout(70 * time.Millisecond))
+	defer cancel()
+
+	opts := testutils.NewOpts().DisableLogVerification()
+	WithVerifiedServer(t, opts, func(server *Channel, hostPort string) {
+		gotCall := make(chan struct{})
+		completeCall := make(chan struct{})
+		testutils.RegisterFunc(server, "dummy", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+			return &raw.Res{}, nil
+		})
+
+		testutils.RegisterEcho(server, func() {
+			close(gotCall)
+			<-completeCall
+		})
+
+		client := testutils.NewClient(t, nil)
+		defer client.Close()
+
+		callDone := make(chan struct{})
+		go func() {
+			assert.NoError(t, testutils.CallEcho(client, server, &raw.Args{}), "Echo failed")
+			close(callDone)
+		}()
+
+		// Wait until the server recieves a call, so it has an active inbound.
+		<-gotCall
+
+		// Start a bunch of clients to trigger races between connecting and close.
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				c := testutils.NewClient(t, nil)
+				defer c.Close()
+
+				c.Ping(ctx, server.PeerInfo().HostPort)
+				raw.Call(ctx, c, server.PeerInfo().HostPort, server.ServiceName(), "dummy", nil, nil)
+			}()
+		}
+
+		// Now try to close the channel, it should block since there's active exchanges.
+		server.Close()
+		assert.Equal(t, ChannelStartClose, server.State(), "Server should be in StartClose")
+
+		close(completeCall)
+		<-callDone
+	})
+
+	// Wait for all calls to complete
+	wg.Wait()
 }
 
 // TestCloseStress ensures that once a Channel is closed, it cannot be reached.

--- a/inbound.go
+++ b/inbound.go
@@ -63,6 +63,12 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	call.conn = c
 	ctx, cancel := newIncomingContext(call, callReq.TimeToLive, &callReq.Tracing)
 
+	if !c.pendingExchangeMethodAdd() {
+		// Connection is closed, no need to do anything.
+		return true
+	}
+	defer c.pendingExchangeMethodDone()
+
 	mex, err := c.inbound.newExchange(ctx, c.framePool, callReq.messageType(), frame.Header.ID, mexChannelBufferSize)
 	if err != nil {
 		if err == errDuplicateMex {

--- a/outbound.go
+++ b/outbound.go
@@ -56,6 +56,12 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 		return nil, ErrTimeout
 	}
 
+	if !c.pendingExchangeMethodAdd() {
+		// Connection is closed, no need to do anything.
+		return nil, ErrInvalidConnectionState
+	}
+	defer c.pendingExchangeMethodDone()
+
 	requestID := c.NextMessageID()
 	mex, err := c.outbound.newExchange(ctx, c.framePool, messageTypeCallReq, requestID, mexChannelBufferSize)
 	if err != nil {

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -31,7 +31,7 @@ import (
 
 // CallEcho calls the "echo" endpoint from the given src to target.
 func CallEcho(src, target *tchannel.Channel, args *raw.Args) error {
-	ctx, cancel := tchannel.NewContext(Timeout(100 * time.Millisecond))
+	ctx, cancel := tchannel.NewContext(Timeout(300 * time.Millisecond))
 	defer cancel()
 
 	if args == nil {

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -30,7 +30,7 @@ import (
 )
 
 // CallEcho calls the "echo" endpoint from the given src to target.
-func CallEcho(src, target *tchannel.Channel, args *raw.Args) error {
+func CallEcho(src *tchannel.Channel, targetHostPort, targetService string, args *raw.Args) error {
 	ctx, cancel := tchannel.NewContext(Timeout(300 * time.Millisecond))
 	defer cancel()
 
@@ -38,8 +38,7 @@ func CallEcho(src, target *tchannel.Channel, args *raw.Args) error {
 		args = &raw.Args{}
 	}
 
-	peerInfo := target.PeerInfo()
-	_, _, _, err := raw.Call(ctx, src, peerInfo.HostPort, peerInfo.ServiceName, "echo", args.Arg2, args.Arg3)
+	_, _, _, err := raw.Call(ctx, src, targetHostPort, targetService, "echo", args.Arg2, args.Arg3)
 	return err
 }
 


### PR DESCRIPTION
There's a few data races in the connection shutdown path. It's possible for these races to cause a panic, but they would only affect servers that are closing anyway.

Fixes #262, #273 