### PR TITLE
Remove error log if onClosedConnRemoved does not find peer

### DIFF
--- a/root_peer_list.go
+++ b/root_peer_list.go
@@ -92,7 +92,8 @@ func (l *RootPeerList) onClosedConnRemoved(peer *Peer) {
 	hostPort := peer.HostPort()
 	p, ok := l.Get(hostPort)
 	if !ok {
-		l.channel.Logger().Error("got connection state change for a peer not in the root peer list")
+		// It's possible that multiple connections were closed and removed at the same time,
+		// so multiple goroutines might be removing the peer from the root peer list.
 		return
 	}
 


### PR DESCRIPTION
If some peer P has multiple connections C1 and C2, and both close
at the same time, then we have the following sequence of events.
Each connection is running on a separate goroutine.

C1 calls connectionCloseStateChange, removes itself from the connections
list, and is scheduled out before onClosedConnRemoved

C2 calls connectionCloseStateChange, removes itself from the list
and runs onClosedConnRemoved, which will see that there's no connection
for this peer, and it can be safely removed. So it removes P from the
root peer list

C1 continues to run, goes into onClosedConnRemoved, but doesn't find
P in the root peer list, and logs an error.

Since this can happen and does not actually signify an error, we do not
need to log anything in this scenario.

@akshayjshah 