### PR TITLE
Add periodic health checks to TChannel

### DIFF
--- a/health.go
+++ b/health.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	_defaultHealthCheckTimeout         = time.Second
+	_defaultHealthCheckFailuresToClose = 5
+
+	_healthHistorySize = 256
+)
+
+// HealthCheckOptions are the parameters to configure active TChannel health
+// checks. These are not intended to check application level health, but
+// TCP connection health (similar to TCP keep-alives). The health checks use
+// TChannel ping messages.
+type HealthCheckOptions struct {
+	// The period between health checks. If this is zeor, active health checks
+	// are disabled.
+	Interval time.Duration
+
+	// The timeout to use for a health check.
+	// If no value is specified, it defaults to time.Second.
+	Timeout time.Duration
+
+	// FailuresToClose is the number of consecutive health check failures that
+	// will cause this connection to be closed.
+	// If no value is specified, it defaults to 5.
+	FailuresToClose int
+}
+
+type healthHistory struct {
+	sync.RWMutex
+
+	states []bool
+
+	insertAt int
+	total    int
+}
+
+func newHealthHistory() *healthHistory {
+	return &healthHistory{
+		states: make([]bool, _healthHistorySize),
+	}
+}
+
+func (hh *healthHistory) add(b bool) {
+	hh.Lock()
+	defer hh.Unlock()
+
+	hh.states[hh.insertAt] = b
+	hh.insertAt = (hh.insertAt + 1) % _healthHistorySize
+	hh.total++
+}
+
+func (hh *healthHistory) asBools() []bool {
+	hh.RLock()
+	defer hh.RUnlock()
+
+	if hh.total < _healthHistorySize {
+		return append([]bool(nil), hh.states[:hh.total]...)
+	}
+
+	states := hh.states
+	copyStates := make([]bool, 0, _healthHistorySize)
+	copyStates = append(copyStates, states[hh.insertAt:]...)
+	copyStates = append(copyStates, states[:hh.insertAt]...)
+	return copyStates
+}
+
+func (hco HealthCheckOptions) enabled() bool {
+	return hco.Interval > 0
+}
+
+func (hco HealthCheckOptions) withDefaults() HealthCheckOptions {
+	if hco.Timeout == 0 {
+		hco.Timeout = _defaultHealthCheckTimeout
+	}
+	if hco.FailuresToClose == 0 {
+		hco.FailuresToClose = _defaultHealthCheckFailuresToClose
+	}
+	return hco
+}
+
+// healthCheck will do periodic pings on the connection to check the state of the connection.
+// We accept connID on the stack so can more easily debug panics or leaked goroutines.
+func (c *Connection) healthCheck(connID uint32) {
+	opts := c.opts.HealthChecks
+
+	ticker := c.timeTicker(opts.Interval)
+	defer ticker.Stop()
+
+	consecutiveFailures := 0
+	for {
+		select {
+		case <-ticker.C:
+		case <-c.healthCheckCtx.Done():
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.healthCheckCtx, opts.Timeout)
+		defer cancel()
+
+		err := c.ping(ctx)
+		c.healthCheckHistory.add(err == nil)
+		if err == nil {
+			if c.log.Enabled(LogLevelDebug) {
+				c.log.Debug("Performed successful active health check.")
+			}
+			consecutiveFailures = 0
+			continue
+		}
+
+		// If the health check failed because the connection closed or health
+		// checks were stopped, we don't need to log or close the connection.
+		if GetSystemErrorCode(err) == ErrCodeCancelled || err == ErrInvalidConnectionState {
+			c.log.WithFields(ErrField(err)).Debug("Health checker stopped.")
+			return
+		}
+
+		consecutiveFailures++
+		c.log.WithFields(LogFields{
+			{"consecutiveFailures", consecutiveFailures},
+			ErrField(err),
+			{"failuresToClose", opts.FailuresToClose},
+		}...).Warn("Failed active health check.")
+
+		if consecutiveFailures >= opts.FailuresToClose {
+			c.close(LogFields{
+				{"reason", "health check failure"},
+				ErrField(err),
+			}...)
+			return
+		}
+	}
+}
+
+func (c *Connection) stopHealthCheck() {
+	// Best effort check to see if health checks were stopped.
+	if c.healthCheckCtx.Err() != nil {
+		return
+	}
+	c.log.Debug("Stopping health checks.")
+	c.healthCheckQuit()
+}

