### PR TITLE
relay: Support lazily reading method to determine destination

### DIFF
--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -30,8 +30,8 @@ type fixedHosts struct {
 	pickI atomic.Int32
 }
 
-func (fh *fixedHosts) Get(svc string) string {
-	peers := fh.hosts[svc]
+func (fh *fixedHosts) Get(call tchannel.CallFrame) string {
+	peers := fh.hosts[call.Service()]
 	if len(peers) == 0 {
 		return ""
 	}

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -65,3 +65,18 @@ func (f *FakeIncomingCall) RemotePeer() tchannel.PeerInfo {
 func NewIncomingCall(callerName string) tchannel.IncomingCall {
 	return &FakeIncomingCall{CallerNameF: callerName}
 }
+
+// FakeCallFrame is a stub implementation of the CallFrame interface.
+type FakeCallFrame struct {
+	ServiceF, MethodF string
+}
+
+// Service returns the service name field.
+func (f FakeCallFrame) Service() string {
+	return f.ServiceF
+}
+
+// Method returns the method field.
+func (f FakeCallFrame) Method() string {
+	return f.MethodF
+}

--- a/testutils/relay_stub.go
+++ b/testutils/relay_stub.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"sync"
 
+	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/trand"
 )
 
@@ -44,11 +45,11 @@ func NewSimpleRelayHosts(peers map[string][]string) *SimpleRelayHosts {
 }
 
 // Get takes a routing key and returns the best host:port for that key.
-func (rh *SimpleRelayHosts) Get(service string) string {
+func (rh *SimpleRelayHosts) Get(frame tchannel.CallFrame) string {
 	rh.RLock()
 	defer rh.RUnlock()
 
-	available, ok := rh.peers[service]
+	available, ok := rh.peers[frame.Service()]
 	if !ok || len(available) == 0 {
 		return ""
 	}


### PR DESCRIPTION
Instead of passing a string with service, instead abstract the frame via
an interface that allows accessing the service and method.

Update tests to ensure this works regardless of the number of headers,
whether the frame contains a checksum, etc.