### PR TITLE
Create new benchmark package with benchmark server/client

### DIFF
--- a/benchmark/benchserver/main.go
+++ b/benchmark/benchserver/main.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// benchserver is used to receive requests for benchmarks.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/uber/tchannel-go/benchmark"
+)
+
+var (
+	serviceName    = flag.String("service", "bench-server", "The benchmark server's service name")
+	advertiseHosts = flag.String("advertise-hosts", "", "Comma-separated list of hosts to advertise to")
+)
+
+func main() {
+	flag.Parse()
+
+	var adHosts []string
+	if len(*advertiseHosts) > 0 {
+		adHosts = strings.Split(*advertiseHosts, ",")
+	}
+
+	server := benchmark.NewServer(
+		benchmark.WithServiceName(*serviceName),
+		benchmark.WithAdvertiseHosts(adHosts),
+	)
+
+	fmt.Println(server.HostPort())
+
+	rdr := bufio.NewReader(os.Stdin)
+	for {
+		line, err := rdr.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			log.Fatalf("stdin read failed: %v", err)
+		}
+
+		line = strings.TrimSuffix(line, "\n")
+		switch line {
+		case "quit":
+			return
+		default:
+			log.Fatalf("unrecognized command: %v", line)
+		}
+	}
+}

--- a/benchmark/build_manager.go
+++ b/benchmark/build_manager.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+type buildManager struct {
+	sync.RWMutex
+	builds map[string]*build
+}
+
+type build struct {
+	once     sync.Once
+	mainFile string
+
+	binaryFile string
+	buildErr   error
+}
+
+func newBuildManager() *buildManager {
+	return &buildManager{
+		builds: make(map[string]*build),
+	}
+}
+
+func (m *buildManager) GoBinary(mainFile string) (string, error) {
+	m.Lock()
+	bld, ok := m.builds[mainFile]
+	if !ok {
+		bld = &build{mainFile: mainFile}
+		m.builds[mainFile] = bld
+	}
+	m.Unlock()
+
+	bld.once.Do(bld.Build)
+	return bld.binaryFile, bld.buildErr
+}
+
+func (b *build) Build() {
+	tempFile, err := ioutil.TempFile("", "bench")
+	if err != nil {
+		panic("Failed to create temp file: " + err.Error())
+	}
+	tempFile.Close()
+
+	buildCmd := exec.Command("go", "build", "-o", tempFile.Name(), b.mainFile)
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		b.buildErr = err
+		return
+	}
+
+	b.binaryFile = tempFile.Name()
+}

--- a/benchmark/external_client.go
+++ b/benchmark/external_client.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// externalClient represents a benchmark client running out-of-process.
+type externalClient struct {
+	*externalCmd
+	opts *options
+}
+
+func newExternalClient(hosts []string, opts *options) Client {
+	benchArgs := []string{
+		"--service", opts.svcName,
+		"--timeout", opts.timeout.String(),
+		"--request-size", strconv.Itoa(opts.reqSize),
+	}
+	benchArgs = append(benchArgs, hosts...)
+
+	cmd, initial := newExternalCmd("benchclient/main.go", benchArgs)
+	if !strings.Contains(initial, "started") {
+		panic("bench-client did not start, got: " + initial)
+	}
+
+	return &externalClient{cmd, opts}
+}
+
+func (c *externalClient) Warmup() error {
+	out, err := c.writeAndRead("warmup")
+	if err != nil {
+		return err
+	}
+	if out != "success" {
+		return fmt.Errorf("warmup failed: %v", out)
+	}
+	return nil
+}
+
+func (c *externalClient) callAndParse(cmd string) (time.Duration, error) {
+	out, err := c.writeAndRead(cmd)
+	if err != nil {
+		return 0, err
+	}
+	return time.ParseDuration(out)
+}
+
+func (c *externalClient) RawCall() (time.Duration, error) {
+	return c.callAndParse("rcall")
+}
+
+func (c *externalClient) ThriftCall() (time.Duration, error) {
+	return c.callAndParse("tcall")
+}

