### PR TITLE
Remove withRelayTest and use TestServer instead

### DIFF
--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -51,6 +51,9 @@ type ChannelOpts struct {
 	// clients. It's ignored by other test helpers.
 	IncludeRelay bool
 
+	// OnlyRelay instructs TestServer the test must only be run with a relay.
+	OnlyRelay bool
+
 	// optFn is run with the channel options before creating the channel.
 	optFn func(*ChannelOpts)
 
@@ -143,8 +146,16 @@ func (o *ChannelOpts) DisableLogVerification() *ChannelOpts {
 	return o
 }
 
-// SetRelay instructs TestServer to put a relay in front of this channel.
+// SetRelay instructs TestServer to run the test twice, once without a relay
+// and once with a relay in front of this channel.
 func (o *ChannelOpts) SetRelay() *ChannelOpts {
+	o.IncludeRelay = true
+	return o
+}
+
+// SetRelayOnly instructs TestServer to only run with a relay in front of this channel.
+func (o *ChannelOpts) SetRelayOnly() *ChannelOpts {
+	o.OnlyRelay = true
 	o.IncludeRelay = true
 	return o
 }

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -91,9 +91,12 @@ func NewTestServer(t testing.TB, opts *ChannelOpts) *TestServer {
 // TODO: run function twice; once with a relay, once without.
 func WithTestServer(t testing.TB, chanOpts *ChannelOpts, f func(*TestServer)) {
 
-	noRelayOpts := chanOpts.Copy()
-	noRelayOpts.IncludeRelay = false
-	withServer(t, noRelayOpts, f)
+	// Run without a relay unless OnlyRelay is set.
+	if chanOpts == nil || !chanOpts.OnlyRelay {
+		noRelayOpts := chanOpts.Copy()
+		noRelayOpts.IncludeRelay = false
+		withServer(t, noRelayOpts, f)
+	}
 
 	if chanOpts != nil && chanOpts.IncludeRelay {
 		withServer(t, chanOpts.Copy(), f)


### PR DESCRIPTION
Add a new option to `TestServer` to only run with a relay, which is used by the relay tests.