### PR TITLE
Re-introduce changes dropped in rebase

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -28,12 +28,12 @@ import (
 
 	. "github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/atomic"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/testutils/goroutines"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 

--- a/close_test.go
+++ b/close_test.go
@@ -69,7 +69,7 @@ func TestCloseOnlyListening(t *testing.T) {
 }
 
 func TestCloseNewClient(t *testing.T) {
-	ch := testutils.NewServer(t, nil)
+	ch := testutils.NewClient(t, nil)
 
 	// If there are no connections, then the channel should close immediately.
 	ch.Close()

--- a/connection_test.go
+++ b/connection_test.go
@@ -369,7 +369,7 @@ func (h onErrorTestHandler) OnError(ctx context.Context, err error) {
 }
 
 func TestTimeout(t *testing.T) {
-	// TODO: Add relaying.
+	// TODO: Test with relay (once relays handle timeouts).
 	opts := testutils.NewOpts()
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		// onError may be called when the block call tries to write the call response.
@@ -457,7 +457,7 @@ func TestFragmentationSlowReader(t *testing.T) {
 	}
 
 	// Inbound forward will timeout and cause a warning log.
-	// TODO: Add relay.
+	// TODO: Test with relay (once relays handle timeouts).
 	opts := testutils.NewOpts().
 		AddLogFilter("Unable to forward frame", 1).
 		AddLogFilter("Connection error", 1)
@@ -485,7 +485,7 @@ func TestFragmentationSlowReader(t *testing.T) {
 
 func TestWriteArg3AfterTimeout(t *testing.T) {
 	// The channel reads and writes during timeouts, causing warning logs.
-	// TODO: Add relay.
+	// TODO: Test with relay (once relays handle timeouts).
 	opts := testutils.NewOpts().DisableLogVerification()
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		timedOut := make(chan struct{})
@@ -525,7 +525,7 @@ func TestWriteArg3AfterTimeout(t *testing.T) {
 
 func TestWriteErrorAfterTimeout(t *testing.T) {
 	// TODO: Make this test block at different points (e.g. before, during read/write).
-	// TODO: Add relay.
+	// TODO: Test with relay (once relays handle timeouts).
 	opts := testutils.NewOpts()
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		timedOut := make(chan struct{})


### PR DESCRIPTION
This mostly re-introduces changes from #333 and #340 - I think they were dropped in a rebase. I dropped the changes in 6017cf77af9468f6d199ae173ca5130cd1907c8c, because we made a conflicting change on the dev branch.