### PR TITLE
Use a separate map for inbound/outbound relay items

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -304,7 +304,7 @@ func (r *Relayer) IntrospectState(opts *IntrospectionOptions) RelayerRuntimeStat
 	r.RLock()
 	defer r.RUnlock()
 	return RelayerRuntimeState{
-		NumItems: len(r.items),
+		NumItems: len(r.inbound) + len(r.outbound),
 	}
 }
 

--- a/relay_stub_test.go
+++ b/relay_stub_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	. "github.com/uber/tchannel-go"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +19,7 @@ type SimpleRelayHosts struct {
 func NewSimpleRelayHosts(peers map[string][]string) *SimpleRelayHosts {
 	// Use a known seed for repeatable tests.
 	return &SimpleRelayHosts{
-		r:     rand.New(rand.NewSource(1)),
+		r:     NewRand(1),
 		peers: peers,
 	}
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -181,18 +181,12 @@ func TestRelayIDClash(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				testutils.AssertEcho(t, s2, rt.relay.PeerInfo().HostPort, s1.ServiceName(), &raw.Args{
-					Arg2: testutils.RandBytes(100),
-					Arg3: testutils.RandBytes(100),
-				})
+				testutils.AssertEcho(t, s2, rt.relay.PeerInfo().HostPort, s1.ServiceName())
 			}()
 		}
 
 		for i := 0; i < 5; i++ {
-			testutils.AssertEcho(t, s1, rt.relay.PeerInfo().HostPort, s2.ServiceName(), &raw.Args{
-				Arg2: testutils.RandBytes(100),
-				Arg3: testutils.RandBytes(100),
-			})
+			testutils.AssertEcho(t, s1, rt.relay.PeerInfo().HostPort, s2.ServiceName())
 		}
 
 		close(unblock)

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -21,10 +21,12 @@
 package testutils
 
 import (
+	"testing"
 	"time"
 
 	"golang.org/x/net/context"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
 )
@@ -40,6 +42,26 @@ func CallEcho(src *tchannel.Channel, targetHostPort, targetService string, args 
 
 	_, _, _, err := raw.Call(ctx, src, targetHostPort, targetService, "echo", args.Arg2, args.Arg3)
 	return err
+}
+
+// AssertEcho calls the "echo" endpoint with random data, and asserts
+// that the returned data matches the arguments "echo" was called with.
+func AssertEcho(tb testing.TB, src *tchannel.Channel, targetHostPort, targetService string) {
+	ctx, cancel := tchannel.NewContext(Timeout(300 * time.Millisecond))
+	defer cancel()
+
+	args := &raw.Args{
+		Arg2: RandBytes(1000),
+		Arg3: RandBytes(1000),
+	}
+
+	arg2, arg3, _, err := raw.Call(ctx, src, targetHostPort, targetService, "echo", args.Arg2, args.Arg3)
+	if !assert.NoError(tb, err, "Call from %v (%v) to %v (%v) failed", src.ServiceName(), src.PeerInfo().HostPort, targetService, targetHostPort) {
+		return
+	}
+
+	assert.Equal(tb, args.Arg2, arg2, "Arg2 mismatch")
+	assert.Equal(tb, args.Arg3, arg3, "Arg3 mismatch")
 }
 
 // RegisterEcho registers an echo endpoint on the given channel. The optional provided


### PR DESCRIPTION
Currently, we use a single map that remaps from ID -> some connection, but IDs are not global across a connection. E.g. if we have `s1` and `s2`, `s1` may make a callReq with ID 1 to `s2`, and `s2` may also start a callReq with ID 1 to `s1`.

Change the relays to use separate maps for the outbounds (callReq starting on this connection) vs inbounds (callReq started on some other connection being forwarded to this connection).