### PR TITLE
Ensure that all created channels are closed

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -42,6 +42,7 @@ func TestLoggers(t *testing.T) {
 		Logger: NewLogger(ioutil.Discard),
 	})
 	require.NoError(t, err, "NewChannel failed")
+	defer ch.Close()
 
 	peerInfo := ch.PeerInfo()
 	fields := toMap(ch.Logger().Fields())
@@ -58,6 +59,7 @@ func TestStats(t *testing.T) {
 		Logger: NewLogger(ioutil.Discard),
 	})
 	require.NoError(t, err, "NewChannel failed")
+	defer ch.Close()
 
 	hostname, err := os.Hostname()
 	require.NoError(t, err, "Hostname failed")
@@ -84,6 +86,7 @@ func TestIsolatedSubChannelsDontSharePeers(t *testing.T) {
 		Logger: NewLogger(ioutil.Discard),
 	})
 	require.NoError(t, err, "NewChannel failed")
+	defer ch.Close()
 
 	sub := ch.GetSubChannel("svc-ringpop")
 	if ch.peers != sub.peers {

--- a/connection_test.go
+++ b/connection_test.go
@@ -262,6 +262,7 @@ func TestPing(t *testing.T) {
 		defer cancel()
 
 		clientCh := testutils.NewClient(t, nil)
+		defer clientCh.Close()
 		require.NoError(t, clientCh.Ping(ctx, hostPort))
 	})
 }

--- a/init_test.go
+++ b/init_test.go
@@ -187,6 +187,7 @@ func TestHandleInitRes(t *testing.T) {
 
 	ch, err := NewChannel("test-svc", nil)
 	require.NoError(t, err, "NewChannel failed")
+	defer ch.Close()
 
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
@@ -223,6 +224,7 @@ func TestInitReqGetsError(t *testing.T) {
 	logOut := &bytes.Buffer{}
 	ch, err := NewChannel("test-svc", &ChannelOptions{Logger: NewLevelLogger(NewLogger(logOut), LogLevelWarn)})
 	require.NoError(t, err, "NewClient failed")
+	defer ch.Close()
 
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()

--- a/peer_test.go
+++ b/peer_test.go
@@ -38,6 +38,7 @@ import (
 
 func TestGetPeerNoPeer(t *testing.T) {
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
 	peer, err := ch.Peers().Get(nil)
 	assert.Equal(t, ErrNoPeers, err, "Empty peer list should return error")
 	assert.Nil(t, peer, "should not return peer")
@@ -45,6 +46,7 @@ func TestGetPeerNoPeer(t *testing.T) {
 
 func TestGetPeerSinglePeer(t *testing.T) {
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
 	ch.Peers().Add("1.1.1.1:1234")
 
 	peer, err := ch.Peers().Get(nil)
@@ -61,6 +63,7 @@ func TestGetPeerAvoidPrevSelected(t *testing.T) {
 	)
 
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
 	a, m := testutils.StrArray, testutils.StrMap
 	tests := []struct {
 		msg          string
@@ -226,7 +229,10 @@ func TestOutboundPeerNotAdded(t *testing.T) {
 }
 
 func TestRemovePeerNotFound(t *testing.T) {
-	peers := testutils.NewClient(t, nil).Peers()
+	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
+
+	peers := ch.Peers()
 	peers.Add("1.1.1.1:1")
 	assert.Error(t, peers.Remove("not-found"), "Remove should fa")
 	assert.NoError(t, peers.Remove("1.1.1.1:1"), "Remove shouldn't fail for existing peer")
@@ -526,6 +532,7 @@ func reverse(s []string) {
 func TestIsolatedPeerHeap(t *testing.T) {
 	const numPeers = 10
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
 
 	ps1 := createSubChannelWNewStrategy(ch, "S1", numPeers, 1)
 	ps2 := createSubChannelWNewStrategy(ch, "S2", numPeers, -1, Isolated)
@@ -558,6 +565,7 @@ func TestPeerSelectionRanking(t *testing.T) {
 
 	for i := 0; i < numIterations; i++ {
 		ch := testutils.NewClient(t, nil)
+		defer ch.Close()
 		ch.SetRandomSeed(int64(i * 100))
 
 		for i := 0; i < numPeers; i++ {

--- a/retry_test.go
+++ b/retry_test.go
@@ -106,6 +106,7 @@ func TestCanRetry(t *testing.T) {
 
 func TestNoRetry(t *testing.T) {
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
 
 	e := getTestErrors()
 	retryOpts := &RetryOptions{RetryOn: RetryNever}
@@ -122,6 +123,7 @@ func TestNoRetry(t *testing.T) {
 
 func TestRetryTillMaxAttempts(t *testing.T) {
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
 
 	setErr := ErrServerBusy
 	runTest := func(maxAttempts, numErrors, expectCounter int, expectErr error) {
@@ -167,6 +169,8 @@ func TestRetrySubContextNoTimeoutPerAttempt(t *testing.T) {
 	defer cancel()
 
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
+
 	counter := 0
 	ch.RunWithRetry(ctx, func(sctx context.Context, _ *RequestState) error {
 		counter++
@@ -183,6 +187,8 @@ func TestRetrySubContextTimeoutPerAttempt(t *testing.T) {
 	defer cancel()
 
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
+
 	var lastDeadline time.Time
 
 	counter := 0
@@ -205,6 +211,7 @@ func TestRetrySubContextTimeoutPerAttempt(t *testing.T) {
 func TestRetryNetConnect(t *testing.T) {
 	e := getTestErrors()
 	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
 
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()

--- a/tracereporter_test.go
+++ b/tracereporter_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTraceReporterFactory(t *testing.T) {
@@ -36,7 +37,8 @@ func TestTraceReporterFactory(t *testing.T) {
 		TraceReporter:        NullReporter,
 		TraceReporterFactory: testTraceReporterFactory,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	defer tc.Close()
 	assert.Equal(t, tc, gotChannel, "TraceReporterFactory got wrong channel")
 	assert.Equal(t, tc.traceReporter, SimpleTraceReporter, "Wrong TraceReporter")
 }


### PR DESCRIPTION
I'm moving towards outputting the introspected state on test failures (e.g. #326), which includes `OtherChannels`. To keep the errors readable and of a reasonable length, we should make sure we always Close channels in tests.

We verify that all channels are closed once all the tests are run successfully in `TestMain`.