### PR TITLE
introspection: Add test coverage

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -246,11 +246,6 @@ func fromPeerList(peers containsPeerList, opts *IntrospectionOptions) map[string
 	return m
 }
 
-// IntrospectState returns the runtime state of the peer list.
-func (l *PeerList) IntrospectState(opts *IntrospectionOptions) map[string]PeerRuntimeState {
-	return fromPeerList(l, opts)
-}
-
 // IntrospectState returns the runtime state of the
 func (l *RootPeerList) IntrospectState(opts *IntrospectionOptions) map[string]PeerRuntimeState {
 	return fromPeerList(l, opts)


### PR DESCRIPTION
Excercise the introspection path to ensure it works and doesn't cause
any unexpected failures. This also gives us coverage on the
introspection code.

Turns out we're not using the `PeerList.IntrospectState` method, so removing it.