### PR TITLE
Fix peer score not being calculated when adding outbound connections

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -404,7 +404,7 @@ func (ch *Channel) serve() {
 
 		// Register the connection in the peer once the channel is set up.
 		events := connectionEvents{
-			OnActive:           ch.incomingConnectionActive,
+			OnActive:           ch.inboundConnectionActive,
 			OnCloseStateChange: ch.connectionCloseStateChange,
 			OnExchangeUpdated:  ch.exchangeUpdated,
 		}
@@ -503,13 +503,8 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, e
 		return nil, err
 	}
 
-	ch.mutable.Lock()
-	ch.mutable.conns[c.connID] = c
-	chState := ch.mutable.state
-	ch.mutable.Unlock()
-
 	// Any connections added after the channel is in StartClose should also be set to start close.
-	if chState == ChannelStartClose {
+	if chState := ch.State(); chState == ChannelStartClose {
 		// TODO(prashant): If Connect is called, but no outgoing calls are made, then this connection
 		// will block Close, as it will never get cleaned up.
 		c.withStateLock(func() error {
@@ -539,17 +534,15 @@ func (ch *Channel) updatePeer(p *Peer) {
 	p.callOnUpdateComplete()
 }
 
-// incomingConnectionActive adds a new active connection to our peer list.
-func (ch *Channel) incomingConnectionActive(c *Connection) {
-	c.log.Debugf("Add inbound connection as an active peer for %v", c.remotePeerInfo.HostPort)
-	// TODO: Alter TChannel spec to allow optionally include the service name
-	// when initializing a connection. As-is, we have to keep these peers in
-	// rootPeers (which isn't used for outbound calls) because we don't know
-	// what services they implement.
+func (ch *Channel) connectionActive(c *Connection, direction connectionDirection) {
+	c.log.Debugf("Add %v connection as an active peer for %v", direction, c.remotePeerInfo.HostPort)
+
 	p := ch.rootPeers().GetOrAdd(c.remotePeerInfo.HostPort)
-	if err := p.AddInboundConnection(c); err != nil {
-		c.log.WithFields(LogField{"remoteHostPort", c.remotePeerInfo.HostPort}).
-			Warn("Failed to add inbound connection to peer")
+	if err := p.addConnection(c, direction); err != nil {
+		c.log.WithFields(
+			LogField{"remoteHostPort", c.remotePeerInfo.HostPort},
+			LogField{"direction", direction},
+		).Warn("Failed to add connection to peer")
 	}
 
 	ch.updatePeer(p)
@@ -559,15 +552,12 @@ func (ch *Channel) incomingConnectionActive(c *Connection) {
 	ch.mutable.Unlock()
 }
 
-func (ch *Channel) outboundConnectionActive(c *Connection) {
-	c.log.Debugf("Add outbound connection as an active peer for %v", c.remotePeerInfo.HostPort)
-	p := ch.rootPeers().GetOrAdd(c.remotePeerInfo.HostPort)
-	if err := p.AddOutboundConnection(c); err != nil {
-		c.log.WithFields(LogField{"remoteHostPort", c.remotePeerInfo.HostPort}).
-			Warn("Failed to add outbound connection to peer")
-	}
+func (ch *Channel) inboundConnectionActive(c *Connection) {
+	ch.connectionActive(c, inbound)
+}
 
-	ch.updatePeer(p)
+func (ch *Channel) outboundConnectionActive(c *Connection) {
+	ch.connectionActive(c, outbound)
 }
 
 // removeClosedConn removes a connection if it's closed.

--- a/connection_direction.go
+++ b/connection_direction.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import "fmt"
+
+type connectionDirection int
+
+const (
+	inbound connectionDirection = iota + 1
+	outbound
+)
+
+func (d connectionDirection) String() string {
+	switch d {
+	case inbound:
+		return "inbound"
+	case outbound:
+		return "outbound"
+	default:
+		return fmt.Sprintf("connectionDirection(%v)", int(d))
+	}
+}

--- a/peer.go
+++ b/peer.go
@@ -362,9 +362,9 @@ func (p *Peer) getConnectionTimeout(timeout time.Duration) (*Connection, error) 
 	return p.Connect(ctx)
 }
 
-// AddInboundConnection adds an active inbound connection to the peer's connection list.
+// addInboundConnection adds an active inbound connection to the peer's connection list.
 // If a connection is not active, ErrInvalidConnectionState will be returned.
-func (p *Peer) AddInboundConnection(c *Connection) error {
+func (p *Peer) addInboundConnection(c *Connection) error {
 	if c.readState() != connectionActive {
 		return ErrInvalidConnectionState
 	}
@@ -397,9 +397,9 @@ func (p *Peer) canRemove() bool {
 	return count == 0
 }
 
-// AddOutboundConnection adds an active outbound connection to the peer's connection list.
+// addOutboundConnection adds an active outbound connection to the peer's connection list.
 // If a connection is not active, ErrInvalidConnectionState will be returned.
-func (p *Peer) AddOutboundConnection(c *Connection) error {
+func (p *Peer) addOutboundConnection(c *Connection) error {
 	switch c.readState() {
 	case connectionActive, connectionStartClose:
 		break
@@ -411,6 +411,13 @@ func (p *Peer) AddOutboundConnection(c *Connection) error {
 	p.outboundConnections = append(p.outboundConnections, c)
 	p.Unlock()
 	return nil
+}
+
+func (p *Peer) addConnection(c *Connection, direction connectionDirection) error {
+	if direction == inbound {
+		return p.addInboundConnection(c)
+	}
+	return p.addOutboundConnection(c)
 }
 
 // removeConnection will check remove the connection if it exists on connsPtr

--- a/peer.go
+++ b/peer.go
@@ -450,16 +450,7 @@ func (p *Peer) connectionCloseStateChange(changed *Connection) {
 
 // Connect adds a new outbound connection to the peer.
 func (p *Peer) Connect(ctx context.Context) (*Connection, error) {
-	c, err := p.channel.Connect(ctx, p.hostPort)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := p.AddOutboundConnection(c); err != nil {
-		return nil, err
-	}
-
-	return c, nil
+	return p.channel.Connect(ctx, p.hostPort)
 }
 
 // BeginCall starts a new call to this specific peer, returning an OutboundCall that can


### PR DESCRIPTION
Use the same connectionEvents.onActive path for adding outbound
connections to a peer, and update the score. This makes the
inbound and outbound paths similar.

Fixes #364

cc @yurishkuro 