### PR TITLE
Add Caller method to lazyCallReq

### DIFF
--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -58,13 +58,11 @@ func (cr testCallReq) req() lazyCallReq {
 	}
 
 	if cr&reqHasChecksum == 0 {
-		checksum := ChecksumTypeCrc32C
-		payload.WriteSingleByte(byte(checksum)) // checksum type
-		payload.WriteUint32(0)                  // checksum contents
-	} else {
-		checksum := ChecksumTypeNone
-		payload.WriteSingleByte(byte(checksum)) // checksum type
+		payload.WriteSingleByte(byte(ChecksumTypeNone)) // checksum type
 		// no checksum contents for None
+	} else {
+		payload.WriteSingleByte(byte(ChecksumTypeCrc32C)) // checksum type
+		payload.WriteUint32(0)                            // checksum contents
 	}
 	payload.WriteLen16String("moneys") // method
 	return newLazyCallReq(f)
@@ -99,15 +97,15 @@ func (cr testCallRes) res() lazyCallRes {
 	payload := typed.NewWriteBuffer(f.Payload)
 
 	if cr&resIsContinued == 0 {
-		payload.WriteSingleByte(hasMoreFragmentsFlag) // flags
-	} else {
 		payload.WriteSingleByte(0) // flags
+	} else {
+		payload.WriteSingleByte(hasMoreFragmentsFlag) // flags
 	}
 
 	if cr&resIsOK == 0 {
-		payload.WriteSingleByte(0) // code ok
-	} else {
 		payload.WriteSingleByte(1) // code not ok
+	} else {
+		payload.WriteSingleByte(0) // code ok
 	}
 
 	if cr&resHasHeaders == 0 {
@@ -117,11 +115,11 @@ func (cr testCallRes) res() lazyCallRes {
 	}
 
 	if cr&resHasChecksum == 0 {
-		payload.WriteSingleByte(byte(ChecksumTypeCrc32C)) // checksum type
-		payload.WriteUint32(0)                            // checksum contents
-	} else {
 		payload.WriteSingleByte(byte(ChecksumTypeNone)) // checksum type
 		// No contents for ChecksumTypeNone.
+	} else {
+		payload.WriteSingleByte(byte(ChecksumTypeCrc32C)) // checksum type
+		payload.WriteUint32(0)                            // checksum contents
 	}
 	payload.WriteUint16(0) // no arg1 for call res
 	return newLazyCallRes(f)
@@ -225,9 +223,9 @@ func TestLazyCallResOK(t *testing.T) {
 	withLazyCallResCombinations(func(crt testCallRes) {
 		cr := crt.res()
 		if crt&resIsOK == 0 {
-			assert.True(t, cr.OK(), "Expected call res to have code ok.")
-		} else {
 			assert.False(t, cr.OK(), "Expected call res to have a non-ok code.")
+		} else {
+			assert.True(t, cr.OK(), "Expected call res to have code ok.")
 		}
 	})
 }


### PR DESCRIPTION
Add a method to `lazyCallReq` to extract the caller name from the variable-length transport headers. Along the way, fix some bugs in the flag logic for the relay messages - we (mostly I) were routinely checking flags incorrectly.