### PR TITLE
Only add new active connections if channel is active

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -534,8 +534,38 @@ func (ch *Channel) updatePeer(p *Peer) {
 	p.callOnUpdateComplete()
 }
 
+// addConnection adds the connection to the channel's list of connection
+// if the channel is in a valid state to accept this connection. It returns
+// whether the connection was added.
+func (ch *Channel) addConnection(c *Connection, direction connectionDirection) bool {
+	ch.mutable.Lock()
+	defer ch.mutable.Unlock()
+
+	switch state := ch.mutable.state; state {
+	case ChannelStartClose:
+		// Outbound connections are allowed in ChannelStartClose, but the
+		// connection state should be set to connectionStartClose.
+		if direction != outbound {
+			return false
+		}
+	case ChannelClient, ChannelListening:
+	default:
+		return false
+	}
+
+	ch.mutable.conns[c.connID] = c
+	return true
+}
+
 func (ch *Channel) connectionActive(c *Connection, direction connectionDirection) {
-	c.log.Debugf("Add %v connection as an active peer for %v", direction, c.remotePeerInfo.HostPort)
+	c.log.Debugf("New active %v connection for peer %v", direction, c.remotePeerInfo.HostPort)
+
+	if added := ch.addConnection(c, direction); !added {
+		// The channel isn't in a valid state to accept this connection, close the connection.
+		c.log.Debugf("Closing connection due to closing channel state")
+		c.Close()
+		return
+	}
 
 	p := ch.rootPeers().GetOrAdd(c.remotePeerInfo.HostPort)
 	if err := p.addConnection(c, direction); err != nil {
@@ -546,10 +576,6 @@ func (ch *Channel) connectionActive(c *Connection, direction connectionDirection
 	}
 
 	ch.updatePeer(p)
-
-	ch.mutable.Lock()
-	ch.mutable.conns[c.connID] = c
-	ch.mutable.Unlock()
 }
 
 func (ch *Channel) inboundConnectionActive(c *Connection) {


### PR DESCRIPTION
We previously checked if the channel was active using a read lock, but
this could go stale, as the channel could be closed between the time the
check was done and the connection being added -- and the connection
would be left in an active state, causing the channel to never close.

To avoid this, we now check the state and add the connection atomically.

If the connection is not added, it means the channel is closed, and so
we close the connection to avoid leaving a rogue TCP connection.