### PR TITLE
Handle timeouts (with tombstones) in relay

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	. "github.com/uber/tchannel-go"
-
 	"github.com/uber/tchannel-go/atomic"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
@@ -79,7 +78,8 @@ func TestCloseNewClient(t *testing.T) {
 }
 
 func TestCloseAfterTimeout(t *testing.T) {
-	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+	opts := testutils.NewOpts().SetRelay()
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		testHandler := onErrorTestHandler{newTestHandler(t), func(_ context.Context, err error) {}}
 		ts.Register(raw.Wrap(testHandler), "block")
 

--- a/connection.go
+++ b/connection.go
@@ -744,6 +744,7 @@ func (c *Connection) handleFrameRelay(frame *Frame) bool {
 	case messageTypeCallReq, messageTypeCallReqContinue, messageTypeCallRes, messageTypeCallResContinue, messageTypeError:
 		if err := c.relay.Relay(frame); err != nil {
 			c.log.WithFields(
+				ErrField(err),
 				LogField{"header", frame.Header},
 				LogField{"remotePeer", c.remotePeerInfo},
 			).Error("Failed to relay frame.")

--- a/frame_pool_test.go
+++ b/frame_pool_test.go
@@ -93,7 +93,7 @@ func doErrorCall(t *testing.T, clientCh *Channel, hostPort string) {
 func TestFramesReleased(t *testing.T) {
 	CheckStress(t)
 
-	defer testutils.SetTimeout(t, 10*time.Second)()
+	defer testutils.SetTimeout(t, 30*time.Second)()
 	const (
 		requestsPerGoroutine = 10
 		numGoroutines        = 10

--- a/testutils/logger.go
+++ b/testutils/logger.go
@@ -177,12 +177,13 @@ func (l errorLogger) checkFilters(msg string) bool {
 	matchCount := l.s.matchCount[match].Inc()
 	return uint(matchCount) <= l.v.Filters[match].Count
 }
+
 func (l errorLogger) checkErr(prefix, msg string) {
 	if l.checkFilters(msg) {
 		return
 	}
 
-	l.t.Errorf("%v: %s %v", prefix, msg, l.Logger.Fields())
+	l.t.Errorf("Unexpected log: %v: %s %v", prefix, msg, l.Logger.Fields())
 }
 
 func (l errorLogger) Fatal(msg string) {

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -68,9 +68,12 @@ type TestServer struct {
 // NewTestServer constructs a TestServer.
 func NewTestServer(t testing.TB, opts *ChannelOpts) *TestServer {
 	ts := &TestServer{
-		TB:             t,
-		channelStates:  make(map[*tchannel.Channel]*tchannel.RuntimeState),
-		introspectOpts: &tchannel.IntrospectionOptions{IncludeExchanges: true},
+		TB:            t,
+		channelStates: make(map[*tchannel.Channel]*tchannel.RuntimeState),
+		introspectOpts: &tchannel.IntrospectionOptions{
+			IncludeExchanges:  true,
+			IncludeTombstones: true,
+		},
 	}
 
 	ts.NewServer(opts)


### PR DESCRIPTION
Add timeout handling and tombstones to the relay, and enabled relaying in the remaining connection tests.