--- a/benchmark/external_common.go
+++ b/benchmark/external_common.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"os/exec"
+)
+
+var _bm = newBuildManager()
+
+// externalCmd handles communication with an external benchmark client.
+type externalCmd struct {
+	cmd        *exec.Cmd
+	stdoutOrig io.ReadCloser
+	stdout     *bufio.Scanner
+	stdin      io.WriteCloser
+}
+
+func newExternalCmd(mainFile string, benchArgs []string) (*externalCmd, string) {
+	bin, err := _bm.GoBinary(BenchmarkDir + mainFile)
+	if err != nil {
+		panic("failed to compile " + mainFile + ": " + err.Error())
+	}
+
+	cmd := exec.Command(bin, benchArgs...)
+	cmd.Stderr = os.Stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		panic("failed to create stdout: " + err.Error())
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		panic("failed to create stdin: " + err.Error())
+	}
+
+	if err := cmd.Start(); err != nil {
+		panic("failed ot start external process: " + err.Error())
+	}
+
+	stdoutScanner := bufio.NewScanner(stdout)
+	if !stdoutScanner.Scan() {
+		panic("failed to check if external process started: " + err.Error())
+	}
+
+	out := stdoutScanner.Text()
+	return &externalCmd{
+		cmd:        cmd,
+		stdin:      stdin,
+		stdout:     stdoutScanner,
+		stdoutOrig: stdout,
+	}, out
+}
+
+func (c *externalCmd) writeAndRead(cmd string) (string, error) {
+	if _, err := io.WriteString(c.stdin, cmd+"\n"); err != nil {
+		return "", err
+	}
+
+	if c.stdout.Scan() {
+		return c.stdout.Text(), nil
+	}
+
+	return "", c.stdout.Err()
+}
+
+func (c *externalCmd) Close() {
+	c.stdin.Close()
+	c.stdoutOrig.Close()
+	c.cmd.Process.Kill()
+}

--- a/benchmark/external_server.go
+++ b/benchmark/external_server.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"net"
+	"strings"
+)
+
+// externalServer represents a benchmark server running out-of-process.
+type externalServer struct {
+	*externalCmd
+	hostPort string
+	opts     *options
+}
+
+func newExternalServer(opts *options) Server {
+	benchArgs := []string{
+		"--service", opts.svcName,
+	}
+	if len(opts.advertiseHosts) > 0 {
+		benchArgs = append(benchArgs,
+			"--advertise-hosts", strings.Join(opts.advertiseHosts, ","))
+	}
+
+	cmd, hostPortStr := newExternalCmd("benchserver/main.go", benchArgs)
+	if _, _, err := net.SplitHostPort(hostPortStr); err != nil {
+		panic("bench-server did not print host:port on startup: " + err.Error())
+	}
+
+	return &externalServer{cmd, hostPortStr, opts}
+}
+
+func (s *externalServer) HostPort() string {
+	return s.hostPort
+}

--- a/benchmark/interfaces.go
+++ b/benchmark/interfaces.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import "time"
+
+// BenchmarkDir should be set to the benchmark source directory.
+var BenchmarkDir = "./"
+
+// Client is a benchmark client that can be used to call a benchmark server.
+type Client interface {
+	// Warmup will create connections to all host:ports the client was created with.
+	Warmup() error
+
+	// RawCall makes an echo call using raw.
+	RawCall() (time.Duration, error)
+
+	// ThriftCall makes an echo call using thrift.
+	ThriftCall() (time.Duration, error)
+
+	// Close closes the benchmark client.
+	Close()
+}
+
+// Server is a benchmark server that can receive requests.
+type Server interface {
+	// HostPort returns the HostPort that the server is listening on.
+	HostPort() string
+
+	// Close closes the benchmark server.
+	Close()
+}

