### PR TITLE
TestServer should allow creating validated clients/servers

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -598,14 +598,16 @@ func TestWriteTimeout(t *testing.T) {
 }
 
 func TestGracefulClose(t *testing.T) {
-	WithVerifiedServer(t, nil, func(ch1 *Channel, hp1 string) {
-		WithVerifiedServer(t, nil, func(ch2 *Channel, hp2 string) {
-			ctx, cancel := NewContext(time.Second)
-			defer cancel()
+	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+		ch2 := ts.NewServer(nil)
+		hp2 := ch2.PeerInfo().HostPort
+		defer ch2.Close()
 
-			assert.NoError(t, ch1.Ping(ctx, hp2), "Ping from ch1 -> ch2 failed")
-			assert.NoError(t, ch2.Ping(ctx, hp1), "Ping from ch2 -> ch1 failed")
-		})
+		ctx, cancel := NewContext(time.Second)
+		defer cancel()
+
+		assert.NoError(t, ts.Server().Ping(ctx, hp2), "Ping from ch1 -> ch2 failed")
+		assert.NoError(t, ch2.Ping(ctx, ts.HostPort()), "Ping from ch2 -> ch1 failed")
 	})
 }
 


### PR DESCRIPTION
TestServer.New{Client,Server} will return a channel that is validated. Channels are closed and validated in most recently created order.

This is required to avoid doing goroutine verification for the inner channels. If the inner channel does goroutine verification, the outer server's accept loop will cause the verification to fail. We skip goroutine verification till the parent TestServer is closed.

@akshayjshah 