### PR TITLE
Fix unexpected goroutine for long runnign tests

### DIFF
--- a/testutils/goroutines/verify.go
+++ b/testutils/goroutines/verify.go
@@ -46,7 +46,7 @@ func filterStacks(stacks []Stack, skipID int, opts *VerifyOpts) []Stack {
 func isTestStack(s Stack) bool {
 	switch funcName := s.firstFunction; funcName {
 	case "testing.RunTests", "testing.(*T).Run":
-		return s.State() == "chan receive"
+		return strings.HasPrefix(s.State(), "chan receive")
 	case "runtime.goexit":
 		return strings.HasPrefix(s.State(), "syscall")
 	default:


### PR DESCRIPTION
The background "RunTests" goroutine changes state from:
"chan wait" to "chan wait, waiting for N minutes".

We should ignore suffixes for "chan wait" (similar to the syscall) to
avoid failures on long running tests.

While tests shouldn't run for > a minute, it can happen when debugging
and running the test in a loop.