### PR TITLE
Improve introspection for exchanges and relay items

### DIFF
--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -21,6 +21,7 @@
 package testutils
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
@@ -270,15 +271,29 @@ func (ts *TestServer) verifyRelaysEmpty(ch *tchannel.Channel) {
 	if ts.Failed() {
 		return
 	}
-	for _, peerState := range ch.IntrospectState(nil).RootPeers {
+	var foundErrors bool
+	state := ch.IntrospectState(&tchannel.IntrospectionOptions{IncludeExchanges: true})
+	for _, peerState := range state.RootPeers {
 		var connStates []tchannel.ConnectionRuntimeState
 		connStates = append(connStates, peerState.InboundConnections...)
 		connStates = append(connStates, peerState.OutboundConnections...)
 		for _, connState := range connStates {
-			n := connState.Relayer.NumItems
-			assert.Equal(ts, 0, n, "Found %v left-over items in relayer for %v.", n, connState.LocalHostPort)
+			n := connState.Relayer.Count
+			if assert.Equal(ts, 0, n, "Found %v left-over items in relayer for %v.", n, connState.LocalHostPort) {
+				continue
+			}
+			foundErrors = true
 		}
 	}
+
+	if !foundErrors {
+		return
+	}
+
+	marshalled, err := json.MarshalIndent(state, "", "  ")
+	require.NoError(ts, err, "Failed to marshal relayer state")
+	// Print out all the exchanges we found.
+	ts.Logf("Relayer state:\n%s", marshalled)
 }
 
 func (ts *TestServer) verifyNoGoroutinesLeaked() {


### PR DESCRIPTION
Relay items introspection is similar to message exchanges -- we should add as much information as possible when `IncludeExchanges` is enabled.

Use a`map[string]T` for the exchanges/items map to match the internal state.