### PR TITLE
relay: Fix race between connection close and new call

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -882,6 +882,13 @@ func (c *Connection) checkExchanges() {
 	}
 
 	if c.readState() == connectionInboundClosed {
+		// Safety check -- this should never happen since we already did the check
+		// when transitioning to connectionInboundClosed.
+		if !c.relay.canClose() {
+			c.relay.logger.Error("Relay can't close even though state is InboundClosed.")
+			return
+		}
+
 		if c.outbound.count() == 0 && moveState(connectionInboundClosed, connectionClosed) {
 			updated = connectionClosed
 		}


### PR DESCRIPTION
Currently, relay items are added without checking the connection state.
This can lead to new items being added while a connection is closing.

This change makes checking the connection state atomic with incrementing
the pending count. This ensures that only active connections can accept
new incoming calls.

Fixes #370