### PR TITLE
Atomically check connection state and add to channel/peer list

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -541,6 +541,10 @@ func (ch *Channel) addConnection(c *Connection, direction connectionDirection) b
 	ch.mutable.Lock()
 	defer ch.mutable.Unlock()
 
+	if c.readState() != connectionActive {
+		return false
+	}
+
 	switch state := ch.mutable.state; state {
 	case ChannelStartClose:
 		// Outbound connections are allowed in ChannelStartClose, but the
@@ -572,6 +576,7 @@ func (ch *Channel) connectionActive(c *Connection, direction connectionDirection
 		c.log.WithFields(
 			LogField{"remoteHostPort", c.remotePeerInfo.HostPort},
 			LogField{"direction", direction},
+			ErrField(err),
 		).Warn("Failed to add connection to peer")
 	}
 


### PR DESCRIPTION
We check the connection state before adding it to the channel's connection list or peer's connection list. However, the connection check is done outside of the lock, and so the state may be stale by the time we get the lock.

We need to hold the container's lock while we check the connection state so we don't get into situations where:
- G1: container checks connection state (which is active)
- G2: connection disconnects, attempts to remove connection from container (which doesn't find any peers)
- G1: container gets lock and adds the connection to the list

We can avoid adding a connection that has closed (and thinks it has been removed from all containers), by holding the container lock while checking the state. This would lead to:

- G1: container gets lock, checks connection state (which is active)
- G2: connection disconnects, attempts to remove connection from container, tries to get lock, but is blocked
- G1: adds the connection to the list, and unlocks
- G2: gets the container's lock, and removes the connection from the list

This change leads to holding multiple locks at once, and so we must ensure that all calls that acquire multiple locks have a very strict ordering. The ordering is container -> child. So if a call needed the following locks: channel, connection, peer, then the ordering would be:
channel, peer, connection.

The goal should still be to only require one lock at a time.