### PR TITLE
Benchmark improvements

### DIFF
--- a/benchmark/benchclient/main.go
+++ b/benchmark/benchclient/main.go
@@ -23,19 +23,15 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"flag"
 	"fmt"
 	"log"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
-	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/benchmark"
-	"github.com/uber/tchannel-go/raw"
-	"github.com/uber/tchannel-go/testutils"
-	"github.com/uber/tchannel-go/thrift"
-	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
 )
 
 var (
@@ -55,12 +51,18 @@ func main() {
 
 	rdr := bufio.NewScanner(os.Stdin)
 	for rdr.Scan() {
-		var (
-			d   time.Duration
-			err error
-		)
+		line := rdr.Text()
+		parts := strings.Split(line, " ")
+		var n int
+		var err error
+		if len(parts) >= 2 {
+			n, err = strconv.Atoi(parts[1])
+			if err != nil {
+				log.Fatalf("unrecognized number %q: %v", parts[1], err)
+			}
+		}
 
-		switch line := rdr.Text(); line {
+		switch cmd := parts[0]; cmd {
 		case "warmup":
 			if err := client.Warmup(); err != nil {
 				log.Fatalf("warmup failed: %v", err)
@@ -68,20 +70,14 @@ func main() {
 			fmt.Println("success")
 			continue
 		case "rcall":
-			d, err = client.RawCall()
+			makeCalls(n, client.RawCall)
 		case "tcall":
-			d, err = client.ThriftCall()
+			makeCalls(n, client.ThriftCall)
 		case "quit":
 			return
 		default:
 			log.Fatalf("unrecognized command: %v", line)
 		}
-
-		if err != nil {
-			log.Printf("Call failed: %v", err)
-			continue
-		}
-		fmt.Println(d)
 	}
 
 	if err := rdr.Err(); err != nil {
@@ -89,40 +85,16 @@ func main() {
 	}
 }
 
-func makeRawCall(ch *tchannel.Channel) {
-	ctx, cancel := tchannel.NewContext(*timeout)
-	defer cancel()
-
-	arg := testutils.RandBytes(*requestSize)
-	started := time.Now()
-
-	sc := ch.GetSubChannel(*serviceName)
-	rArg2, rArg3, _, err := raw.CallSC(ctx, sc, "echo", arg, arg)
+func makeCalls(n int, f func(n int) ([]time.Duration, error)) {
+	durations, err := f(n)
 	if err != nil {
-		fmt.Println("failed:", err)
-		return
+		log.Fatalf("Call failed: %v", err)
 	}
-	duration := time.Since(started)
-	if !bytes.Equal(rArg2, arg) || !bytes.Equal(rArg3, arg) {
-		log.Fatalf("Echo gave different string!")
+	for i, d := range durations {
+		if i > 0 {
+			fmt.Printf(" ")
+		}
+		fmt.Printf("%v", d)
 	}
-	fmt.Println(duration)
-}
-
-func makeCall(client gen.TChanSecondService) {
-	ctx, cancel := thrift.NewContext(*timeout)
-	defer cancel()
-
-	arg := testutils.RandString(*requestSize)
-	started := time.Now()
-	res, err := client.Echo(ctx, arg)
-	if err != nil {
-		fmt.Println("failed:", err)
-		return
-	}
-	duration := time.Since(started)
-	if res != arg {
-		log.Fatalf("Echo gave different string!")
-	}
-	fmt.Println(duration)
+	fmt.Println()
 }

--- a/benchmark/benchclient/main.go
+++ b/benchmark/benchclient/main.go
@@ -39,6 +39,7 @@ var (
 	timeout     = flag.Duration("timeout", time.Second, "Timeout for each request")
 	requestSize = flag.Int("request-size", 10000, "The number of bytes of each request")
 	noLibrary   = flag.Bool("no-library", false, "Whether to use the template based library instead of TChannel's client library")
+	numClients  = flag.Int("num-clients", 1, "Number of concurrent clients to run in process")
 )
 
 func main() {
@@ -48,6 +49,7 @@ func main() {
 		benchmark.WithServiceName(*serviceName),
 		benchmark.WithTimeout(*timeout),
 		benchmark.WithRequestSize(*requestSize),
+		benchmark.WithNumClients(*numClients),
 	}
 	if *noLibrary {
 		opts = append(opts, benchmark.WithNoLibrary())

--- a/benchmark/benchclient/main.go
+++ b/benchmark/benchclient/main.go
@@ -40,6 +40,7 @@ var (
 	requestSize = flag.Int("request-size", 10000, "The number of bytes of each request")
 	noLibrary   = flag.Bool("no-library", false, "Whether to use the template based library instead of TChannel's client library")
 	numClients  = flag.Int("num-clients", 1, "Number of concurrent clients to run in process")
+	noDurations = flag.Bool("no-durations", false, "Disable printing of latencies to stdout")
 )
 
 func main() {
@@ -99,11 +100,13 @@ func makeCalls(n int, f func(n int) ([]time.Duration, error)) {
 	if err != nil {
 		log.Fatalf("Call failed: %v", err)
 	}
-	for i, d := range durations {
-		if i > 0 {
-			fmt.Printf(" ")
+	if !*noDurations {
+		for i, d := range durations {
+			if i > 0 {
+				fmt.Printf(" ")
+			}
+			fmt.Printf("%v", d)
 		}
-		fmt.Printf("%v", d)
 	}
 	fmt.Println()
 }

--- a/benchmark/benchclient/main.go
+++ b/benchmark/benchclient/main.go
@@ -38,15 +38,22 @@ var (
 	serviceName = flag.String("service", "bench-server", "The benchmark server's service name")
 	timeout     = flag.Duration("timeout", time.Second, "Timeout for each request")
 	requestSize = flag.Int("request-size", 10000, "The number of bytes of each request")
+	noLibrary   = flag.Bool("no-library", false, "Whether to use the template based library instead of TChannel's client library")
 )
 
 func main() {
 	flag.Parse()
 
-	client := benchmark.NewClient(flag.Args(),
+	opts := []benchmark.Option{
 		benchmark.WithServiceName(*serviceName),
 		benchmark.WithTimeout(*timeout),
-		benchmark.WithRequestSize(*requestSize))
+		benchmark.WithRequestSize(*requestSize),
+	}
+	if *noLibrary {
+		opts = append(opts, benchmark.WithNoLibrary())
+	}
+
+	client := benchmark.NewClient(flag.Args(), opts...)
 	fmt.Println("bench-client started")
 
 	rdr := bufio.NewScanner(os.Stdin)

--- a/benchmark/benchserver/main.go
+++ b/benchmark/benchserver/main.go
@@ -65,6 +65,10 @@ func main() {
 
 		line = strings.TrimSuffix(line, "\n")
 		switch line {
+		case "count-raw":
+			fmt.Println(server.RawCalls())
+		case "count-thrift":
+			fmt.Println(server.ThriftCalls())
 		case "quit":
 			return
 		default:

--- a/benchmark/client_server_bench_test.go
+++ b/benchmark/client_server_bench_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkServer(b *testing.B) {
+	server := NewServer()
+
+	client := NewClient([]string{server.HostPort()},
+		WithExternalProcess(),
+		WithNoLibrary(),
+		WithNumClients(10),
+		WithNoDurations(),
+		WithTimeout(10*time.Second),
+	)
+
+	assert.NoError(b, client.Warmup(), "Warmup failed")
+
+	b.ResetTimer()
+	started := time.Now()
+	_, err := client.RawCall(b.N)
+	total := time.Since(started)
+	assert.NoError(b, err, "client.RawCall failed")
+
+	if n := server.RawCalls(); b.N > n {
+		b.Errorf("Server received %v calls, expected at least %v calls", n, b.N)
+	}
+	log.Printf("Calls: %v Duration: %v RPS: %.0f", b.N, total, float64(b.N)/total.Seconds())
+}
+
+func BenchmarkClient(b *testing.B) {
+	servers := make([]Server, 3)
+	serverHosts := make([]string, len(servers))
+	for i := range servers {
+		servers[i] = NewServer(
+			WithExternalProcess(),
+			WithNoLibrary(),
+		)
+		serverHosts[i] = servers[i].HostPort()
+	}
+
+	// To saturate a single process, we need to have multiple clients.
+	client := NewClient(serverHosts,
+		WithNoChecking(),
+		WithNumClients(10),
+	)
+	require.NoError(b, client.Warmup(), "Warmup failed")
+
+	b.ResetTimer()
+	started := time.Now()
+	if _, err := client.RawCall(b.N); err != nil {
+		b.Fatalf("Call failed: %v", err)
+	}
+	total := time.Since(started)
+	log.Printf("Calls: %v Duration: %v RPS: %.0f", b.N, total, float64(b.N)/total.Seconds())
+}

--- a/benchmark/external_client.go
+++ b/benchmark/external_client.go
@@ -38,6 +38,7 @@ func newExternalClient(hosts []string, opts *options) Client {
 		"--service", opts.svcName,
 		"--timeout", opts.timeout.String(),
 		"--request-size", strconv.Itoa(opts.reqSize),
+		"--num-clients", strconv.Itoa(opts.numClients),
 	}
 	if opts.noLibrary {
 		benchArgs = append(benchArgs, "--no-library")

--- a/benchmark/external_client.go
+++ b/benchmark/external_client.go
@@ -39,6 +39,9 @@ func newExternalClient(hosts []string, opts *options) Client {
 		"--timeout", opts.timeout.String(),
 		"--request-size", strconv.Itoa(opts.reqSize),
 	}
+	if opts.noLibrary {
+		benchArgs = append(benchArgs, "--no-library")
+	}
 	benchArgs = append(benchArgs, hosts...)
 
 	cmd, initial := newExternalCmd("benchclient/main.go", benchArgs)

--- a/benchmark/external_client.go
+++ b/benchmark/external_client.go
@@ -60,18 +60,34 @@ func (c *externalClient) Warmup() error {
 	return nil
 }
 
-func (c *externalClient) callAndParse(cmd string) (time.Duration, error) {
+func (c *externalClient) callAndParse(cmd string) ([]time.Duration, error) {
 	out, err := c.writeAndRead(cmd)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return time.ParseDuration(out)
+
+	if out == "" {
+		return nil, nil
+	}
+
+	durationStrs := strings.Split(out, " ")
+	durations := make([]time.Duration, len(durationStrs))
+	for i, s := range durationStrs {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("calls failed: %v", out)
+		}
+
+		durations[i] = d
+	}
+
+	return durations, nil
 }
 
-func (c *externalClient) RawCall() (time.Duration, error) {
-	return c.callAndParse("rcall")
+func (c *externalClient) RawCall(n int) ([]time.Duration, error) {
+	return c.callAndParse(fmt.Sprintf("rcall %v", n))
 }
 
-func (c *externalClient) ThriftCall() (time.Duration, error) {
-	return c.callAndParse("tcall")
+func (c *externalClient) ThriftCall(n int) ([]time.Duration, error) {
+	return c.callAndParse(fmt.Sprintf("tcall %v", n))
 }

--- a/benchmark/external_client.go
+++ b/benchmark/external_client.go
@@ -40,6 +40,9 @@ func newExternalClient(hosts []string, opts *options) Client {
 		"--request-size", strconv.Itoa(opts.reqSize),
 		"--num-clients", strconv.Itoa(opts.numClients),
 	}
+	if opts.noDurations {
+		benchArgs = append(benchArgs, "--no-durations")
+	}
 	if opts.noLibrary {
 		benchArgs = append(benchArgs, "--no-library")
 	}

--- a/benchmark/external_common.go
+++ b/benchmark/external_common.go
@@ -56,7 +56,7 @@ func newExternalCmd(mainFile string, benchArgs []string) (*externalCmd, string) 
 	}
 
 	if err := cmd.Start(); err != nil {
-		panic("failed ot start external process: " + err.Error())
+		panic("failed to start external process: " + err.Error())
 	}
 
 	stdoutScanner := bufio.NewScanner(stdout)

--- a/benchmark/external_server.go
+++ b/benchmark/external_server.go
@@ -22,6 +22,7 @@ package benchmark
 
 import (
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -51,4 +52,26 @@ func newExternalServer(opts *options) Server {
 
 func (s *externalServer) HostPort() string {
 	return s.hostPort
+}
+
+func (s *externalServer) RawCalls() int {
+	return s.writeAndReadInt("count-raw")
+}
+
+func (s *externalServer) ThriftCalls() int {
+	return s.writeAndReadInt("count-thrift")
+}
+
+func (s *externalServer) writeAndReadInt(cmd string) int {
+	v, err := s.writeAndRead(cmd)
+	if err != nil {
+		panic(err)
+	}
+
+	vInt, err := strconv.Atoi(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return vInt
 }

--- a/benchmark/frame_templates.go
+++ b/benchmark/frame_templates.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"time"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+const (
+	_idOffset    = 4             /* size (2) + type (1) + reserved (1) */
+	_idOffsetEnd = _idOffset + 4 /* length */
+)
+
+type frames struct {
+	outgoing [][]byte
+	incoming [][]byte
+}
+
+func (f frames) duplicate() frames {
+	return frames{
+		outgoing: deepCopyByteSlice(f.outgoing),
+		incoming: deepCopyByteSlice(f.incoming),
+	}
+}
+
+func deepCopyByteSlice(bs [][]byte) [][]byte {
+	newBs := make([][]byte, len(bs))
+	for i, b := range bs {
+		newBs[i] = make([]byte, len(b))
+		copy(newBs[i], b)
+	}
+	return newBs
+}
+
+func (f frames) writeInitReq(w io.Writer) error {
+	_, err := w.Write(f.outgoing[0])
+	return err
+}
+
+func (f frames) writeInitRes(w io.Writer) error {
+	_, err := w.Write(f.incoming[0])
+	return err
+}
+
+func (f frames) writeCallReq(id uint32, w io.Writer) (int, error) {
+	frames := f.outgoing[1:]
+	return f.writeMulti(id, w, frames)
+}
+
+func (f frames) writeCallRes(id uint32, w io.Writer) (int, error) {
+	frames := f.incoming[1:]
+	return f.writeMulti(id, w, frames)
+}
+
+func (f frames) writeMulti(id uint32, w io.Writer, frames [][]byte) (int, error) {
+	written := 0
+	for _, f := range frames {
+		binary.BigEndian.PutUint32(f[_idOffset:_idOffsetEnd], id)
+		if _, err := w.Write(f); err != nil {
+			return written, err
+		}
+		written++
+	}
+
+	return written, nil
+}
+
+func getRawCallFrames(timeout time.Duration, svcName string, reqSize int) frames {
+	var fs frames
+	modifier := func(fromClient bool, f *tchannel.Frame) *tchannel.Frame {
+		buf := &bytes.Buffer{}
+		if err := f.WriteOut(buf); err != nil {
+			panic(err)
+		}
+
+		if fromClient {
+			fs.outgoing = append(fs.outgoing, buf.Bytes())
+		} else {
+			fs.incoming = append(fs.incoming, buf.Bytes())
+		}
+
+		return f
+	}
+
+	withNewServerClient(svcName, func(server, client *tchannel.Channel) {
+		testutils.RegisterEcho(server, nil)
+
+		relay, err := NewTCPFrameRelay([]string{server.PeerInfo().HostPort}, modifier)
+		if err != nil {
+			panic(err)
+		}
+
+		args := &raw.Args{
+			Arg2: getRequestBytes(reqSize),
+			Arg3: getRequestBytes(reqSize),
+		}
+
+		ctx, cancel := tchannel.NewContext(timeout)
+		defer cancel()
+
+		if _, _, _, err := raw.Call(ctx, client, relay.HostPort(), svcName, "echo", args.Arg2, args.Arg3); err != nil {
+			panic(err)
+		}
+	})
+
+	return fs
+}
+
+func withNewServerClient(svcName string, f func(server, client *tchannel.Channel)) {
+	opts := testutils.NewOpts().SetServiceName(svcName)
+	server, err := testutils.NewServerChannel(opts)
+	if err != nil {
+		panic(err)
+	}
+	defer server.Close()
+
+	client, err := testutils.NewClientChannel(opts)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	f(server, client)
+}

--- a/benchmark/interfaces.go
+++ b/benchmark/interfaces.go
@@ -31,13 +31,25 @@ type Client interface {
 	Warmup() error
 
 	// RawCall makes an echo call using raw.
-	RawCall() (time.Duration, error)
+	RawCall(n int) ([]time.Duration, error)
 
 	// ThriftCall makes an echo call using thrift.
-	ThriftCall() (time.Duration, error)
+	ThriftCall(n int) ([]time.Duration, error)
 
 	// Close closes the benchmark client.
 	Close()
+}
+
+// inProcClient represents a client that is running in the same process.
+// It adds methods to reduce allocations.
+type inProcClient interface {
+	Client
+
+	// RawCallBuffer will make n raw calls and store the latencies in the specified buffer.
+	RawCallBuffer(latencies []time.Duration) error
+
+	// ThriftCallBuffer will make n thrift calls and store the latencies in the specified buffer.
+	ThriftCallBuffer(latencies []time.Duration) error
 }
 
 // Server is a benchmark server that can receive requests.
@@ -47,4 +59,10 @@ type Server interface {
 
 	// Close closes the benchmark server.
 	Close()
+
+	// RawCalls returns the number of raw calls the server has received.
+	RawCalls() int
+
+	// ThriftCalls returns the number of Thrift calls the server has received.
+	ThriftCalls() int
 }

--- a/benchmark/interfaces.go
+++ b/benchmark/interfaces.go
@@ -66,3 +66,12 @@ type Server interface {
 	// ThriftCalls returns the number of Thrift calls the server has received.
 	ThriftCalls() int
 }
+
+// Relay represents a relay for benchmarking.
+type Relay interface {
+	// HostPort is the host:port that the relay is listening on.
+	HostPort() string
+
+	// Close clsoes the relay.
+	Close()
+}

--- a/benchmark/internal_client.go
+++ b/benchmark/internal_client.go
@@ -70,8 +70,8 @@ func newInternalClient(hosts []string, opts *options) inProcClient {
 		ch:       ch,
 		sc:       ch.GetSubChannel(opts.svcName),
 		tClient:  client,
-		argBytes: randomBytes(opts.reqSize),
-		argStr:   string(randomBytes(opts.reqSize)),
+		argBytes: getRequestBytes(opts.reqSize),
+		argStr:   getRequestString(opts.reqSize),
 		opts:     opts,
 	}
 }

--- a/benchmark/internal_client.go
+++ b/benchmark/internal_client.go
@@ -52,6 +52,9 @@ func NewClient(hosts []string, optFns ...Option) Client {
 }
 
 func newClient(hosts []string, opts *options) inProcClient {
+	if opts.noLibrary {
+		return newInternalTCPClient(hosts, opts)
+	}
 	return newInternalClient(hosts, opts)
 }
 

--- a/benchmark/internal_client.go
+++ b/benchmark/internal_client.go
@@ -48,10 +48,17 @@ func NewClient(hosts []string, optFns ...Option) Client {
 	if opts.external {
 		return newExternalClient(hosts, opts)
 	}
+	if opts.numClients > 1 {
+		return newInternalMultiClient(hosts, opts)
+	}
 	return newClient(hosts, opts)
 }
 
 func newClient(hosts []string, opts *options) inProcClient {
+	if opts.external || opts.numClients > 1 {
+		panic("newClient got options that should be handled by NewClient")
+	}
+
 	if opts.noLibrary {
 		return newInternalTCPClient(hosts, opts)
 	}

--- a/benchmark/internal_client.go
+++ b/benchmark/internal_client.go
@@ -22,6 +22,7 @@ package benchmark
 
 import (
 	"bytes"
+	"fmt"
 	"time"
 
 	"github.com/uber/tchannel-go"
@@ -32,21 +33,29 @@ import (
 
 // internalClient represents a benchmark client.
 type internalClient struct {
-	ch       *tchannel.Channel
-	sc       *tchannel.SubChannel
-	tClient  gen.TChanSecondService
-	argStr   string
-	argBytes []byte
-	opts     *options
+	ch          *tchannel.Channel
+	sc          *tchannel.SubChannel
+	tClient     gen.TChanSecondService
+	argStr      string
+	argBytes    []byte
+	checkResult bool
+	opts        *options
 }
 
 // NewClient returns a new Client that can make calls to a benchmark server.
 func NewClient(hosts []string, optFns ...Option) Client {
-	opts := getOptions(optFns...)
+	opts := getOptions(optFns)
 	if opts.external {
 		return newExternalClient(hosts, opts)
 	}
+	return newClient(hosts, opts)
+}
 
+func newClient(hosts []string, opts *options) inProcClient {
+	return newInternalClient(hosts, opts)
+}
+
+func newInternalClient(hosts []string, opts *options) inProcClient {
 	ch, err := tchannel.NewChannel(opts.svcName, nil)
 	if err != nil {
 		panic("failed to create channel: " + err.Error())
@@ -57,13 +66,12 @@ func NewClient(hosts []string, optFns ...Option) Client {
 	thriftClient := thrift.NewClient(ch, opts.svcName, nil)
 	client := gen.NewTChanSecondServiceClient(thriftClient)
 
-	argBytes := randomBytes(opts.reqSize)
 	return &internalClient{
 		ch:       ch,
 		sc:       ch.GetSubChannel(opts.svcName),
 		tClient:  client,
-		argBytes: argBytes,
-		argStr:   string(argBytes),
+		argBytes: randomBytes(opts.reqSize),
+		argStr:   string(randomBytes(opts.reqSize)),
 		opts:     opts,
 	}
 }
@@ -82,38 +90,69 @@ func (c *internalClient) Warmup() error {
 	return nil
 }
 
-func (c *internalClient) RawCall() (time.Duration, error) {
-	ctx, cancel := tchannel.NewContext(c.opts.timeout)
-	defer cancel()
-
-	started := time.Now()
-	rArg2, rArg3, _, err := raw.CallSC(ctx, c.sc, "echo", c.argBytes, c.argBytes)
-	duration := time.Since(started)
-
-	if err != nil {
-		return 0, err
+func (c *internalClient) makeCalls(latencies []time.Duration, f func() (time.Duration, error)) error {
+	for i := range latencies {
+		var err error
+		latencies[i], err = f()
+		if err != nil {
+			return err
+		}
 	}
-	if !bytes.Equal(rArg2, c.argBytes) || !bytes.Equal(rArg3, c.argBytes) {
-		panic("echo call returned wrong results")
-	}
-	return duration, nil
+	return nil
 }
 
-func (c *internalClient) ThriftCall() (time.Duration, error) {
-	ctx, cancel := thrift.NewContext(c.opts.timeout)
-	defer cancel()
+func (c *internalClient) RawCallBuffer(latencies []time.Duration) error {
+	return c.makeCalls(latencies, func() (time.Duration, error) {
+		ctx, cancel := tchannel.NewContext(c.opts.timeout)
+		defer cancel()
 
-	started := time.Now()
-	res, err := c.tClient.Echo(ctx, c.argStr)
-	duration := time.Since(started)
+		started := time.Now()
+		rArg2, rArg3, _, err := raw.CallSC(ctx, c.sc, "echo", c.argBytes, c.argBytes)
+		duration := time.Since(started)
 
-	if err != nil {
-		return 0, err
-	}
-	if res != c.argStr {
-		panic("thrift Echo returned wrong result")
-	}
-	return duration, nil
+		if err != nil {
+			return 0, err
+		}
+		if c.checkResult {
+			if !bytes.Equal(rArg2, c.argBytes) || !bytes.Equal(rArg3, c.argBytes) {
+				fmt.Println("Arg2", rArg2, "Expect", c.argBytes)
+				fmt.Println("Arg3", rArg3, "Expect", c.argBytes)
+				panic("echo call returned wrong results")
+			}
+		}
+		return duration, nil
+	})
+}
+
+func (c *internalClient) RawCall(n int) ([]time.Duration, error) {
+	latencies := make([]time.Duration, n)
+	return latencies, c.RawCallBuffer(latencies)
+}
+
+func (c *internalClient) ThriftCallBuffer(latencies []time.Duration) error {
+	return c.makeCalls(latencies, func() (time.Duration, error) {
+		ctx, cancel := thrift.NewContext(c.opts.timeout)
+		defer cancel()
+
+		started := time.Now()
+		res, err := c.tClient.Echo(ctx, c.argStr)
+		duration := time.Since(started)
+
+		if err != nil {
+			return 0, err
+		}
+		if c.checkResult {
+			if res != c.argStr {
+				panic("thrift Echo returned wrong result")
+			}
+		}
+		return duration, nil
+	})
+}
+
+func (c *internalClient) ThriftCall(n int) ([]time.Duration, error) {
+	latencies := make([]time.Duration, n)
+	return latencies, c.ThriftCallBuffer(latencies)
 }
 
 func (c *internalClient) Close() {

--- a/benchmark/internal_multi_client.go
+++ b/benchmark/internal_multi_client.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import "time"
+
+type internalMultiClient struct {
+	clients []inProcClient
+}
+
+func newInternalMultiClient(hosts []string, opts *options) Client {
+	clients := make([]inProcClient, opts.numClients)
+	opts.numClients = 1
+
+	for i := range clients {
+		clients[i] = newClient(hosts, opts)
+	}
+
+	return &internalMultiClient{clients: clients}
+}
+
+func (c *internalMultiClient) Warmup() error {
+	for _, c := range c.clients {
+		if err := c.Warmup(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *internalMultiClient) Close() {
+	for _, client := range c.clients {
+		client.Close()
+	}
+}
+
+func (c *internalMultiClient) RawCall(n int) ([]time.Duration, error) {
+	return c.makeCalls(n, func(c inProcClient) callFunc {
+		return c.RawCallBuffer
+	})
+}
+
+func (c *internalMultiClient) ThriftCall(n int) ([]time.Duration, error) {
+	return c.makeCalls(n, func(c inProcClient) callFunc {
+		return c.ThriftCallBuffer
+	})
+}
+
+type callFunc func([]time.Duration) error
+
+type clientToCallFunc func(c inProcClient) callFunc
+
+func (c *internalMultiClient) makeCalls(n int, f clientToCallFunc) ([]time.Duration, error) {
+	perClient := n / len(c.clients)
+	remaining := n - perClient*len(c.clients)
+
+	errCs := make([]chan error, len(c.clients))
+
+	var start int
+	latencies := make([]time.Duration, n)
+	for i := range c.clients {
+		calls := perClient
+		if i == 0 {
+			calls += remaining
+		}
+
+		end := start + calls
+		errCs[i] = c.callUsingClient(latencies[start:end], f(c.clients[i]))
+		start = end
+	}
+
+	for _, errC := range errCs {
+		if err := <-errC; err != nil {
+			return nil, err
+		}
+	}
+
+	return latencies, nil
+}
+
+func (c *internalMultiClient) callUsingClient(latencies []time.Duration, f callFunc) chan error {
+	errC := make(chan error, 1)
+	if len(latencies) == 0 {
+		errC <- nil
+		return errC
+	}
+
+	go func() {
+		errC <- f(latencies)
+	}()
+	return errC
+}

--- a/benchmark/internal_tcp_client.go
+++ b/benchmark/internal_tcp_client.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"time"
+
+	"github.com/uber/tchannel-go"
+)
+
+// internalTCPClient represents a TCP client that makes
+// TChannel calls using raw TCP packets.
+type internalTCPClient struct {
+	host        string
+	lastID      uint32
+	responseIDs chan uint32
+	conn        net.Conn
+	frames      frames
+	opts        *options
+}
+
+func newInternalTCPClient(hosts []string, opts *options) inProcClient {
+	return &internalTCPClient{
+		host:        hosts[rand.Intn(len(hosts))],
+		responseIDs: make(chan uint32, 1000),
+		frames:      getRawCallFrames(opts.timeout, opts.svcName, opts.reqSize),
+		lastID:      1,
+		opts:        opts,
+	}
+}
+
+func (c *internalTCPClient) Warmup() error {
+	conn, err := net.Dial("tcp", c.host)
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+	go c.readConn()
+
+	if err := c.frames.writeInitReq(conn); err != nil {
+		panic(err)
+	}
+
+	return nil
+}
+
+func (c *internalTCPClient) readConn() {
+	defer close(c.responseIDs)
+
+	wantFirstID := true
+	f := tchannel.NewFrame(tchannel.MaxFrameSize)
+	for {
+		err := f.ReadIn(c.conn)
+		if err != nil {
+			return
+		}
+
+		if wantFirstID {
+			if f.Header.ID != 1 {
+				panic(fmt.Errorf("Expected first response ID to be 1, got %v", f.Header.ID))
+			}
+			wantFirstID = false
+			continue
+		}
+
+		c.responseIDs <- f.Header.ID
+	}
+}
+
+type call struct {
+	id        uint32
+	started   time.Time
+	numFrames int
+}
+
+func (c *internalTCPClient) makeCalls(latencies []time.Duration, f func() (call, error)) error {
+	n := len(latencies)
+	calls := make(map[uint32]*call, n)
+
+	for i := 0; i < n; i++ {
+		c, err := f()
+		if err != nil {
+			return err
+		}
+
+		calls[c.id] = &c
+	}
+
+	timer := time.NewTimer(c.opts.timeout)
+
+	// Use the original underlying slice for latencies.
+	durations := latencies[:0]
+	for {
+		if len(calls) == 0 {
+			return nil
+		}
+
+		timer.Reset(c.opts.timeout)
+		select {
+		case id, ok := <-c.responseIDs:
+			if !ok {
+				panic("expecting more calls, but connection is closed")
+			}
+			call, ok := calls[id]
+			if !ok {
+				panic(fmt.Errorf("received unexpected response frame: %v", id))
+			}
+
+			call.numFrames--
+			if call.numFrames != 0 {
+				continue
+			}
+			durations = append(durations, time.Since(call.started))
+			delete(calls, id)
+		case <-timer.C:
+			return tchannel.ErrTimeout
+		}
+	}
+}
+
+func (c *internalTCPClient) RawCallBuffer(latencies []time.Duration) error {
+	return c.makeCalls(latencies, func() (call, error) {
+		c.lastID++
+
+		started := time.Now()
+		numFrames, err := c.frames.writeCallReq(c.lastID, c.conn)
+		if err != nil {
+			return call{}, err
+		}
+
+		return call{c.lastID, started, numFrames}, nil
+	})
+}
+
+func (c *internalTCPClient) RawCall(n int) ([]time.Duration, error) {
+	latencies := make([]time.Duration, n)
+	return latencies, c.RawCallBuffer(latencies)
+}
+
+func (c *internalTCPClient) ThriftCallBuffer(latencies []time.Duration) error {
+	panic("not yet implemented")
+}
+
+func (c *internalTCPClient) ThriftCall(n int) ([]time.Duration, error) {
+	panic("not yet implemented")
+}
+
+func (c *internalTCPClient) Close() {
+	c.conn.Close()
+}

--- a/benchmark/internal_tcp_server.go
+++ b/benchmark/internal_tcp_server.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"log"
+	"net"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
+)
+
+// internalTCPServer represents a TCP server responds to TChannel
+// calls using raw TCP packets.
+type internalTCPServer struct {
+	frames   frames
+	ln       net.Listener
+	opts     *options
+	rawCalls atomic.Int64
+}
+
+func newInternalTCPServer(opts *options) Server {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+
+	s := &internalTCPServer{
+		ln:     ln,
+		frames: getRawCallFrames(opts.timeout, opts.svcName, opts.reqSize),
+		opts:   opts,
+	}
+	go s.acceptLoop()
+	return s
+}
+
+func (s *internalTCPServer) acceptLoop() {
+	for {
+		conn, err := s.ln.Accept()
+		if err, ok := err.(net.Error); ok && err.Temporary() {
+			continue
+		}
+		if err != nil {
+			return
+		}
+
+		go s.handleConn(conn)
+	}
+}
+
+func (s *internalTCPServer) handleConn(conn net.Conn) {
+	c := make(chan uint32, 1000)
+	defer close(c)
+	go s.writeResponses(conn, c)
+
+	var lastID uint32
+
+	f := tchannel.NewFrame(tchannel.MaxFrameSize)
+	for {
+		if err := f.ReadIn(conn); err != nil {
+			return
+		}
+
+		if f.Header.ID > lastID {
+			c <- f.Header.ID
+			lastID = f.Header.ID
+		}
+	}
+}
+
+func (s *internalTCPServer) writeResponses(conn net.Conn, ids chan uint32) {
+	frames := s.frames.duplicate()
+
+	for id := range ids {
+		if id == 1 {
+			if err := frames.writeInitRes(conn); err != nil {
+				log.Printf("writeInitRes failed: %v", err)
+			}
+			continue
+		}
+
+		s.rawCalls.Inc()
+		if _, err := frames.writeCallRes(id, conn); err != nil {
+			log.Printf("writeCallRes failed: %v", err)
+			return
+		}
+	}
+}
+
+func (s *internalTCPServer) HostPort() string {
+	return s.ln.Addr().String()
+}
+
+func (s *internalTCPServer) RawCalls() int {
+	return int(s.rawCalls.Load())
+}
+
+func (s *internalTCPServer) ThriftCalls() int {
+	// Server does not support Thrift calls currently.
+	return 0
+}
+
+func (s *internalTCPServer) Close() {
+	s.ln.Close()
+}

--- a/benchmark/matrix_test.go
+++ b/benchmark/matrix_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+)
+
+// combinations will call f with every combination of selecting elements
+// from a slice with the specified length.
+// e.g. for 2, the callback would be:
+// f(false, false)
+// f(false, true)
+// f(true, false)
+// f(true, true)
+func combinations(length int, f func([]bool)) {
+	cur := make([]bool, length)
+	toGenerate := (1 << uint(length))
+
+	f(cur)
+	for i := 0; i < toGenerate-1; i++ {
+		var digit int
+		for digit = length - 1; cur[digit]; digit-- {
+			cur[digit] = false
+		}
+		cur[digit] = true
+		f(cur)
+	}
+}
+
+func TestCombinations(t *testing.T) {
+	tests := []struct {
+		length int
+		want   [][]bool
+	}{
+		{
+			length: 1,
+			want:   [][]bool{{false}, {true}},
+		},
+		{
+			length: 2,
+			want:   [][]bool{{false, false}, {false, true}, {true, false}, {true, true}},
+		},
+	}
+
+	for _, tt := range tests {
+		var got [][]bool
+		recordCombs := func(comb []bool) {
+			copied := append([]bool(nil), comb...)
+			got = append(got, copied)
+		}
+		combinations(tt.length, recordCombs)
+		assert.Equal(t, tt.want, got, "Mismatch for combinations of length %v", tt.length)
+	}
+}
+
+func selectOptions(options []Option, toSelect []bool) []Option {
+	var opts []Option
+	for i, v := range toSelect {
+		if v {
+			opts = append(opts, options[i])
+		}
+	}
+	return opts
+}
+
+func combineOpts(base, override []Option) []Option {
+	resultOpts := append([]Option(nil), base...)
+	return append(resultOpts, override...)
+}
+
+func runSingleTest(t *testing.T, baseOpts, serverOpts, clientOpts []Option) {
+	serverOpts = combineOpts(baseOpts, serverOpts)
+	clientOpts = combineOpts(baseOpts, clientOpts)
+
+	msgP := fmt.Sprintf("%+v: ", struct {
+		serverOpts options
+		clientOpts options
+	}{*(getOptions(serverOpts)), *(getOptions(clientOpts))})
+
+	server := NewServer(serverOpts...)
+	defer server.Close()
+
+	client := NewClient([]string{server.HostPort()}, clientOpts...)
+	defer client.Close()
+
+	require.NoError(t, client.Warmup(), msgP+"Client warmup failed")
+
+	durations, err := client.RawCall(0)
+	require.NoError(t, err, msgP+"Call(0) failed")
+	assert.Equal(t, 0, len(durations), msgP+"Wrong number of calls")
+
+	assert.Equal(t, 0, server.RawCalls(), msgP+"server.RawCalls mismatch")
+	assert.Equal(t, 0, server.ThriftCalls(), msgP+"server.ThriftCalls mismatch")
+
+	expectCalls := 0
+	for i := 1; i < 10; i *= 2 {
+		durations, err = client.RawCall(i)
+		require.NoError(t, err, msgP+"Call(%v) failed", i)
+		require.Equal(t, i, len(durations), msgP+"Wrong number of calls")
+
+		expectCalls += i
+		require.Equal(t, expectCalls, server.RawCalls(), msgP+"server.RawCalls mismatch")
+		require.Equal(t, 0, server.ThriftCalls(), msgP+"server.ThriftCalls mismatch")
+	}
+}
+
+func TestServerClientMatrix(t *testing.T) {
+	tests := [][]Option{
+		{WithServiceName("other")},
+		{WithRequestSize(tchannel.MaxFrameSize)},
+	}
+
+	// These options can be independently applied to the server or the client.
+	independentOpts := []Option{
+		WithExternalProcess(),
+		WithNoLibrary(),
+	}
+
+	// These options only apply to the client.
+	clientOnlyOpts := combineOpts(independentOpts, []Option{
+		WithNumClients(5),
+	})
+
+	for _, tt := range tests {
+		combinations(len(independentOpts), func(serverSelect []bool) {
+			combinations(len(clientOnlyOpts), func(clientSelect []bool) {
+				serverOpts := selectOptions(independentOpts, serverSelect)
+				clientOpts := selectOptions(clientOnlyOpts, clientSelect)
+				runSingleTest(t, tt, serverOpts, clientOpts)
+			})
+		})
+	}
+}

--- a/benchmark/options.go
+++ b/benchmark/options.go
@@ -30,6 +30,7 @@ type options struct {
 	// Following options only make sense for clients.
 	timeout time.Duration
 	reqSize int
+	numClients int
 
 	// Following options only make sense for servers.
 	advertiseHosts []string
@@ -71,6 +72,17 @@ func WithExternalProcess() Option {
 func WithNoLibrary() Option {
 	return func(opts *options) {
 		opts.noLibrary = true
+	}
+}
+
+// WithNumClients sets the number of concurrent TChannel clients to use
+// internally under a single benchmark.Client. This is used to generate
+// generate a large amount of traffic, as a single TChannel client will
+// not saturate a CPU since it will spend most of the time blocking and
+// waiting for the remote side to respond.
+func WithNumClients(numClients int) Option {
+	return func(opts *options) {
+		opts.numClients = numClients
 	}
 }
 

--- a/benchmark/options.go
+++ b/benchmark/options.go
@@ -28,9 +28,14 @@ type options struct {
 	noLibrary bool
 
 	// Following options only make sense for clients.
-	timeout time.Duration
-	reqSize int
+	noChecking bool
+	timeout    time.Duration
+	reqSize    int
 	numClients int
+
+	// noDurations disables printing of durations to stdout.
+	// This only applies to clients running out-of-process.
+	noDurations bool
 
 	// Following options only make sense for servers.
 	advertiseHosts []string
@@ -75,6 +80,15 @@ func WithNoLibrary() Option {
 	}
 }
 
+// WithNoChecking disables result verification on the client side, which
+// may slow down the client (as it compares all request bytes against the
+// response bytes).
+func WithNoChecking() Option {
+	return func(opts *options) {
+		opts.noChecking = true
+	}
+}
+
 // WithNumClients sets the number of concurrent TChannel clients to use
 // internally under a single benchmark.Client. This is used to generate
 // generate a large amount of traffic, as a single TChannel client will
@@ -83,6 +97,13 @@ func WithNoLibrary() Option {
 func WithNumClients(numClients int) Option {
 	return func(opts *options) {
 		opts.numClients = numClients
+	}
+}
+
+// WithNoDurations disables printing of latencies to standard out.
+func WithNoDurations() Option {
+	return func(opts *options) {
+		opts.noDurations = true
 	}
 }
 

--- a/benchmark/options.go
+++ b/benchmark/options.go
@@ -23,8 +23,9 @@ package benchmark
 import "time"
 
 type options struct {
-	external bool
-	svcName  string
+	external  bool
+	svcName   string
+	noLibrary bool
 
 	// Following options only make sense for clients.
 	timeout time.Duration
@@ -62,6 +63,14 @@ func WithServiceName(svcName string) Option {
 func WithExternalProcess() Option {
 	return func(opts *options) {
 		opts.external = true
+	}
+}
+
+// WithNoLibrary uses the fast TCP-template based approach for generating
+// TChannel frames rather than the TChannel client library.
+func WithNoLibrary() Option {
+	return func(opts *options) {
+		opts.noLibrary = true
 	}
 }
 

--- a/benchmark/options.go
+++ b/benchmark/options.go
@@ -72,7 +72,7 @@ func WithAdvertiseHosts(hosts []string) Option {
 	}
 }
 
-func getOptions(optFns ...Option) *options {
+func getOptions(optFns []Option) *options {
 	opts := &options{
 		timeout: time.Second,
 		svcName: "bench-server",

--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/atomic"
+)
+
+type fixedHosts struct {
+	hosts map[string][]string
+	pickI atomic.Int32
+}
+
+func (fh *fixedHosts) Get(svc string) string {
+	peers := fh.hosts[svc]
+	if len(peers) == 0 {
+		return ""
+	}
+
+	pickI := int(fh.pickI.Inc()-1) % len(peers)
+	return peers[pickI]
+}
+
+type realRelay struct {
+	ch    *tchannel.Channel
+	hosts *fixedHosts
+}
+
+// NewRealRelay creates a TChannel relay.
+func NewRealRelay(services map[string][]string) (Relay, error) {
+	hosts := &fixedHosts{hosts: services}
+	ch, err := tchannel.NewChannel("relay", &tchannel.ChannelOptions{
+		RelayHosts: hosts,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ch.ListenAndServe("127.0.0.1:0"); err != nil {
+		return nil, err
+	}
+
+	return &realRelay{
+		ch:    ch,
+		hosts: hosts,
+	}, nil
+}
+
+func (r *realRelay) HostPort() string {
+	return r.ch.PeerInfo().HostPort
+}
+
+func (r *realRelay) Close() {
+	r.ch.Close()
+}

--- a/benchmark/req_bytes.go
+++ b/benchmark/req_bytes.go
@@ -20,32 +20,20 @@
 
 package benchmark
 
-import (
-	"io"
-	"math/rand"
-	"time"
-)
-
-type randReader struct {
-	src rand.Source
-}
-
-func newRandReader() io.Reader {
-	return randReader{rand.NewSource(time.Now().UnixNano())}
-}
-
-func (r randReader) Read(p []byte) (n int, err error) {
-	for i := range p {
-		p[i] = byte(r.src.Int63() & 0xff)
-	}
-	return len(p), nil
-}
-
-func randomBytes(n int) []byte {
-	reader := newRandReader()
+func getRequestBytes(n int) []byte {
 	bs := make([]byte, n)
-	if _, err := io.ReadFull(reader, bs); err != nil {
-		panic("failed to read random bytes: " + err.Error())
+	for i := range bs {
+		bs[i] = byte(i)
 	}
 	return bs
+}
+
+func getRequestString(n int) string {
+	// TODO: we should replace this with base64 once we drop go1.4 support.
+	chars := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcedefghijklmnopqrstuvwxyz")
+	bs := make([]byte, n)
+	for i := range bs {
+		bs[i] = chars[i%len(chars)]
+	}
+	return string(bs)
 }

--- a/benchmark/tcp_bench_test.go
+++ b/benchmark/tcp_bench_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"io"
+	"io/ioutil"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func echoServer(tb testing.TB) net.Listener {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(tb, err, "Listen failed")
+
+	go func() {
+		conn, err := ln.Accept()
+		require.NoError(tb, err, "Accept failed")
+
+		// Echo the connection back to itself.
+		io.Copy(conn, conn)
+	}()
+
+	return ln
+}
+
+func benchmarkClient(b *testing.B, dst string, reqSize int) {
+	req := getRequestBytes(reqSize)
+	totalExpected := b.N * reqSize
+
+	conn, err := net.Dial("tcp", dst)
+	require.NoError(b, err, "Failed to connect to destination")
+	defer conn.Close()
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		n, err := io.CopyN(ioutil.Discard, conn, int64(totalExpected))
+		assert.NoError(b, err, "Expected %v response bytes, got %v", totalExpected, n)
+	}()
+
+	b.SetBytes(int64(reqSize))
+	for i := 0; i < b.N; i++ {
+		_, err := conn.Write(req)
+		require.NoError(b, err, "Write failed")
+	}
+
+	<-readerDone
+}
+
+func benchmarkTCPDirect(b *testing.B, reqSize int) {
+	ln := echoServer(b)
+	benchmarkClient(b, ln.Addr().String(), reqSize)
+}
+
+func BenchmarkTCPDirect100Bytes(b *testing.B) {
+	benchmarkTCPDirect(b, 100)
+}
+
+func BenchmarkTCPDirect1k(b *testing.B) {
+	benchmarkTCPDirect(b, 1024)
+}
+
+func BenchmarkTCPDirect4k(b *testing.B) {
+	benchmarkTCPDirect(b, 4*1024)
+}
+
+func benchmarkTCPRelay(b *testing.B, reqSize int) {
+	ln := echoServer(b)
+
+	relay, err := NewTCPRawRelay([]string{ln.Addr().String()})
+	require.NoError(b, err, "Relay failed")
+	defer relay.Close()
+
+	benchmarkClient(b, relay.HostPort(), reqSize)
+}
+
+func BenchmarkTCPRelay100Bytes(b *testing.B) {
+	benchmarkTCPRelay(b, 100)
+}
+
+func BenchmarkTCPRelay1kBytes(b *testing.B) {
+	benchmarkTCPRelay(b, 1024)
+}
+
+func BenchmarkTCPRelay4k(b *testing.B) {
+	benchmarkTCPRelay(b, 4*1024)
+}

--- a/benchmark/tcp_frame_relay.go
+++ b/benchmark/tcp_frame_relay.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"log"
+	"net"
+)
+import "github.com/uber/tchannel-go"
+
+type tcpFrameRelay struct {
+	*tcpRelay
+	modifier func(bool, *tchannel.Frame) *tchannel.Frame
+}
+
+// NewTCPFrameRelay relays frames from one connection to another. It reads
+// and writes frames using the TChannel frame functions.
+func NewTCPFrameRelay(dests []string, modifier func(bool, *tchannel.Frame) *tchannel.Frame) (Relay, error) {
+	var err error
+	r := &tcpFrameRelay{modifier: modifier}
+
+	r.tcpRelay, err = newTCPRelay(dests, r.handleConnFrameRelay)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *tcpFrameRelay) handleConnFrameRelay(fromClient bool, src, dst net.Conn) {
+	pool := tchannel.NewSyncFramePool()
+	frameCh := make(chan *tchannel.Frame, 100)
+	defer close(frameCh)
+
+	go func() {
+		for f := range frameCh {
+			if err := f.WriteOut(dst); err != nil {
+				log.Printf("Failed to write out frame: %v", err)
+				return
+			}
+			pool.Release(f)
+		}
+	}()
+
+	for {
+		f := pool.Get()
+		if err := f.ReadIn(src); err != nil {
+			return
+		}
+
+		if r.modifier != nil {
+			f = r.modifier(fromClient, f)
+		}
+
+		select {
+		case frameCh <- f:
+		default:
+			panic("frame buffer full")
+		}
+	}
+}

--- a/benchmark/tcp_raw_relay.go
+++ b/benchmark/tcp_raw_relay.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmark
+
+import (
+	"io"
+	"log"
+	"net"
+
+	"github.com/uber/tchannel-go/atomic"
+)
+
+type tcpRelay struct {
+	destI      atomic.Int32
+	dests      []string
+	ln         net.Listener
+	handleConn func(fromClient bool, src, dst net.Conn)
+}
+
+func newTCPRelay(dests []string, handleConn func(fromClient bool, src, dst net.Conn)) (*tcpRelay, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	relay := &tcpRelay{
+		dests:      dests,
+		ln:         ln,
+		handleConn: handleConn,
+	}
+	go relay.acceptLoop()
+	return relay, nil
+}
+
+// NewTCPRawRelay creates a relay that just pipes data from one connection
+// to another directly.
+func NewTCPRawRelay(dests []string) (Relay, error) {
+	return newTCPRelay(dests, func(_ bool, src, dst net.Conn) {
+		io.Copy(src, dst)
+	})
+}
+
+func (r *tcpRelay) acceptLoop() {
+	for {
+		conn, err := r.ln.Accept()
+		if err, ok := err.(net.Error); ok && err.Temporary() {
+			continue
+		}
+		if err != nil {
+			return
+		}
+
+		go r.handleIncoming(conn)
+	}
+}
+
+func (r *tcpRelay) handleIncoming(src net.Conn) {
+	defer src.Close()
+
+	dst, err := net.Dial("tcp", r.nextDestination())
+	if err != nil {
+		log.Printf("Connection failed: %v", err)
+		return
+	}
+	defer dst.Close()
+
+	go r.handleConn(true, src, dst)
+	r.handleConn(false, dst, src)
+}
+
+func (r *tcpRelay) nextDestination() string {
+	i := int(r.destI.Inc()-1) % len(r.dests)
+	return r.dests[i]
+}
+
+func (r *tcpRelay) HostPort() string {
+	return r.ln.Addr().String()
+}
+
+func (r *tcpRelay) Close() {
+	r.ln.Close()
+}

--- a/connection_bench_test.go
+++ b/connection_bench_test.go
@@ -148,7 +148,7 @@ func benchmarkCallsN(b *testing.B, c benchmarkConfig) {
 	reqsLeft := testutils.Decrementor(c.numCalls)
 	clientWorker := func(client *Channel, clientNum, workerNum int) {
 		sc := client.GetSubChannel(benchService)
-		for reqsLeft() {
+		for reqsLeft.Single() {
 			call(sc)
 		}
 	}

--- a/relay_benchmark_test.go
+++ b/relay_benchmark_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/uber/tchannel-go/atomic"
 	"github.com/uber/tchannel-go/benchmark"
 	"github.com/uber/tchannel-go/testutils"
 
@@ -81,13 +80,7 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 	b.SetBytes(int64(p.requestSize))
 	b.ReportAllocs()
 
-	relayHosts := testutils.NewSimpleRelayHosts(map[string][]string{})
-	ch, err := NewChannel("relay", &ChannelOptions{
-		RelayHosts: relayHosts,
-	})
-	defer closeAndVerify(b, ch)
-	require.NoError(b, err, "Failed to create relay")
-	require.NoError(b, ch.ListenAndServe("127.0.0.1:0"), "relay listen failed")
+	services := make(map[string][]string)
 
 	servers := make([]benchmark.Server, p.servers)
 	for i := range servers {
@@ -97,12 +90,16 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 			benchmark.WithExternalProcess(),
 		)
 		defer servers[i].Close()
-		relayHosts.Add("svc", servers[i].HostPort())
+		services["svc"] = append(services["svc]"], servers[i].HostPort())
 	}
+
+	relay, err := benchmark.NewRealRelay(services)
+	require.NoError(b, err, "Failed to create relay")
+	defer relay.Close()
 
 	clients := make([]benchmark.Client, p.clients)
 	for i := range clients {
-		clients[i] = benchmark.NewClient([]string{ch.PeerInfo().HostPort},
+		clients[i] = benchmark.NewClient([]string{relay.HostPort()},
 			benchmark.WithServiceName("svc"),
 			benchmark.WithRequestSize(p.requestSize),
 			benchmark.WithExternalProcess(),
@@ -116,27 +113,30 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 		quantiles[i] = quantile.NewTargeted(quantileVals...)
 	}
 
-	var errors atomic.Int64
-	var success atomic.Int64
-
 	wc := newWorkerControl(p.clients)
-	benchMore := testutils.Decrementor(b.N)
+	dec := testutils.Decrementor(b.N)
 
 	for i, c := range clients {
 		go func(i int, c benchmark.Client) {
 			// Do a warm up call.
-			c.RawCall()
+			c.RawCall(1)
 
 			wc.WorkerStart()
 			defer wc.WorkerDone()
 
-			for benchMore() {
-				d, err := c.RawCall()
-				if err == nil {
+			for {
+				tokens := dec.Multiple(200)
+				if tokens == 0 {
+					break
+				}
+
+				durations, err := c.RawCall(tokens)
+				if err != nil {
+					b.Fatalf("Call failed: %v", err)
+				}
+
+				for _, d := range durations {
 					quantiles[i].Insert(float64(d))
-					success.Inc()
-				} else {
-					errors.Inc()
 				}
 			}
 		}(i, c)
@@ -149,11 +149,8 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 	})
 	wc.WaitForEnd()
 	duration := time.Since(started)
-	if errors.Load() > 0 {
-		b.Errorf("Errors during benchmarl: %v", errors.Load())
-	}
 
-	fmt.Printf("\nb.N: %v Duration: %v Requests = %v RPS = %0.2f\n", b.N, duration, success.Load(), float64(success.Load())/duration.Seconds())
+	fmt.Printf("\nb.N: %v Duration: %v RPS = %0.2f\n", b.N, duration, float64(b.N)/duration.Seconds())
 
 	// Merge all the quantiles into 1
 	for _, q := range quantiles[1:] {
@@ -173,10 +170,10 @@ func BenchmarkRelay2Servers5Clients1k(b *testing.B) {
 	benchmarkRelay(b, p)
 }
 
-func BenchmarkRelay2Servers10Clients1k(b *testing.B) {
+func BenchmarkRelay4Servers20Clients1k(b *testing.B) {
 	p := defaultParams()
-	p.clients = 10
-	p.servers = 2
+	p.clients = 20
+	p.servers = 4
 	benchmarkRelay(b, p)
 }
 

--- a/relay_benchmark_test.go
+++ b/relay_benchmark_test.go
@@ -166,24 +166,24 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 	fmt.Println()
 }
 
-func BenchmarkRelay2Servers2Clients1k(b *testing.B) {
+func BenchmarkRelay2Servers5Clients1k(b *testing.B) {
 	p := defaultParams()
-	p.clients = 2
+	p.clients = 5
 	p.servers = 2
 	benchmarkRelay(b, p)
 }
 
-func BenchmarkRelay2Servers4Clients1k(b *testing.B) {
+func BenchmarkRelay2Servers10Clients1k(b *testing.B) {
 	p := defaultParams()
-	p.clients = 2
+	p.clients = 10
 	p.servers = 2
 	benchmarkRelay(b, p)
 }
 
-func BenchmarkRelay2Servers2Clients4k(b *testing.B) {
+func BenchmarkRelay2Servers5Clients4k(b *testing.B) {
 	p := defaultParams()
 	p.requestSize = 4 * 1024
-	p.clients = 2
+	p.clients = 5
 	p.servers = 2
 	benchmarkRelay(b, p)
 }

--- a/testutils/counter.go
+++ b/testutils/counter.go
@@ -66,6 +66,19 @@ func Decrementor(n int) Decrement {
 	}
 }
 
+// Batch returns a slice with n broken into batches of size batchSize.
+func Batch(n, batchSize int) []int {
+	fullBatches := n / batchSize
+	batches := make([]int, 0, fullBatches+1)
+	for i := 0; i < fullBatches; i++ {
+		batches = append(batches, batchSize)
+	}
+	if remaining := n % batchSize; remaining > 0 {
+		batches = append(batches, remaining)
+	}
+	return batches
+}
+
 // RunN runs the given f n times (and passes the run's index) and waits till they complete.
 // It starts n-1 goroutines, and runs one instance in the current goroutine.
 func RunN(n int, f func(i int)) {

--- a/testutils/counter.go
+++ b/testutils/counter.go
@@ -79,6 +79,20 @@ func Batch(n, batchSize int) []int {
 	return batches
 }
 
+// Buckets splits n over the specified number of buckets.
+func Buckets(n int, numBuckets int) []int {
+	perBucket := n / numBuckets
+
+	buckets := make([]int, numBuckets)
+	for i := range buckets {
+		buckets[i] = perBucket
+		if i == 0 {
+			buckets[i] += n % numBuckets
+		}
+	}
+	return buckets
+}
+
 // RunN runs the given f n times (and passes the run's index) and waits till they complete.
 // It starts n-1 goroutines, and runs one instance in the current goroutine.
 func RunN(n int, f func(i int)) {

--- a/testutils/counter_test.go
+++ b/testutils/counter_test.go
@@ -87,3 +87,20 @@ func TestBatch(t *testing.T) {
 		assert.Equal(t, tt.want, got, "Batch(%v, %v) unexpected result", tt.n, tt.batch)
 	}
 }
+
+func TestBuckets(t *testing.T) {
+	tests := []struct {
+		n       int
+		buckets int
+		want    []int
+	}{
+		{2, 3, []int{2, 0, 0}},
+		{3, 3, []int{1, 1, 1}},
+		{4, 3, []int{2, 1, 1}},
+	}
+
+	for _, tt := range tests {
+		got := Buckets(tt.n, tt.buckets)
+		assert.Equal(t, tt.want, got, "Buckets(%v, %v) unexpected result", tt.n, tt.buckets)
+	}
+}

--- a/testutils/counter_test.go
+++ b/testutils/counter_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutils
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testDecrementor(t *testing.T, f func(dec Decrement) int) {
+	const count = 10000
+	const numGoroutines = 100
+
+	dec := Decrementor(count)
+	results := make(chan int, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			results <- f(dec)
+		}()
+	}
+
+	var total int
+	for i := 0; i < numGoroutines; i++ {
+		total += <-results
+	}
+	assert.Equal(t, count, total, "Count mismatch")
+}
+
+func TestDecrementSingle(t *testing.T) {
+	testDecrementor(t, func(dec Decrement) int {
+		count := 0
+		for dec.Single() {
+			count++
+		}
+		return count
+	})
+}
+
+func TestDecrementMultiple(t *testing.T) {
+	testDecrementor(t, func(dec Decrement) int {
+		count := 0
+		for {
+			tokens := dec.Multiple(rand.Intn(100) + 1)
+			if tokens == 0 {
+				break
+			}
+			count += tokens
+		}
+		return count
+	})
+}

--- a/testutils/counter_test.go
+++ b/testutils/counter_test.go
@@ -70,3 +70,20 @@ func TestDecrementMultiple(t *testing.T) {
 		return count
 	})
 }
+
+func TestBatch(t *testing.T) {
+	tests := []struct {
+		n     int
+		batch int
+		want  []int
+	}{
+		{40, 10, []int{10, 10, 10, 10}},
+		{5, 10, []int{5}},
+		{45, 10, []int{10, 10, 10, 10, 5}},
+	}
+
+	for _, tt := range tests {
+		got := Batch(tt.n, tt.batch)
+		assert.Equal(t, tt.want, got, "Batch(%v, %v) unexpected result", tt.n, tt.batch)
+	}
+}

--- a/testutils/timeout.go
+++ b/testutils/timeout.go
@@ -39,7 +39,7 @@ func init() {
 			panic(err)
 		}
 		timeoutScaleFactor = fv
-		fmt.Println("Scaling timeouts by factor", timeoutScaleFactor)
+		fmt.Fprintln(os.Stderr, "Scaling timeouts by factor", timeoutScaleFactor)
 	}
 }
 


### PR DESCRIPTION
 - Support running a no-library version of client and server (uses templated TChannel frames)
 - Add dummy relay benchmarks that just relay TCP