### PR TITLE
Avoid goroutine creation when creating contexts

### DIFF
--- a/context_builder.go
+++ b/context_builder.go
@@ -225,6 +225,9 @@ func (cb *ContextBuilder) Build() (ContextWithHeaders, context.CancelFunc) {
 	parent := cb.ParentContext
 	if parent == nil {
 		parent = context.Background()
+	} else if headerCtx, ok := parent.(*headerCtx); ok {
+		// Unwrap any headerCtx, since we'll be rewrapping anyway.
+		parent = headerCtx.Context
 	}
 	ctx, cancel := context.WithTimeout(parent, cb.Timeout)
 

--- a/context_builder.go
+++ b/context_builder.go
@@ -225,7 +225,7 @@ func (cb *ContextBuilder) Build() (ContextWithHeaders, context.CancelFunc) {
 	parent := cb.ParentContext
 	if parent == nil {
 		parent = context.Background()
-	} else if headerCtx, ok := parent.(*headerCtx); ok {
+	} else if headerCtx, ok := parent.(headerCtx); ok {
 		// Unwrap any headerCtx, since we'll be rewrapping anyway.
 		parent = headerCtx.Context
 	}

--- a/context_header.go
+++ b/context_header.go
@@ -46,7 +46,7 @@ type headersContainer struct {
 	respHeaders map[string]string
 }
 
-func (c *headerCtx) headers() *headersContainer {
+func (c headerCtx) headers() *headersContainer {
 	if h, ok := c.Value(contextKeyHeaders).(*headersContainer); ok {
 		return h
 	}
@@ -54,7 +54,7 @@ func (c *headerCtx) headers() *headersContainer {
 }
 
 // Headers gets application headers out of the context.
-func (c *headerCtx) Headers() map[string]string {
+func (c headerCtx) Headers() map[string]string {
 	if h := c.headers(); h != nil {
 		return h.reqHeaders
 	}
@@ -62,7 +62,7 @@ func (c *headerCtx) Headers() map[string]string {
 }
 
 // ResponseHeaders returns the response headers.
-func (c *headerCtx) ResponseHeaders() map[string]string {
+func (c headerCtx) ResponseHeaders() map[string]string {
 	if h := c.headers(); h != nil {
 		return h.respHeaders
 	}
@@ -70,7 +70,7 @@ func (c *headerCtx) ResponseHeaders() map[string]string {
 }
 
 // SetResponseHeaders sets the response headers.
-func (c *headerCtx) SetResponseHeaders(headers map[string]string) {
+func (c headerCtx) SetResponseHeaders(headers map[string]string) {
 	if h := c.headers(); h != nil {
 		h.respHeaders = headers
 		return
@@ -82,9 +82,12 @@ func (c *headerCtx) SetResponseHeaders(headers map[string]string) {
 // If the parent `ctx` is already an instance of ContextWithHeaders, its existing headers
 // will be ignored. In order to merge new headers with parent headers, use ContextBuilder.
 func WrapWithHeaders(ctx context.Context, headers map[string]string) ContextWithHeaders {
+	if hctx, ok := ctx.(headerCtx); ok {
+		ctx = hctx
+	}
 	h := &headersContainer{
 		reqHeaders: headers,
 	}
 	newCtx := context.WithValue(ctx, contextKeyHeaders, h)
-	return &headerCtx{Context: newCtx}
+	return headerCtx{Context: newCtx}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -184,6 +184,22 @@ func TestContextBuilderParentContextReplaceHeaders(t *testing.T) {
 	goroutines.VerifyNoLeaks(t, nil)
 }
 
+func TestContextWrapWithHeaders(t *testing.T) {
+	headers1 := map[string]string{
+		"k1": "v1",
+	}
+	ctx, _ := NewContextBuilder(time.Second).
+		SetHeaders(headers1).
+		Build()
+	assert.Equal(t, headers1, ctx.Headers(), "Headers mismatch after Build")
+
+	headers2 := map[string]string{
+		"k1": "v1",
+	}
+	ctx2 := WrapWithHeaders(ctx, headers2)
+	assert.Equal(t, headers2, ctx2.Headers(), "Headers mismatch after WrapWithHeaders")
+}
+
 func TestContextWithHeadersAsContext(t *testing.T) {
 	var ctx context.Context = getParentContext(t)
 	assert.EqualValues(t, "some value", ctx.Value("some key"), "inherited from parent ctx")

--- a/context_test.go
+++ b/context_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+	"github.com/uber/tchannel-go/testutils/goroutines"
 	"golang.org/x/net/context"
 )
 
@@ -161,6 +162,8 @@ func TestContextBuilderParentContextMergeHeaders(t *testing.T) {
 		"header key":   "header value 2", // overwritten
 		"fixed header": "fixed value",    // inherited
 	}, ctx3.Headers())
+
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestContextBuilderParentContextReplaceHeaders(t *testing.T) {
@@ -177,6 +180,8 @@ func TestContextBuilderParentContextReplaceHeaders(t *testing.T) {
 		SetHeaders(map[string]string{"header key": "header value 2"}).
 		Build()
 	assert.Equal(t, map[string]string{"header key": "header value 2"}, ctx2.Headers())
+
+	goroutines.VerifyNoLeaks(t, nil)
 }
 
 func TestContextWithHeadersAsContext(t *testing.T) {
@@ -205,4 +210,6 @@ func TestContextBuilderParentContextSpan(t *testing.T) {
 		Build()
 	span4 := NewSpan(3, 2, 1)
 	assert.Equal(t, &span4, CurrentSpan(ctx4), "external span used")
+
+	goroutines.VerifyNoLeaks(t, nil)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -123,11 +123,10 @@ func TestCurrentCallWithNilResult(t *testing.T) {
 func getParentContext(t *testing.T) ContextWithHeaders {
 	ctx := context.WithValue(context.Background(), "some key", "some value")
 
-	ctx1, cancel := NewContextBuilder(time.Second).
+	ctx1, _ := NewContextBuilder(time.Second).
 		SetParentContext(ctx).
 		AddHeader("header key", "header value").
 		Build()
-	cancel()
 	return ctx1
 }
 
@@ -142,11 +141,10 @@ func TestContextBuilderParentContextMergeHeaders(t *testing.T) {
 	ctx.Headers()["fixed header"] = "fixed value"
 
 	// append header to parent
-	ctx2, cancel := NewContextBuilder(time.Second).
+	ctx2, _ := NewContextBuilder(time.Second).
 		SetParentContext(ctx).
 		AddHeader("header key 2", "header value 2").
 		Build()
-	defer cancel()
 	assert.Equal(t, map[string]string{
 		"header key":   "header value",   // inherited
 		"fixed header": "fixed value",    // inherited
@@ -154,11 +152,10 @@ func TestContextBuilderParentContextMergeHeaders(t *testing.T) {
 	}, ctx2.Headers())
 
 	// override parent header
-	ctx3, cancel := NewContextBuilder(time.Second).
+	ctx3, _ := NewContextBuilder(time.Second).
 		SetParentContext(ctx).
 		AddHeader("header key", "header value 2"). // override
 		Build()
-	defer cancel()
 
 	assert.Equal(t, map[string]string{
 		"header key":   "header value 2", // overwritten
@@ -191,24 +188,21 @@ func TestContextBuilderParentContextSpan(t *testing.T) {
 	ctx := getParentContext(t)
 	span := NewSpan(5, 4, 3)
 
-	ctx2, cancel := NewContextBuilder(time.Second).
+	ctx2, _ := NewContextBuilder(time.Second).
 		SetParentContext(ctx).
 		SetSpanForTest(&span).
 		Build()
-	defer cancel()
 	assert.Equal(t, &span, CurrentSpan(ctx2), "explicitly provided span used")
 
-	ctx3, cancel := NewContextBuilder(time.Second).
+	ctx3, _ := NewContextBuilder(time.Second).
 		SetParentContext(ctx2).
 		Build()
-	defer cancel()
 	assert.Equal(t, &span, CurrentSpan(ctx3), "span inherited from parent")
 
-	ctx4, cancel := NewContextBuilder(time.Second).
+	ctx4, _ := NewContextBuilder(time.Second).
 		SetParentContext(ctx2).
 		SetExternalSpan(3, 2, 1, true).
 		Build()
-	defer cancel()
 	span4 := NewSpan(3, 2, 1)
 	assert.Equal(t, &span4, CurrentSpan(ctx4), "external span used")
 }

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -53,7 +53,7 @@ type testArgs struct {
 }
 
 func ctxArg() mock.AnythingOfTypeArgument {
-	return mock.AnythingOfType("*tchannel.headerCtx")
+	return mock.AnythingOfType("tchannel.headerCtx")
 }
 
 func TestThriftArgs(t *testing.T) {

--- a/trace/reporter_test.go
+++ b/trace/reporter_test.go
@@ -229,7 +229,7 @@ type testArgs struct {
 }
 
 func ctxArg() mock.AnythingOfTypeArgument {
-	return mock.AnythingOfType("*tchannel.headerCtx")
+	return mock.AnythingOfType("tchannel.headerCtx")
 }
 
 func TestSubmit(t *testing.T) {


### PR DESCRIPTION
Unwrap our custom `headerCtx` when it's used as a parent context, so the underlying context will be recognized by `context.Context` and it won't create a goroutine to track cancellation.

@akshayjshah 