--- a/benchmark/internal_client.go
+++ b/benchmark/internal_client.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/thrift"
+	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
+)
+
+// internalClient represents a benchmark client.
+type internalClient struct {
+	ch       *tchannel.Channel
+	sc       *tchannel.SubChannel
+	tClient  gen.TChanSecondService
+	argStr   string
+	argBytes []byte
+	opts     *options
+}
+
+// NewClient returns a new Client that can make calls to a benchmark server.
+func NewClient(hosts []string, optFns ...Option) Client {
+	opts := getOptions(optFns...)
+	if opts.external {
+		return newExternalClient(hosts, opts)
+	}
+
+	ch, err := tchannel.NewChannel(opts.svcName, nil)
+	if err != nil {
+		panic("failed to create channel: " + err.Error())
+	}
+	for _, host := range hosts {
+		ch.Peers().Add(host)
+	}
+	thriftClient := thrift.NewClient(ch, opts.svcName, nil)
+	client := gen.NewTChanSecondServiceClient(thriftClient)
+
+	argBytes := randomBytes(opts.reqSize)
+	return &internalClient{
+		ch:       ch,
+		sc:       ch.GetSubChannel(opts.svcName),
+		tClient:  client,
+		argBytes: argBytes,
+		argStr:   string(argBytes),
+		opts:     opts,
+	}
+}
+
+func (c *internalClient) Warmup() error {
+	for _, peer := range c.ch.Peers().Copy() {
+		ctx, cancel := tchannel.NewContext(c.opts.timeout)
+		_, err := peer.GetConnection(ctx)
+		cancel()
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *internalClient) RawCall() (time.Duration, error) {
+	ctx, cancel := tchannel.NewContext(c.opts.timeout)
+	defer cancel()
+
+	started := time.Now()
+	rArg2, rArg3, _, err := raw.CallSC(ctx, c.sc, "echo", c.argBytes, c.argBytes)
+	duration := time.Since(started)
+
+	if err != nil {
+		return 0, err
+	}
+	if !bytes.Equal(rArg2, c.argBytes) || !bytes.Equal(rArg3, c.argBytes) {
+		panic("echo call returned wrong results")
+	}
+	return duration, nil
+}
+
+func (c *internalClient) ThriftCall() (time.Duration, error) {
+	ctx, cancel := thrift.NewContext(c.opts.timeout)
+	defer cancel()
+
+	started := time.Now()
+	res, err := c.tClient.Echo(ctx, c.argStr)
+	duration := time.Since(started)
+
+	if err != nil {
+		return 0, err
+	}
+	if res != c.argStr {
+		panic("thrift Echo returned wrong result")
+	}
+	return duration, nil
+}
+
+func (c *internalClient) Close() {
+	c.ch.Close()
+}

--- a/benchmark/internal_server.go
+++ b/benchmark/internal_server.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"log"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/hyperbahn"
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/thrift"
+	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
+
+	"golang.org/x/net/context"
+)
+
+// internalServer represents a benchmark server.
+type internalServer struct {
+	ch   *tchannel.Channel
+	opts *options
+}
+
+// NewServer returns a new Server that can recieve Thrift calls or raw calls.
+func NewServer(optFns ...Option) Server {
+	opts := getOptions(optFns...)
+	if opts.external {
+		return newExternalServer(opts)
+	}
+
+	ch, err := tchannel.NewChannel(opts.svcName, nil)
+	if err != nil {
+		panic("failed to create channel: " + err.Error())
+	}
+	if err := ch.ListenAndServe("127.0.0.1:0"); err != nil {
+		panic("failed to listen on port 0: " + err.Error())
+	}
+
+	tServer := thrift.NewServer(ch)
+	tServer.Register(gen.NewTChanSecondServiceServer(handler{}))
+	ch.Register(raw.Wrap(rawHandler{}), "echo")
+
+	s := &internalServer{
+		ch:   ch,
+		opts: opts,
+	}
+
+	if len(opts.advertiseHosts) > 0 {
+		if err := s.Advertise(opts.advertiseHosts); err != nil {
+			panic("failed to advertise: " + err.Error())
+		}
+	}
+
+	return s
+}
+
+// HostPort returns the host:port that the server is listening on.
+func (s *internalServer) HostPort() string {
+	return s.ch.PeerInfo().HostPort
+}
+
+// Advertise advertises with Hyperbahn.
+func (s *internalServer) Advertise(hyperbahnHosts []string) error {
+	config := hyperbahn.Configuration{InitialNodes: hyperbahnHosts}
+	hc, err := hyperbahn.NewClient(s.ch, config, nil)
+	if err != nil {
+		panic("failed to setup Hyperbahn client: " + err.Error())
+	}
+	return hc.Advertise()
+}
+
+func (s *internalServer) Close() {
+	s.ch.Close()
+}
+
+type rawHandler struct{}
+
+func (rawHandler) OnError(ctx context.Context, err error) {
+	log.Printf("Server error: %v", err)
+}
+
+func (rawHandler) Handle(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+	return &raw.Res{
+		Arg2: args.Arg2,
+		Arg3: args.Arg3,
+	}, nil
+}
+
+type handler struct{}
+
+func (handler) Echo(ctx thrift.Context, arg1 string) (string, error) {
+	return arg1, nil
+}

