### PR TITLE
Make leaked goroutine detector simpler

### DIFF
--- a/testutils/goroutines/stacks.go
+++ b/testutils/goroutines/stacks.go
@@ -30,34 +30,6 @@ import (
 	"strings"
 )
 
-func getStackBuffer(all bool) []byte {
-	for i := 4096; ; i *= 2 {
-		buf := make([]byte, i)
-		if n := runtime.Stack(buf, all); n < i {
-			return buf
-		}
-	}
-}
-
-// parseGoStackHeader parses a stack header that looks like:
-// goroutine 643 [runnable]:\n
-// And returns the goroutine ID, and the state.
-func parseGoStackHeader(line string) (goroutineID int, state string) {
-	line = strings.TrimSuffix(line, ":\n")
-	parts := strings.SplitN(line, " ", 3)
-	if len(parts) != 3 {
-		panic(fmt.Sprintf("unexpected stack header format: %v", line))
-	}
-
-	id, err := strconv.Atoi(parts[1])
-	if err != nil {
-		panic(fmt.Sprintf("failed to parse goroutine ID: %v", parts[1]))
-	}
-
-	state = strings.TrimSuffix(strings.TrimPrefix(parts[2], "["), "]")
-	return id, state
-}
-
 // Stack represents a single Goroutine's stack.
 type Stack struct {
 	id        int
@@ -119,4 +91,32 @@ func GetAll() []Stack {
 		stacks = append(stacks, *curStack)
 	}
 	return stacks
+}
+
+func getStackBuffer(all bool) []byte {
+	for i := 4096; ; i *= 2 {
+		buf := make([]byte, i)
+		if n := runtime.Stack(buf, all); n < i {
+			return buf
+		}
+	}
+}
+
+// parseGoStackHeader parses a stack header that looks like:
+// goroutine 643 [runnable]:\n
+// And returns the goroutine ID, and the state.
+func parseGoStackHeader(line string) (goroutineID int, state string) {
+	line = strings.TrimSuffix(line, ":\n")
+	parts := strings.SplitN(line, " ", 3)
+	if len(parts) != 3 {
+		panic(fmt.Sprintf("unexpected stack header format: %v", line))
+	}
+
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse goroutine ID: %v", parts[1]))
+	}
+
+	state = strings.TrimSuffix(strings.TrimPrefix(parts[2], "["), "]")
+	return id, state
 }

--- a/testutils/goroutines/verify.go
+++ b/testutils/goroutines/verify.go
@@ -54,14 +54,12 @@ func IdentifyLeaks(opts *VerifyOpts) error {
 		stacks = GetAll()[1:]
 		stacks = filterStacks(stacks, opts)
 
-		// If there are leaks found, retry 3 times since the goroutine's state
-		// may not yet have updated.
 		if len(stacks) <= _expectedRuntimeGoroutines {
 			return nil
 		}
 
 		if i > maxAttempts/2 {
-			time.Sleep(time.Millisecond)
+			time.Sleep(time.Duration(i) * time.Millisecond)
 		} else {
 			runtime.Gosched()
 		}

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -168,12 +168,8 @@ func (ts *TestServer) verifyExchangesCleared() {
 }
 
 func (ts *TestServer) verifyNoGoroutinesLeaked() {
-	leaks, err := goroutines.IdentifyLeaks(ts.verifyOpts)
-	if err != nil {
-		ts.Error(err.Error())
-		return
-	}
-	if len(leaks) == 0 {
+	err := goroutines.IdentifyLeaks(ts.verifyOpts)
+	if err == nil {
 		// No leaks, nothing to do.
 		return
 	}
@@ -186,9 +182,7 @@ func (ts *TestServer) verifyNoGoroutinesLeaked() {
 		// more failures.
 		return
 	}
-	for _, leak := range leaks {
-		ts.Error(leak)
-	}
+	ts.Error(err.Error())
 }
 
 func describeLeakedExchanges(rs *tchannel.RuntimeState) string {


### PR DESCRIPTION
Now that our tests don't leak tons of goroutines, we don't need to be so picky about which blocked goroutines are problematic - just fail the tests if any goroutines aren't making progress. This makes the retry logic much simpler, and should resolve some test flakiness.

Addresses some of #207.