### PR TITLE
Don't allow outgoing connections while a channel is closing

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -358,8 +358,8 @@ func (t *closeSemanticsTest) runTest(ctx context.Context) {
 		t.Errorf("err %v", t.call(s2, s1))
 	}
 
-	require.NoError(t, t.call(s1, s2),
-		"closed channel with pending incoming calls should allow outgoing calls")
+	require.Error(t, t.call(s1, s2),
+		"closed channel with pending incoming calls disallows outgoing calls")
 
 	// Once the incoming connection is drained, outgoing calls should fail.
 	s1C <- struct{}{}

--- a/outbound.go
+++ b/outbound.go
@@ -36,9 +36,9 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 	now := c.timeNow()
 
 	switch state := c.readState(); state {
-	case connectionActive, connectionStartClose:
+	case connectionActive:
 		break
-	case connectionInboundClosed, connectionClosed:
+	case connectionStartClose, connectionInboundClosed, connectionClosed:
 		return nil, ErrConnectionClosed
 	case connectionWaitingToRecvInitReq, connectionWaitingToSendInitReq, connectionWaitingToRecvInitRes:
 		return nil, ErrConnectionNotReady
@@ -69,7 +69,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 	}
 
 	// Close may have been called between the time we checked the state and us creating the exchange.
-	if state := c.readState(); state != connectionStartClose && state != connectionActive {
+	if state := c.readState(); state != connectionActive {
 		mex.shutdown()
 		return nil, ErrConnectionClosed
 	}


### PR DESCRIPTION
Previously, we allowed creating a new connection to be made during
shutdown, but this had a few drawbacks:
- Channel may never close in specific scenarios (connect without call
  being made)
- Code had hacks to set the connection state specifically for this
  scenario

There doesn't seem to be a strong benefit in supporting this, as it
slows down the shutdown path.