### PR TITLE
Fix flaky TestCloseSendError test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ godep:
 test_ci: test
 ifdef SHOULD_LINT
 	@echo Stress testing TestCloseSendError
-	go test $(TEST_ARG) -run "TestCloseSendError" -timeoutMultiplier=10 -parallel=4 -count 500 .
+	go test $(TEST_ARG) -run "TestCloseSendError" -timeoutMultiplier=10 -parallel=4 -count 5000 .
 endif
 
 test: clean setup

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ godep:
 	godep save ./...
 
 test_ci: test
+ifdef SHOULD_LINT
+	@echo Stress testing TestCloseSendError
+	go test $(TEST_ARG) -run "TestCloseSendError" -timeoutMultiplier=10 -parallel=4 -count 500 .
+endif
 
 test: clean setup
 	@echo Testing packages:


### PR DESCRIPTION
WIP! Temporarily amending Makefile to make sure we can reliably reproduce this test failure on Travis.

Calls to the echo procedure are timing out on Travis; there's not much we can do about it except to increase the timeout.

Partially addresses #207.