### PR TITLE
Ignore subchannels and peer during state leak checking

### DIFF
--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -213,6 +213,7 @@ func comparableState(ch *tchannel.Channel) *tchannel.RuntimeState {
 	})
 	s.OtherChannels = nil
 	s.SubChannels = nil
+	s.Peers = nil
 	return s
 }
 

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -212,11 +212,7 @@ func comparableState(ch *tchannel.Channel) *tchannel.RuntimeState {
 		IncludeExchanges: true,
 	})
 	s.OtherChannels = nil
-	for sc := range s.SubChannels {
-		scState := s.SubChannels[sc]
-		scState.Handler = tchannel.HandlerRuntimeState{}
-		s.SubChannels[sc] = scState
-	}
+	s.SubChannels = nil
 	return s
 }
 


### PR DESCRIPTION
A service may have new subchannels and peers since they get added/modified during tests.

We only care about connections which is in root peers, so it's safe to ignore the Peers.

@akshayjshah 