### PR TITLE
Close and verify all channels in TestServer, add logs to make debugging easier

### DIFF
--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -150,6 +150,8 @@ func (ts *TestServer) addChannel(createChannel func(t testing.TB, opts *ChannelO
 	opts = getOptsForTest(ts, opts)
 	ch := createChannel(ts, opts)
 	ts.postFns = append(ts.postFns, opts.postFns...)
+	ts.channels = append(ts.channels, ch)
+	ts.channelStates[ch] = comparableState(ch)
 	return ch
 }
 

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -86,6 +86,7 @@ func WithTestServer(t testing.TB, chanOpts *ChannelOpts, f func(*TestServer)) {
 	defer ts.post()
 
 	f(ts)
+	ts.Server().Logger().Debugf("TEST: Test function complete")
 	ts.CloseAndVerify()
 }
 
@@ -128,6 +129,7 @@ func (ts *TestServer) Register(h tchannel.Handler, methodName string) {
 func (ts *TestServer) CloseAndVerify() {
 	for i := len(ts.channels) - 1; i >= 0; i-- {
 		ch := ts.channels[i]
+		ch.Logger().Debugf("TEST: TestServer is closing and verifying channel")
 		ts.close(ch)
 		ts.verify(ch)
 	}


### PR DESCRIPTION
Follow up to https://github.com/uber/tchannel-go/pull/305

I forgot to actually add the channels to the list, so channels created using `NewClient`/`NewServer` were not actually being validated (nor closed), which was causing some tests to be flaky.

cc @akshayjshah 