### PR TITLE
Update WithVerifiedServer to use testutils.TestServer

### DIFF
--- a/verify_utils_test.go
+++ b/verify_utils_test.go
@@ -58,18 +58,7 @@ func waitForChannelClose(t *testing.T, ch *Channel) bool {
 // WithVerifiedServer runs the given test function with a server channel that is verified
 // at the end to make sure there are no leaks (e.g. no exchanges leaked).
 func WithVerifiedServer(t *testing.T, opts *testutils.ChannelOpts, f func(serverCh *Channel, hostPort string)) {
-	var ch *Channel
-	testutils.WithServer(t, opts, func(serverCh *Channel, hostPort string) {
-		f(serverCh, hostPort)
-		ch = serverCh
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		f(ts.Server(), ts.HostPort())
 	})
-
-	if !waitForChannelClose(t, ch) {
-		return
-	}
-
-	// Check the message exchanges and make sure they are all empty.
-	if exchangesLeft := CheckEmptyExchanges(ch); exchangesLeft != "" {
-		t.Errorf("Found uncleared message exchanges:\n%v", exchangesLeft)
-	}
 }


### PR DESCRIPTION
We'll probably want to replace `WIthVerifiedServer` when updating tests to work with the relay, but this is a first step to making sure that all tests work correctly with the new TestServer.

This also gives us:
 - Stronger verification for every test (each test will do mex, state, and goroutine verification)
 - Debug log dump on failure

cc @akshayjshah 