### PR TITLE
Fix ErrInvalidConnectionState not being retried

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -33,7 +33,9 @@ import (
 
 var (
 	// ErrInvalidConnectionState indicates that the connection is not in a valid state.
-	ErrInvalidConnectionState = errors.New("connection is in an invalid state")
+	// This may be due to a race between selecting the connection and it closing, so
+	// it is a network failure that can be retried.
+	ErrInvalidConnectionState = NewSystemError(ErrCodeNetwork, "connection is in an invalid state")
 
 	// ErrNoPeers indicates that there are no peers.
 	ErrNoPeers = errors.New("no peers available")


### PR DESCRIPTION
It's possible that ErrInvalidConnectionState is retried in a race
between selecting a connection, and the connection being closed.

This should be treated as a network error which can be retried.

Caught this while debugging why TestRequestStateRetry was flaky, this
fixes the flakiness.

To test the flakiness, I ran this test 1000 times till it failed,
https://travis-ci.org/uber/tchannel-go/jobs/124585965

After the fix, it passes even after 1000 iterations,
https://travis-ci.org/uber/tchannel-go/jobs/124586838