### PR TITLE
Print debug logs on test failures

### DIFF
--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -49,6 +49,10 @@ type ChannelOpts struct {
 
 	// optFn is run with the channel options before creating the channel.
 	optFn func(*ChannelOpts)
+
+	// postFns is a list of functions that are run after the test.
+	// They are run even if the test fails.
+	postFns []func()
 }
 
 // LogVerification contains options to control the log verification.
@@ -140,6 +144,10 @@ func (o *ChannelOpts) AddLogFilter(filter string, maxCount uint, fields ...strin
 		FieldFilters: fieldFilters,
 	})
 	return o
+}
+
+func (o *ChannelOpts) addPostFn(f func()) {
+	o.postFns = append(o.postFns, f)
 }
 
 func defaultString(v string, defaultValue string) string {

--- a/testutils/channel_t.go
+++ b/testutils/channel_t.go
@@ -35,7 +35,7 @@ func getOptsForTest(t testing.TB, opts *ChannelOpts) *ChannelOpts {
 		opts.optFn = func(opts *ChannelOpts) {
 			// Set a custom logger now.
 			if opts.Logger == nil {
-				opts.Logger = tchannel.NullLogger
+				opts.Logger = newTestLogger(t)
 			}
 			opts.Logger = opts.LogVerification.WrapLogger(t, opts.Logger)
 		}

--- a/testutils/channel_t.go
+++ b/testutils/channel_t.go
@@ -35,7 +35,11 @@ func getOptsForTest(t testing.TB, opts *ChannelOpts) *ChannelOpts {
 		opts.optFn = func(opts *ChannelOpts) {
 			// Set a custom logger now.
 			if opts.Logger == nil {
-				opts.Logger = newTestLogger(t)
+				tl := newTestLogger(t)
+				opts.Logger = tl
+				opts.addPostFn(func() {
+					tl.report()
+				})
 			}
 			opts.Logger = opts.LogVerification.WrapLogger(t, opts.Logger)
 		}

--- a/testutils/logger.go
+++ b/testutils/logger.go
@@ -64,6 +64,63 @@ type errorLoggerState struct {
 	matchCount []atomic.Uint32
 }
 
+type testLogger struct {
+	t      testing.TB
+	fields tchannel.LogFields
+}
+
+func newTestLogger(t testing.TB) tchannel.Logger {
+	return testLogger{t, nil}
+}
+
+func (l testLogger) Enabled(level tchannel.LogLevel) bool {
+	return true
+}
+
+func (l testLogger) log(prefix string, msg string) {
+	l.t.Logf("[%s] %v", prefix, msg)
+}
+
+func (l testLogger) Fatal(msg string) {
+	l.log("F", msg)
+}
+
+func (l testLogger) Error(msg string) {
+	l.log("E", msg)
+}
+
+func (l testLogger) Warn(msg string) {
+	l.log("W", msg)
+}
+
+func (l testLogger) Info(msg string) {
+	l.log("I", msg)
+}
+
+func (l testLogger) Infof(msg string, args ...interface{}) {
+	l.log("I", fmt.Sprintf(msg, args...))
+}
+
+func (l testLogger) Debug(msg string) {
+	l.log("D", msg)
+}
+
+func (l testLogger) Debugf(msg string, args ...interface{}) {
+	l.log("D", fmt.Sprintf(msg, args...))
+}
+
+func (l testLogger) Fields() tchannel.LogFields {
+	return l.fields
+}
+
+func (l testLogger) WithFields(fields ...tchannel.LogField) tchannel.Logger {
+	existing := len(l.Fields())
+	newFields := make(tchannel.LogFields, existing+len(fields))
+	copy(newFields, l.Fields())
+	copy(newFields[existing:], fields)
+	return testLogger{l.t, newFields}
+}
+
 type errorLogger struct {
 	tchannel.Logger
 	t testing.TB


### PR DESCRIPTION
Write all logs to testing.T's logger, which only prints the output if
the test fails.

If --connectionLog is specified, logs will be streamed as usual.
Otherwise, output will be printed only if the test fails.

@akshayjshah 