### PR TITLE
Create new lazy message types that wrap a *Frame

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -38,10 +38,6 @@ const (
 
 	// MaxFramePayloadSize is the maximum size of the payload for a single frame
 	MaxFramePayloadSize = MaxFrameSize - FrameHeaderSize
-
-	_flagsIndex       = 0
-	_serviceLenIndex  = 1 /* flags */ + 4 /* ttl */ + 25 /* tracing */
-	_serviceNameIndex = _serviceLenIndex + 1
 )
 
 // FrameHeader is the header for a frame, containing the MessageType and size
@@ -174,16 +170,6 @@ func (f *Frame) SizedPayload() []byte {
 // messageType returns the message type.
 func (f *Frame) messageType() messageType {
 	return f.Header.messageType
-}
-
-// Service returns the name of the destination service. It panics if called for
-// a non-callReq frame.
-func (f *Frame) Service() string {
-	if f.messageType() != messageTypeCallReq {
-		panic("Shouldn't need to inspect the service name for a non-callReq frame.")
-	}
-	l := f.Payload[_serviceLenIndex]
-	return string(f.Payload[_serviceNameIndex : _serviceNameIndex+l])
 }
 
 func (f *Frame) write(msg message) error {

--- a/frame_test.go
+++ b/frame_test.go
@@ -135,44 +135,6 @@ func TestReservedBytes(t *testing.T) {
 		buf.Bytes(), "Unexpected bytes")
 }
 
-func TestServiceCallReq(t *testing.T) {
-	// TODO: This test doesn't work, since the initial flags byte is written in
-	// reqResWriter instead of callReq. We should instead handle that in
-	// callReq, which will allow tests to be sane.
-	if 1 == 2 { // go vet doesn't like unreachable code...
-		frame := NewFrame(MaxFramePayloadSize)
-		err := frame.write(&callReq{Service: "udr"})
-		require.NoError(t, err, "Error writing message to frame.")
-		assert.Equal(t, "udr", frame.Service(), "Failed to read service name from frame.")
-	}
-}
-
-func TestServiceCallReqTerrible(t *testing.T) {
-	// TODO: Delete in favor of TestServiceCallReq.
-	f := NewFrame(100)
-	fh := fakeHeader()
-	f.Header = fh
-	fh.write(typed.NewWriteBuffer(f.headerBuffer))
-
-	payload := typed.NewWriteBuffer(f.Payload)
-	payload.WriteSingleByte(0)           // flags
-	payload.WriteUint32(42)              // TTL
-	payload.WriteBytes(make([]byte, 25)) // tracing
-	payload.WriteLen8String("bankmoji")  // service
-	assert.Equal(t, "bankmoji", f.Service(), "Failed to read service name from frame.")
-}
-
-func TestServiceOtherMessages(t *testing.T) {
-	msg := &initReq{initMessage{id: 1, Version: 0x1, initParams: initParams{
-		InitParamHostPort:    "0.0.0.0:0",
-		InitParamProcessName: "test",
-	}}}
-	frame := NewFrame(MaxFramePayloadSize)
-	err := frame.write(msg)
-	require.NoError(t, err, "Error writing message to frame.")
-	assert.Panics(t, func() { frame.Service() }, "Should panic when getting service from non-callReq frame.")
-}
-
 func TestMessageType(t *testing.T) {
 	frame := NewFrame(MaxFramePayloadSize)
 	err := frame.write(&callReq{Service: "foo"})

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import "fmt"
+
+const (
+	_serviceLenIndex  = 1 /* flags */ + 4 /* ttl */ + 25 /* tracing */
+	_serviceNameIndex = _serviceLenIndex + 1
+	_flagsIndex       = 0
+)
+
+type lazyCallReq struct {
+	*Frame
+}
+
+func newLazyCallReq(f *Frame) lazyCallReq {
+	if msgType := f.Header.messageType; msgType != messageTypeCallReq {
+		panic(fmt.Errorf("newLazyCallReq called for wrong messageType: %v", msgType))
+	}
+	return lazyCallReq{f}
+}
+
+// Service returns the name of the destination service for this callReq.
+func (f lazyCallReq) Service() string {
+	l := f.Payload[_serviceLenIndex]
+	return string(f.Payload[_serviceNameIndex : _serviceNameIndex+l])
+}
+
+// finishesCall checks whether this frame is the last one we should expect for
+// this RPC req-res.
+func finishesCall(f *Frame) bool {
+	switch f.messageType() {
+	case messageTypeError:
+		return true
+	case messageTypeCallRes, messageTypeCallResContinue:
+		flags := f.Payload[_flagsIndex]
+		return flags&hasMoreFragmentsFlag == 0
+	default:
+		return false
+	}
+}

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package tchannel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/typed"
+)
+
+func TestCallReqService(t *testing.T) {
+	// TODO: This test doesn't work, since the initial flags byte is written in
+	// reqResWriter instead of callReq. We should instead handle that in
+	// callReq, which will allow tests to be sane.
+	if 1 == 2 { // go vet doesn't like unreachable code...
+		frame := NewFrame(MaxFramePayloadSize)
+		err := frame.write(&callReq{Service: "udr"})
+		require.NoError(t, err, "Error writing message to frame.")
+
+		callReq := newLazyCallReq(frame)
+		assert.Equal(t, "udr", callReq.Service(), "Failed to read service name from frame.")
+	}
+}
+
+func TestCallReqServiceTerrible(t *testing.T) {
+	// TODO: Delete in favor of TestCallReqService.
+	f := NewFrame(100)
+	fh := fakeHeader()
+	f.Header = fh
+	fh.write(typed.NewWriteBuffer(f.headerBuffer))
+
+	payload := typed.NewWriteBuffer(f.Payload)
+	payload.WriteSingleByte(0)           // flags
+	payload.WriteUint32(42)              // TTL
+	payload.WriteBytes(make([]byte, 25)) // tracing
+	payload.WriteLen8String("bankmoji")  // service
+
+	callReq := newLazyCallReq(f)
+	assert.Equal(t, "bankmoji", callReq.Service(), "Failed to read service name from frame.")
+}
+
+func TestServiceOtherMessages(t *testing.T) {
+	msg := &initReq{initMessage{id: 1, Version: 0x1, initParams: initParams{
+		InitParamHostPort:    "0.0.0.0:0",
+		InitParamProcessName: "test",
+	}}}
+	frame := NewFrame(MaxFramePayloadSize)
+	err := frame.write(msg)
+	require.NoError(t, err, "Error writing message to frame.")
+	assert.Panics(t, func() {
+		newLazyCallReq(frame)
+	}, "Should panic when creating callReq from non-callReq frame.")
+}


### PR DESCRIPTION
The wrapped classes are the same size as the pointer, and allow us to
add messageType-specific methods on top of a frame rather than adding
them to the frame directly.

In future, we may want to cache items in the wrapped class.