### PR TITLE
TestServer fixes and clean up

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -21,7 +21,6 @@
 package tchannel_test
 
 import (
-	"log"
 	"math/rand"
 	"sync"
 	"testing"
@@ -102,8 +101,6 @@ func TestCloseAfterTimeout(t *testing.T) {
 }
 
 func TestRaceExchangesWithClose(t *testing.T) {
-	log.SetFlags(log.Lmicroseconds)
-
 	var wg sync.WaitGroup
 
 	ctx, cancel := NewContext(testutils.Timeout(70 * time.Millisecond))
@@ -124,7 +121,7 @@ func TestRaceExchangesWithClose(t *testing.T) {
 			<-completeCall
 		})
 
-		client := testutils.NewClient(t, nil)
+		client := ts.NewClient(opts)
 		defer client.Close()
 
 		callDone := make(chan struct{})
@@ -142,7 +139,8 @@ func TestRaceExchangesWithClose(t *testing.T) {
 			go func() {
 				defer wg.Done()
 
-				c := testutils.NewClient(t, nil)
+				// We don't use ts.NewClient here to avoid data races.
+				c := testutils.NewClient(t, opts)
 				defer c.Close()
 
 				c.Ping(ctx, ts.HostPort())

--- a/close_test.go
+++ b/close_test.go
@@ -493,7 +493,8 @@ func TestCloseSendError(t *testing.T) {
 		counter atomic.Uint32
 	)
 
-	serverCh := testutils.NewServer(t, nil)
+	opts := testutils.NewOpts().DisableLogVerification()
+	serverCh := testutils.NewServer(t, opts)
 	testutils.RegisterEcho(serverCh, func() {
 		if counter.Inc() > 10 {
 			// Close the server in a goroutine to possibly trigger more race conditions.
@@ -504,7 +505,7 @@ func TestCloseSendError(t *testing.T) {
 		}
 	})
 
-	clientCh := testutils.NewClient(t, nil)
+	clientCh := testutils.NewClient(t, opts)
 
 	// Create a connection that will be shared.
 	require.NoError(t, testutils.Ping(clientCh, serverCh), "Ping from client to server failed")

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -32,6 +32,7 @@ import (
 )
 
 // NewServerChannel creates a TChannel that is listening and returns the channel.
+// Passed in options may be mutated (for post-verification of state).
 func NewServerChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 	if opts == nil {
 		opts = &ChannelOpts{}
@@ -48,7 +49,7 @@ func NewServerChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 
 	serviceName := defaultString(opts.ServiceName, DefaultServerName)
 	opts.ProcessName = defaultString(opts.ProcessName, serviceName+"-"+port)
-	ch, err := tchannel.NewChannel(serviceName, getChannelOptions(opts))
+	ch, err := tchannel.NewChannel(serviceName, opts.GetTChannelOptions())
 	if err != nil {
 		return nil, fmt.Errorf("NewChannel failed: %v", err)
 	}
@@ -63,6 +64,7 @@ func NewServerChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 var totalClients atomic.Uint32
 
 // NewClientChannel creates a TChannel that is not listening.
+// Passed in options may be mutated (for post-verification of state).
 func NewClientChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 	if opts == nil {
 		opts = &ChannelOpts{}
@@ -71,7 +73,7 @@ func NewClientChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 	clientNum := totalClients.Inc()
 	serviceName := defaultString(opts.ServiceName, DefaultClientName)
 	opts.ProcessName = defaultString(opts.ProcessName, serviceName+"-"+fmt.Sprint(clientNum))
-	return tchannel.NewChannel(serviceName, getChannelOptions(opts))
+	return tchannel.NewChannel(serviceName, opts.GetTChannelOptions())
 }
 
 type rawFuncHandler struct {

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -159,21 +159,23 @@ func (o *ChannelOpts) addPostFn(f func()) {
 	o.postFns = append(o.postFns, f)
 }
 
+// GetTChannelOptions returns the tchannel.ChannelOptions to create a channel.
+// Note: we use a value receiver so this method does not mutate ChannelOpts.
+func (o ChannelOpts) GetTChannelOptions() *tchannel.ChannelOptions {
+	if o.Logger == nil && *connectionLog {
+		o.Logger = tchannel.SimpleLogger
+	}
+	if o.optFn != nil {
+		o.optFn(&o)
+	}
+	return &o.ChannelOptions
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue
 	}
 	return v
-}
-
-func getChannelOptions(opts *ChannelOpts) *tchannel.ChannelOptions {
-	if opts.Logger == nil && *connectionLog {
-		opts.Logger = tchannel.SimpleLogger
-	}
-	if opts.optFn != nil {
-		opts.optFn(opts)
-	}
-	return &opts.ChannelOptions
 }
 
 // NewOpts returns a new ChannelOpts that can be used in a chained fashion.


### PR DESCRIPTION
(This PR backports some ocde from the muttley branch, and specifically, has extra functions like `withTestServer` to make it easy to merge with the `muttley` branch).

There's been a bunch of testutils.TestServer issues:
 - Logs not always being verified
 - Debug logs not always printed for all channels
 - Unclear mutations of options

This change cleans up:
 - Mutation of options. Now we only do it in `update*` methods, and exported functions never modify the passed in `opts` (they always make a copy). I've tried to reduce the amount of options mutations as well (e.g. `GetTChannelOptions`).
 - Internal functions that require mutation (e.g. for the post-verification steps), will use unexported methods
 - TestServer no longer has a special first channel, but adds the initial channel using the same `NewTestServer` path that other channels go through
 - State verification is now a post-step since we need to wait for runnable goroutines to end to avoid flaky tests

Some new failures started after the fixes as some tests weren't seeing their log filter options correctly.