### PR TITLE
Set test timeout scale factor using environment variable instead of flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ go:
   - 1.6
   - tip
 install: make install_ci
+env:
+ # Set higher timeouts for Travis
+ - TEST_TIMEOUT_SCALE=20
 script:
  - make test_ci
  - make cover_ci

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ OLDGOPATH := $(GOPATH)
 PATH := $(GODEPS)/bin:$(PATH)
 EXAMPLES=./examples/bench/server ./examples/bench/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server
 PKGS := . ./atomic ./json ./hyperbahn ./thrift ./typed ./trace $(EXAMPLES)
-TEST_ARG ?= -race -v -timeout 2m
+TEST_ARG ?= -race -v -timeout 5m
 BUILD := ./build
 THRIFT_GEN_RELEASE := ./thrift-gen-release
 THRIFT_GEN_RELEASE_LINUX := $(THRIFT_GEN_RELEASE)/linux-x86_64
@@ -27,12 +27,6 @@ ARCH := $(shell uname -m)
 THRIFT_REL := ./scripts/travis/thrift-release/$(PLATFORM)-$(ARCH)
 
 export PATH := $(realpath $(THRIFT_REL)):$(PATH)
-
-
-# Separate packages that use testutils and don't, since they can have different flags.
-# This is especially useful for timeoutMultiplier and connectionLog
-TESTUTILS_TEST_PKGS := . hyperbahn testutils http json thrift pprof trace
-NO_TESTUTILS_PKGS := atomic stats thrift/thrift-gen tnet typed
 
 # Cross language test args
 TEST_HOST=127.0.0.1
@@ -66,7 +60,7 @@ install_ci: get_thrift install
 	go get -u github.com/mattn/goveralls
 
 install_test:
-	go test -i $(TEST_ARG) $(addprefix github.com/uber/tchannel-go/,$(NO_TESTUTILS_PKGS) $(TESTUTILS_TEST_PKGS))
+	go test -i $(TEST_ARG) github.com/uber/tchannel-go/...
 
 help:
 	@egrep "^# target:" [Mm]akefile | sort -
@@ -90,10 +84,9 @@ test_ci: test
 
 test: clean setup install_test
 	@echo Testing packages:
-	go test -parallel=4 $(TEST_ARG) $(addprefix github.com/uber/tchannel-go/,$(NO_TESTUTILS_PKGS))
-	go test -parallel=4 -timeoutMultiplier=10 $(TEST_ARG) $(addprefix github.com/uber/tchannel-go/,$(TESTUTILS_TEST_PKGS))
+	go test -parallel=4 $(TEST_ARG) github.com/uber/tchannel-go/...
 	@echo Running frame pool tests
-	go test -run TestFramesReleased -stressTest $(TEST_ARG) -timeoutMultiplier 10
+	go test -run TestFramesReleased -stressTest $(TEST_ARG)
 
 benchmark: clean setup
 	echo Running benchmarks:

--- a/testutils/timeout.go
+++ b/testutils/timeout.go
@@ -21,19 +21,31 @@
 package testutils
 
 import (
-	"flag"
 	"fmt"
+	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
 
-var timeoutMultiplier = flag.Float64("timeoutMultiplier", 1, "All calls to {Get,Set}Timeout have their timeout multiplied by this value")
+var timeoutScaleFactor = 1.0
+
+func init() {
+	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
+		fv, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			panic(err)
+		}
+		timeoutScaleFactor = fv
+		fmt.Println("Scaling timeouts by factor", timeoutScaleFactor)
+	}
+}
 
 // Timeout returns the timeout multiplied by any set multiplier.
 func Timeout(timeout time.Duration) time.Duration {
-	return time.Duration(*timeoutMultiplier * float64(timeout))
+	return time.Duration(timeoutScaleFactor * float64(timeout))
 }
 
 // getCallerName returns the test name that called this function.


### PR DESCRIPTION
Using an environment variable means it can be set in the .travis.yml file and the Makefile does not need to distinguish between packages that use testutils and packages that don't.

This should also fix some "timeout" flakes we see, it looks like we were running tests for coverage without the timeout multiplier, and so tests were being run with a lower timeout than expected.