### PR TITLE
Use UnmarshalText for FailStrategy

### DIFF
--- a/hyperbahn/advertise_test.go
+++ b/hyperbahn/advertise_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"
 	"github.com/uber/tchannel-go/testutils"
-
-	"gopkg.in/yaml.v2"
 )
 
 func TestInitialAdvertiseFailedRetryBackoff(t *testing.T) {
@@ -339,46 +337,6 @@ func TestRetryFailure(t *testing.T) {
 		// Wait for the handler to be called and the mock expectation to be recorded.
 		<-doneTesting
 	})
-}
-
-func TestCanUnmarshalYAMLFailStrategy(t *testing.T) {
-	tests := []struct {
-		strategy string
-		expected FailStrategy
-		wantErr  bool
-	}{
-		{
-			strategy: "fatal",
-			expected: FailStrategyFatal,
-		},
-		{
-			strategy: "ignore",
-			expected: FailStrategyIgnore,
-		},
-		{
-			strategy: "unknown",
-			wantErr:  true,
-		},
-		{
-			// YAML uses type default when parsing an empty string which is 0 == FailStrategyFatal.
-			strategy: "",
-			expected: FailStrategyFatal,
-		},
-	}
-
-	for _, tt := range tests {
-		var fs FailStrategy
-		err := yaml.Unmarshal([]byte(tt.strategy), &fs)
-		if tt.wantErr {
-			assert.Error(t, err, "Unmarshal %v should fail", tt.strategy)
-		} else {
-			assert.NoError(t, err, "Unmarshal %v shouldn't fail", tt.strategy)
-		}
-		if err != nil {
-			continue
-		}
-		assert.Equal(t, tt.expected, fs, "FailStrategy mismatch")
-	}
 }
 
 func checkAdvertiseInterval(t *testing.T, sleptFor time.Duration) {

--- a/hyperbahn/client.go
+++ b/hyperbahn/client.go
@@ -59,16 +59,12 @@ const (
 
 const hyperbahnServiceName = "hyperbahn"
 
-// UnmarshalYAML implements the yaml.UnmarshalYAML interface. This allows FailStrategy
-// to be specified as a string (e.g. "fatal") in configuration files.
-func (f *FailStrategy) UnmarshalYAML(unmarshal func(v interface{}) error) error {
-	var strategy string
-	if err := unmarshal(&strategy); err != nil {
-		return err
-	}
-
-	switch strategy {
-	case "fatal":
+// UnmarshalText implements encoding/text.Unmarshaler.
+// This allows FailStrategy to be specified as a string in many
+// file formats (e.g. JSON, YAML, TOML).
+func (f *FailStrategy) UnmarshalText(text []byte) error {
+	switch strategy := string(text); strategy {
+	case "", "fatal":
 		*f = FailStrategyFatal
 	case "ignore":
 		*f = FailStrategyIgnore


### PR DESCRIPTION
This makes it compatible with JSON and YAML (and a bunch of other encoding formats).