--- a/benchmark/options.go
+++ b/benchmark/options.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import "time"
+
+type options struct {
+	external bool
+	svcName  string
+
+	// Following options only make sense for clients.
+	timeout time.Duration
+	reqSize int
+
+	// Following options only make sense for servers.
+	advertiseHosts []string
+}
+
+// Option represents a Benchmark option.
+type Option func(*options)
+
+// WithTimeout sets the timeout to use for each call.
+func WithTimeout(timeout time.Duration) Option {
+	return func(opts *options) {
+		opts.timeout = timeout
+	}
+}
+
+// WithRequestSize sets the request size for each call.
+func WithRequestSize(reqSize int) Option {
+	return func(opts *options) {
+		opts.reqSize = reqSize
+	}
+}
+
+// WithServiceName sets the service name of the benchmark server.
+func WithServiceName(svcName string) Option {
+	return func(opts *options) {
+		opts.svcName = svcName
+	}
+}
+
+// WithExternalProcess creates a separate process to host the server/client.
+func WithExternalProcess() Option {
+	return func(opts *options) {
+		opts.external = true
+	}
+}
+
+// WithAdvertiseHosts sets the hosts to advertise with on startup.
+func WithAdvertiseHosts(hosts []string) Option {
+	return func(opts *options) {
+		opts.advertiseHosts = hosts
+	}
+}
+
+func getOptions(optFns ...Option) *options {
+	opts := &options{
+		timeout: time.Second,
+		svcName: "bench-server",
+	}
+	for _, opt := range optFns {
+		opt(opts)
+	}
+	return opts
+}

--- a/benchmark/rand.go
+++ b/benchmark/rand.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"io"
+	"math/rand"
+	"time"
+)
+
+type randReader struct {
+	src rand.Source
+}
+
+func newRandReader() io.Reader {
+	return randReader{rand.NewSource(time.Now().UnixNano())}
+}
+
+func (r randReader) Read(p []byte) (n int, err error) {
+	for i := range p {
+		p[i] = byte(r.src.Int63() & 0xff)
+	}
+	return len(p), nil
+}
+
+func randomBytes(n int) []byte {
+	reader := newRandReader()
+	bs := make([]byte, n)
+	if _, err := io.ReadFull(reader, bs); err != nil {
+		panic("failed to read random bytes: " + err.Error())
+	}
+	return bs
+}

--- a/thrift/thrift_bench_test.go
+++ b/thrift/thrift_bench_test.go
@@ -21,250 +21,88 @@
 package thrift_test
 
 import (
-	"bufio"
 	"flag"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/atomic"
-	"github.com/uber/tchannel-go/hyperbahn"
-	"github.com/uber/tchannel-go/testutils"
-	"github.com/uber/tchannel-go/thrift"
-	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
+	"github.com/uber/tchannel-go/benchmark"
 
 	"github.com/stretchr/testify/require"
 )
 
 var (
 	useHyperbahn   = flag.Bool("useHyperbahn", false, "Whether to advertise and route requests through Hyperbahn")
-	hyperbahnNodes = flag.String("hyperbahnNodes", "127.0.0.1:21300,127.0.0.1:21301", "Comma-separated list of Hyperbahn nodes")
-	requestSize    = flag.Int("requestSize", 4, "Call payload size")
-	timeout        = flag.Duration("callTimeout", time.Second, "Timeout for each call")
+	hyperbahnNodes = flag.String("hyperbahn-nodes", "127.0.0.1:21300,127.0.0.1:21301", "Comma-separated list of Hyperbahn nodes")
+	requestSize    = flag.Int("request-size", 4, "Call payload size")
+	timeout        = flag.Duration("call-timeout", time.Second, "Timeout for each call")
 )
 
