### PR TITLE
relay: Use connection's logger which includes connID and addresses

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -173,7 +173,7 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 		inbound:  newRelayItems(ch.Logger().WithFields(LogField{"relay", "inbound"})),
 		peers:    ch.Peers(),
 		conn:     conn,
-		logger:   ch.Logger(),
+		logger:   conn.log,
 	}
 }
 


### PR DESCRIPTION
Right now, we're using the channel logger, so we don't have any unique information for each `Relayer` even though we have multiple relayers (one per conneciton).

cc @akshayjshah 