--- a/health.go
+++ b/health.go
@@ -123,9 +123,8 @@ func (c *Connection) healthCheck(connID uint32) {
 		}
 
 		ctx, cancel := context.WithTimeout(c.healthCheckCtx, opts.Timeout)
-		defer cancel()
-
 		err := c.ping(ctx)
+		cancel()
 		c.healthCheckHistory.add(err == nil)
 		if err == nil {
 			if c.log.Enabled(LogLevelDebug) {

--- a/health_ext_test.go
+++ b/health_ext_test.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/uber/tchannel-go"
+
+	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTicker struct {
+	c chan time.Time
+}
+
+func newFakeTicker() *fakeTicker {
+	return &fakeTicker{
+		c: make(chan time.Time, 1),
+	}
+}
+
+func (ft *fakeTicker) tick() {
+	ft.c <- time.Now()
+}
+
+func (ft *fakeTicker) tryTick() bool {
+	select {
+	case ft.c <- time.Time{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (ft *fakeTicker) New(d time.Duration) *time.Ticker {
+	t := time.NewTicker(time.Hour)
+	t.C = ft.c
+	return t
+}
+
+func TestHealthCheckStopBeforeStart(t *testing.T) {
+	opts := testutils.NewOpts().NoRelay()
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+
+		var pingCount int
+		frameRelay, cancel := testutils.FrameRelay(t, ts.HostPort(), func(outgoing bool, f *Frame) *Frame {
+			if strings.Contains(f.Header.String(), "PingRes") {
+				pingCount++
+			}
+			return f
+		})
+		defer cancel()
+
+		ft := newFakeTicker()
+		opts := testutils.NewOpts().
+			SetTimeTicker(ft.New).
+			SetHealthChecks(HealthCheckOptions{Interval: time.Second})
+		client := ts.NewClient(opts)
+
+		ctx, cancel := NewContext(time.Second)
+		defer cancel()
+
+		conn, err := client.RootPeers().GetOrAdd(frameRelay).GetConnection(ctx)
+		require.NoError(t, err, "Failed to get connection")
+
+		conn.StopHealthCheck()
+
+		// Should be no ping messages sent.
+		for i := 0; i < 10; i++ {
+			ft.tryTick()
+		}
+		assert.Equal(t, 0, pingCount, "No pings when health check is stopped")
+	})
+}
+
+func TestHealthCheckStopNoError(t *testing.T) {
+	opts := testutils.NewOpts().NoRelay()
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+
+		var pingCount int
+		frameRelay, cancel := testutils.FrameRelay(t, ts.HostPort(), func(outgoing bool, f *Frame) *Frame {
+			if strings.Contains(f.Header.String(), "PingRes") {
+				pingCount++
+			}
+			return f
+		})
+		defer cancel()
+
+		ft := newFakeTicker()
+		opts := testutils.NewOpts().
+			SetTimeTicker(ft.New).
+			SetHealthChecks(HealthCheckOptions{Interval: time.Second}).
+			AddLogFilter("Unexpected ping response.", 1)
+		client := ts.NewClient(opts)
+
+		ctx, cancel := NewContext(time.Second)
+		defer cancel()
+
+		conn, err := client.RootPeers().GetOrAdd(frameRelay).GetConnection(ctx)
+		require.NoError(t, err, "Failed to get connection")
+
+		for i := 0; i < 10; i++ {
+			ft.tick()
+			waitForNHealthChecks(t, conn, i+1)
+		}
+		conn.StopHealthCheck()
+
+		// We stop the health check, so the ticks channel is no longer read, so
+		// we can't use the synchronous tick here.
+		for i := 0; i < 10; i++ {
+			ft.tryTick()
+		}
+
+		assert.Equal(t, 10, pingCount, "Pings should stop after health check is stopped")
+	})
+}
+
+func TestHealthCheckIntegration(t *testing.T) {
+	tests := []struct {
+		msg                 string
+		disable             bool
+		failuresToClose     int
+		pingResponses       []bool
+		wantActive          bool
+		wantHealthCheckLogs int
+	}{
+		{
+			msg:             "no failures with failuresToClose=0",
+			failuresToClose: 1,
+			pingResponses:   []bool{true, true, true, true},
+			wantActive:      true,
+		},
+		{
+			msg:                 "single failure with failuresToClose=1",
+			failuresToClose:     1,
+			pingResponses:       []bool{true, false, true, true},
+			wantActive:          false,
+			wantHealthCheckLogs: 1,
+		},
+		{
+			msg:                 "single failure with failuresToClose=2",
+			failuresToClose:     2,
+			pingResponses:       []bool{true, false, true, false, true},
+			wantActive:          true,
+			wantHealthCheckLogs: 2,
+		},
+		{
+			msg:                 "up to 2 consecutive failures with failuresToClose=3",
+			failuresToClose:     3,
+			pingResponses:       []bool{true, false, true, false, true, false, false, true, false, false, true},
+			wantActive:          true,
+			wantHealthCheckLogs: 6,
+		},
+		{
+			msg:                 "3 consecutive failures with failuresToClose=3",
+			failuresToClose:     3,
+			pingResponses:       []bool{true, false, true, false, true, false, false, true, false, false, false},
+			wantActive:          false,
+			wantHealthCheckLogs: 7,
+		},
+	}
+
+	errFrame := getErrorFrame(t)
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			opts := testutils.NewOpts().NoRelay()
+			testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+				var pingCount int
+				frameRelay, cancel := testutils.FrameRelay(t, ts.HostPort(), func(outgoing bool, f *Frame) *Frame {
+					if strings.Contains(f.Header.String(), "PingRes") {
+						success := tt.pingResponses[pingCount]
+						pingCount++
+						if !success {
+							errFrame.Header.ID = f.Header.ID
+							f = errFrame
+						}
+					}
+					return f
+				})
+				defer cancel()
+
+				ft := newFakeTicker()
+				opts := testutils.NewOpts().
+					SetTimeTicker(ft.New).
+					SetHealthChecks(HealthCheckOptions{Interval: time.Second, FailuresToClose: tt.failuresToClose}).
+					AddLogFilter("Failed active health check.", uint(tt.wantHealthCheckLogs)).
+					AddLogFilter("Unexpected ping response.", 1)
+				client := ts.NewClient(opts)
+
+				ctx, cancel := NewContext(time.Second)
+				defer cancel()
+
+				conn, err := client.RootPeers().GetOrAdd(frameRelay).GetConnection(ctx)
+				require.NoError(t, err, "Failed to get connection")
+
+				for i := 0; i < len(tt.pingResponses); i++ {
+					ft.tryTick()
+
+					waitForNHealthChecks(t, conn, i+1)
+					assert.Equal(t, tt.pingResponses[:i+1], introspectConn(conn).HealthChecks, "Unexpectd health check history")
+					if !conn.IsActive() {
+						break
+					}
+				}
+				assert.Equal(t, tt.wantActive, conn.IsActive(), "Connection active mismatch")
+			})
+		})
+	}
+}
+
+func waitForNHealthChecks(t *testing.T, conn *Connection, n int) {
+	require.True(t, testutils.WaitFor(time.Second, func() bool {
+		return len(introspectConn(conn).HealthChecks) >= n
+	}), "Failed while waiting for %v health checks", n)
+}
+
+func introspectConn(c *Connection) ConnectionRuntimeState {
+	return c.IntrospectState(&IntrospectionOptions{})
+}

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthCheckEnabled(t *testing.T) {
+	hc := HealthCheckOptions{}
+	assert.False(t, hc.enabled(), "Default struct should not have health checks enabled")
+
+	hc.Interval = time.Second
+	assert.True(t, hc.enabled(), "Setting interval should enable health checks")
+}
+
+func TestHealthCheckOptionsDefaults(t *testing.T) {
+	tests := []struct {
+		opts HealthCheckOptions
+		want HealthCheckOptions
+	}{
+		{
+			opts: HealthCheckOptions{},
+			want: HealthCheckOptions{Timeout: _defaultHealthCheckTimeout, FailuresToClose: _defaultHealthCheckFailuresToClose},
+		},
+		{
+			opts: HealthCheckOptions{Timeout: 2 * time.Second},
+			want: HealthCheckOptions{Timeout: 2 * time.Second, FailuresToClose: _defaultHealthCheckFailuresToClose},
+		},
+		{
+			opts: HealthCheckOptions{FailuresToClose: 3},
+			want: HealthCheckOptions{Timeout: _defaultHealthCheckTimeout, FailuresToClose: 3},
+		},
+		{
+			opts: HealthCheckOptions{Timeout: 2 * time.Second, FailuresToClose: 3},
+			want: HealthCheckOptions{Timeout: 2 * time.Second, FailuresToClose: 3},
+		},
+	}
+
+	for _, tt := range tests {
+		got := tt.opts.withDefaults()
+		assert.Equal(t, tt.want, got, "Unexpected defaults for %+v", tt.opts)
+	}
+}
+
+func TestHealthHistory(t *testing.T) {
+	hh := newHealthHistory()
+	var want []bool
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, want, hh.asBools())
+		b := rand.Intn(3) > 0
+		hh.add(b)
+		want = append(want, b)
+		if len(want) > _healthHistorySize {
+			want = want[1:]
+		}
+	}
+
+}