-const benchServerName = "bench-server"
-
-func setupBenchServer() ([]string, error) {
-	ch, err := testutils.NewServerChannel(testutils.NewOpts().
-		SetServiceName(benchServerName).
-		SetFramePool(tchannel.NewSyncFramePool()))
-	if err != nil {
-		return nil, err
-	}
-	fmt.Println(benchServerName, "started on", ch.PeerInfo().HostPort)
-
-	server := thrift.NewServer(ch)
-	server.Register(gen.NewTChanSecondServiceServer(benchSecondHandler{}))
-
-	if !*useHyperbahn {
-		return []string{ch.PeerInfo().HostPort}, nil
-	}
-
-	// Set up a Hyperbahn client and advertise it.
-	nodes := strings.Split(*hyperbahnNodes, ",")
-	config := hyperbahn.Configuration{InitialNodes: nodes}
-	hc, err := hyperbahn.NewClient(ch, config, nil)
-	if err := hc.Advertise(); err != nil {
-		return nil, err
-	}
-
-	return nodes, nil
+func init() {
+	benchmark.BenchmarkDir = "../benchmark/"
 }
 
 func BenchmarkBothSerial(b *testing.B) {
-	serverAddr, err := setupBenchServer()
-	require.NoError(b, err, "setupBenchServer failed")
-
-	opts := testutils.NewOpts().SetFramePool(tchannel.NewSyncFramePool())
-	clientCh := testutils.NewClient(b, opts)
-	for _, addr := range serverAddr {
-		clientCh.Peers().Add(addr)
-	}
-
-	thriftClient := thrift.NewClient(clientCh, "bench-server", nil)
-	client := gen.NewTChanSecondServiceClient(thriftClient)
-	ctx, cancel := thrift.NewContext(10 * time.Millisecond)
-	client.Echo(ctx, "make connection")
-	cancel()
+	server := benchmark.NewServer()
+	client := benchmark.NewClient(
+		[]string{server.HostPort()},
+		benchmark.WithTimeout(*timeout),
+		benchmark.WithRequestSize(*requestSize),
+	)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ctx, cancel := thrift.NewContext(10 * time.Millisecond)
-		defer cancel()
 
-		_, err := client.Echo(ctx, "hello world")
-		if err != nil {
-			b.Errorf("Echo failed: %v", err)
+		if _, err := client.ThriftCall(); err != nil {
+			b.Errorf("Call failed: %v", err)
 		}
 	}
 }
 
 func BenchmarkInboundSerial(b *testing.B) {
-	serverAddr, err := setupBenchServer()
-	require.NoError(b, err, "setupBenchServer failed")
-
-	// Start a client for each runner
-	client, err := startClient(serverAddr)
-	require.NoError(b, err, "startClient failed")
+	server := benchmark.NewServer()
+	client := benchmark.NewClient(
+		[]string{server.HostPort()},
+		benchmark.WithTimeout(*timeout),
+		benchmark.WithExternalProcess(),
+		benchmark.WithRequestSize(*requestSize),
+	)
 	defer client.Close()
+	require.NoError(b, client.Warmup(), "Warmup failed")
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		client.CallAndWait()
+		if _, err := client.ThriftCall(); err != nil {
+			b.Errorf("Call failed: %v", err)
+		}
 	}
 }
 
 func BenchmarkInboundParallel(b *testing.B) {
-	var reqCounter atomic.Int32
-	serverAddr, err := setupBenchServer()
-	require.NoError(b, err, "setupBenchServer failed")
+	server := benchmark.NewServer()
 
+	var reqCounter atomic.Int32
 	started := time.Now()
 
 	b.RunParallel(func(pb *testing.PB) {
-		// Start a client for each runner
-		client, err := startClient(serverAddr)
-		require.NoError(b, err, "startClient failed")
+		client := benchmark.NewClient(
+			[]string{server.HostPort()},
+			benchmark.WithTimeout(*timeout),
+			benchmark.WithExternalProcess(),
+			benchmark.WithRequestSize(*requestSize),
+		)
 		defer client.Close()
+		require.NoError(b, client.Warmup(), "Warmup failed")
 
 		for pb.Next() {
-			client.CallAndWait()
+			if _, err := client.ThriftCall(); err != nil {
+				b.Errorf("Call failed: %v", err)
+			}
 			reqCounter.Inc()
-		}
-		fmt.Println("Successful requests", client.numTimes, "Mean", client.mean)
-		for err, count := range client.errors {
-			fmt.Printf("%v: %v\n", count, err)
 		}
 	})
 
 	duration := time.Since(started)
 	reqs := reqCounter.Load()
-	fmt.Println("Requests", reqs, "RPS: ", float64(reqs)/duration.Seconds())
-}
-
-type benchSecondHandler struct{}
-
-func (benchSecondHandler) Echo(ctx thrift.Context, s string) (string, error) {
-	return s, nil
-}
-
-type benchClient struct {
-	cmd    *exec.Cmd
-	stdin  io.WriteCloser
-	stdout *bufio.Reader
-
-	numTimes int
-	mean     time.Duration
-	errors   map[string]int
-}
-
-var (
-	benchClientOnce sync.Once
-	benchClientPath string
-)
-
-func getBenchClientPath() (path string, err error) {
-	benchClientOnce.Do(func() {
-		var tempFile *os.File
-		tempFile, err = ioutil.TempFile("", "benchclient")
-		if err != nil {
-			return
-		}
-		if err = tempFile.Chmod(0755); err != nil {
-			return
-		}
-
-		benchClientPath = tempFile.Name()
-		cmd := exec.Command("go", "build", "-o", tempFile.Name(), ".")
-		cmd.Dir = "./benchclient"
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-	})
-
-	return benchClientPath, err
-}
-
-func startClient(servers []string) (*benchClient, error) {
-	path, err := getBenchClientPath()
-	if err != nil {
-		return nil, err
-	}
-
-	flags := []string{
-		"--serviceName", benchServerName,
-		"--requestSize", fmt.Sprint(*requestSize),
-		"--timeout", fmt.Sprint(*timeout),
-	}
-	flags = append(flags, servers...)
-	cmd := exec.Command(path, flags...)
-	cmd.Stderr = os.Stderr
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	bc := &benchClient{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdout), errors: make(map[string]int)}
-	return bc, bc.waitForStart()
-}
-
-func (c *benchClient) waitForStart() error {
-	line, err := c.stdout.ReadString('\n')
-	if err != nil {
-		return err
-	}
-
-	if line != "bench-client started\n" {
-		return fmt.Errorf("unexpected line: %v", line)
-	}
-	return nil
-}
-
-func (c *benchClient) CallAndWait() error {
-	fmt.Fprintln(c.stdin, "call")
-
-	// Wait till we read a line with the result.
-	line, err := c.stdout.ReadString('\n')
-	if err != nil {
-		return err
-	}
-
-	if strings.HasPrefix(line, "failed") {
-		c.errors[strings.TrimSuffix(line, "\n")]++
-	} else if t, err := time.ParseDuration(strings.TrimSuffix(line, "\n")); err == nil {
-		if c.numTimes > 0 {
-			c.mean = time.Duration(float64(c.mean)*float64(c.numTimes)/float64(c.numTimes+1) + float64(t)/float64(c.numTimes+1))
-		} else {
-			c.mean = t
-		}
-		c.numTimes++
-	} else {
-		fmt.Println("unexpected line:", err)
-	}
-
-	return nil
-}
-
-func (c *benchClient) Close() {
-	fmt.Fprintln(c.stdin, "quit")
-	go func() {
-		time.Sleep(time.Second)
-		c.cmd.Process.Kill()
-	}()
+	b.Logf("Requests: %v   RPS: %v", reqs, float64(reqs)/duration.Seconds())
 }


### PR DESCRIPTION
Make it easy to run these benchmarks as a separate process by passing an
option. Use new benchmark package for Thrift benchmarks.

Goal is to also add benchmarks to `_test.go` in the same folder, with the same code being used for raw and Thrift. That will come as a separate change. 