### PR TITLE
Make `make benchmark` only run benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test: clean setup install_test
 
 benchmark: clean setup
 	echo Running benchmarks:
-	go test $(PKGS) -bench=. -parallel=4
+	go test $(PKGS) -bench=. -parallel=4 -run ^$
 
 cover_profile: clean setup
 	@echo Testing packages:


### PR DESCRIPTION
I noticed this was running some other tests that were flaking locally (TestWriteArg3AfterTimeout). To keep things clean I'd rather retrict `make benchmark` to only benchmark tests.

@akshayjshah @prashantv 