### PR TITLE
Fix flaky TestWriteArg3AfterTimeout

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -471,7 +471,7 @@ func TestWriteArg3AfterTimeout(t *testing.T) {
 		}
 		ch.Register(HandlerFunc(handler), "call")
 
-		ctx, cancel := NewContext(testutils.Timeout(20 * time.Millisecond))
+		ctx, cancel := NewContext(testutils.Timeout(50 * time.Millisecond))
 		defer cancel()
 		_, _, _, err := raw.Call(ctx, ch, hostPort, testServiceName, "call", nil, nil)
 		assert.Equal(t, err, ErrTimeout, "Call should timeout")


### PR DESCRIPTION
Test was failing because the timeout was too low -- it was timing out
before the handler got the call (at the connection stage).

The test needs the handler to get the call, so increase the timeout.