### PR TITLE
Remove duplicate callOptions nil check

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -475,9 +475,6 @@ func (p *Peer) BeginCall(ctx context.Context, serviceName, methodName string, ca
 		return nil, err
 	}
 
-	if callOptions == nil {
-		callOptions = defaultCallOptions
-	}
 	call, err := conn.beginCall(ctx, serviceName, methodName, callOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Since we already check at the top, the second check is unnecessary.

Thanks for catching this @yurishkuro 
@akshayjshah