--- a/introspection.go
+++ b/introspection.go
@@ -148,6 +148,7 @@ type ConnectionRuntimeState struct {
 	InboundExchange  ExchangeSetRuntimeState `json:"inboundExchange"`
 	OutboundExchange ExchangeSetRuntimeState `json:"outboundExchange"`
 	Relayer          RelayerRuntimeState     `json:"relayer"`
+	HealthChecks     []bool                  `json:"healthChecks,omitempty"`
 }
 
 // RelayerRuntimeState is the runtime state for a single relayer.
@@ -336,6 +337,7 @@ func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRunti
 	c.stateMut.RLock()
 	defer c.stateMut.RUnlock()
 
+	// TODO(prashantv): Add total number of health checks, and health check options.
 	state := ConnectionRuntimeState{
 		ID:               c.connID,
 		ConnectionState:  c.state.String(),
@@ -345,6 +347,7 @@ func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRunti
 		RemotePeer:       c.remotePeerInfo,
 		InboundExchange:  c.inbound.IntrospectState(opts),
 		OutboundExchange: c.outbound.IntrospectState(opts),
+		HealthChecks:     c.healthCheckHistory.asBools(),
 	}
 	if c.relay != nil {
 		state.Relayer = c.relay.IntrospectState(opts)

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -119,6 +119,12 @@ func (o *ChannelOpts) SetFramePool(framePool tchannel.FramePool) *ChannelOpts {
 	return o
 }
 
+// SetHealthChecks sets HealthChecks in DefaultConnectionOptions.
+func (o *ChannelOpts) SetHealthChecks(healthChecks tchannel.HealthCheckOptions) *ChannelOpts {
+	o.DefaultConnectionOptions.HealthChecks = healthChecks
+	return o
+}
+
 // SetSendBufferSize sets the SendBufferSize in DefaultConnectionOptions.
 func (o *ChannelOpts) SetSendBufferSize(bufSize int) *ChannelOpts {
 	o.DefaultConnectionOptions.SendBufferSize = bufSize
@@ -134,6 +140,12 @@ func (o *ChannelOpts) SetTosPriority(tosPriority tos.ToS) *ChannelOpts {
 // SetTimeNow sets TimeNow in ChannelOptions.
 func (o *ChannelOpts) SetTimeNow(timeNow func() time.Time) *ChannelOpts {
 	o.TimeNow = timeNow
+	return o
+}
+
+// SetTimeTicker sets TimeTicker in ChannelOptions.
+func (o *ChannelOpts) SetTimeTicker(timeTicker func(d time.Duration) *time.Ticker) *ChannelOpts {
+	o.TimeTicker = timeTicker
 	return o
 }
 

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -56,14 +56,19 @@ func (ch *Channel) SetRandomSeed(seed int64) {
 	}
 }
 
-// Ping sends a ping on the specific connection.
+// Ping exports ping for tests.
 func (c *Connection) Ping(ctx context.Context) error {
 	return c.ping(ctx)
 }
 
-// Logger returns the logger for the specific connection.
+// Logger returns the logger for the specific connection for tests.
 func (c *Connection) Logger() Logger {
 	return c.log
+}
+
+// StopHealthCheck exports stopHealthCheck for tests.
+func (c *Connection) StopHealthCheck() {
+	c.stopHealthCheck()
 }
 
 // OutboundConnection returns the underlying connection for an outbound call.


### PR DESCRIPTION
If a TChannel connection stalls (e.g., the remote side has disappeared,
and traffic starts black-holing), TChannel waits for TCP to detect this
issue, but this is often not configurable, and it can be a long period
of time (we've observed many minutes in production).
    
In many P2P situations, it's desirable to detect these failures as soon
as possible. Support active health checking using TChannel pings on a
periodic basis, with configurable timeouts, number of failures etc.
