### PR TITLE
Avoid creating a context on every request

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -217,16 +217,15 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 	}
 	peer := r.peers.GetOrAdd(hostPort)
 
-	ctx, cancel := NewContext(time.Second)
-	defer cancel()
-
-	remoteConn, err := peer.GetConnection(ctx)
+	// TODO: Should connections use the call timeout? Or a separate timeout?
+	remoteConn, err := peer.getConnectionTimeout(f.TTL())
 	if err != nil {
 		r.logger.WithFields(
 			ErrField(err),
 			LogField{"hostPort", hostPort},
 		).Warn("Failed to connect to relay host.")
-		// TODO: return an error frame.
+		// TODO: Same as above, do we need span here?
+		r.conn.SendSystemError(f.Header.ID, nil, NewWrappedSystemError(ErrCodeNetwork, err))
 		return nil
 	}
 


### PR DESCRIPTION
The context is only required if we need to create a new connection. Move
the context creation to creating a new connection.

This reduces per-request allocations from 20 to 5.