### PR TITLE
Enable relay by default in all tests

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -78,7 +78,10 @@ func TestCloseNewClient(t *testing.T) {
 }
 
 func TestCloseAfterTimeout(t *testing.T) {
-	opts := testutils.NewOpts().SetRelay()
+	// Disable log verfication since connections are closed after a timeout
+	// and the relay might still be reading/writing to the connection.
+	// TODO: Ideally, we only disable log verification on the relay.
+	opts := testutils.NewOpts().DisableLogVerification()
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		testHandler := onErrorTestHandler{newTestHandler(t), func(_ context.Context, err error) {}}
 		ts.Register(raw.Wrap(testHandler), "block")

--- a/frame_pool_test.go
+++ b/frame_pool_test.go
@@ -103,8 +103,7 @@ func TestFramesReleased(t *testing.T) {
 	opts := testutils.NewOpts().
 		SetServiceName("swap-server").
 		SetFramePool(pool).
-		AddLogFilter("Couldn't find handler.", 2*numGoroutines*requestsPerGoroutine).
-		SetRelay()
+		AddLogFilter("Couldn't find handler.", 2*numGoroutines*requestsPerGoroutine)
 
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		ts.Register(raw.Wrap(&swapper{t}), "swap")
@@ -161,8 +160,7 @@ func TestDirtyFrameRequests(t *testing.T) {
 
 	opts := testutils.NewOpts().
 		SetServiceName("swap-server").
-		SetFramePool(dirtyFramePool{}).
-		SetRelay()
+		SetFramePool(dirtyFramePool{})
 
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		ts.Register(raw.Wrap(&swapper{t}), "swap")

--- a/incoming_test.go
+++ b/incoming_test.go
@@ -36,7 +36,8 @@ func TestPeersIncomingConnection(t *testing.T) {
 		return ch, hostPort
 	}
 
-	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+	opts := testutils.NewOpts().NoRelay()
+	WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 		doPing := func(ch *Channel) {
 			ctx, cancel := NewContext(time.Second)
 			defer cancel()

--- a/peer_test.go
+++ b/peer_test.go
@@ -188,7 +188,9 @@ func TestInboundEphemeralPeerRemoved(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+	// No relay, since we look for the exact host:port in peer lists.
+	opts := testutils.NewOpts().NoRelay()
+	WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 		client := testutils.NewClient(t, nil)
 		assert.NoError(t, client.Ping(ctx, hostPort), "Ping to server failed")
 
@@ -283,7 +285,8 @@ func TestPeerRemovedFromRootPeers(t *testing.T) {
 	defer cancel()
 
 	for _, tt := range tests {
-		WithVerifiedServer(t, nil, func(server *Channel, hostPort string) {
+		opts := testutils.NewOpts().NoRelay()
+		WithVerifiedServer(t, opts, func(server *Channel, hostPort string) {
 			ch := testutils.NewServer(t, nil)
 			clientHP := ch.PeerInfo().HostPort
 
@@ -386,7 +389,10 @@ func TestPeerSelectionPreferIncoming(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+		// We need to directly connect from the server to the client and verify
+		// the exact peers.
+		opts := testutils.NewOpts().NoRelay()
+		WithVerifiedServer(t, opts, func(ch *Channel, hostPort string) {
 			ctx, cancel := NewContext(time.Second)
 			defer cancel()
 

--- a/retry_request_test.go
+++ b/retry_request_test.go
@@ -36,9 +36,7 @@ func TestRequestStateRetry(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	opts := testutils.NewOpts().SetRelay()
-
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
 		ts.Register(raw.Wrap(newTestHandler(t)), "echo")
 
 		closedHostPorts := make([]string, 4)

--- a/stats_test.go
+++ b/stats_test.go
@@ -144,7 +144,9 @@ func TestStatsWithRetries(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	WithVerifiedServer(t, nil, func(serverCh *Channel, hostPort string) {
+	// TODO why do we need this??
+	opts := testutils.NewOpts().NoRelay()
+	WithVerifiedServer(t, opts, func(serverCh *Channel, hostPort string) {
 		respErr := make(chan error, 1)
 		testutils.RegisterFunc(serverCh, "req", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 			return &raw.Res{Arg2: args.Arg2, Arg3: args.Arg3}, <-respErr

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -48,9 +48,9 @@ type ChannelOpts struct {
 	// LogVerification contains options for controlling the log verification.
 	LogVerification LogVerification
 
-	// IncludeRelay instructs TestServer to interpose a relay between servers and
-	// clients. It's ignored by other test helpers.
-	IncludeRelay bool
+	// DisableRelay disables the relay interposed between clients/servers.
+	// By default, all tests are run with a relay interposed.
+	DisableRelay bool
 
 	// OnlyRelay instructs TestServer the test must only be run with a relay.
 	OnlyRelay bool
@@ -148,17 +148,15 @@ func (o *ChannelOpts) DisableLogVerification() *ChannelOpts {
 	return o
 }
 
-// SetRelay instructs TestServer to run the test twice, once without a relay
-// and once with a relay in front of this channel.
-func (o *ChannelOpts) SetRelay() *ChannelOpts {
-	o.IncludeRelay = true
+// NoRelay disables running the test with a relay interposed.
+func (o *ChannelOpts) NoRelay() *ChannelOpts {
+	o.DisableRelay = true
 	return o
 }
 
 // SetRelayOnly instructs TestServer to only run with a relay in front of this channel.
 func (o *ChannelOpts) SetRelayOnly() *ChannelOpts {
 	o.OnlyRelay = true
-	o.IncludeRelay = true
 	return o
 }
 

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -78,7 +78,7 @@ func NewTestServer(t testing.TB, opts *ChannelOpts) *TestServer {
 	}
 
 	ts.NewServer(opts)
-	if opts != nil && opts.IncludeRelay {
+	if opts == nil || !opts.DisableRelay {
 		ts.addRelay(opts.LogVerification)
 	}
 
@@ -99,13 +99,15 @@ func WithTestServer(t testing.TB, chanOpts *ChannelOpts, f func(*TestServer)) {
 			return
 		}
 
+		// Run without the relay, unless OnlyRelay was set.
 		if !chanOpts.OnlyRelay {
 			noRelayOpts := chanOpts.Copy()
-			noRelayOpts.IncludeRelay = false
+			noRelayOpts.DisableRelay = true
 			withServer(t, noRelayOpts, f)
 		}
 
-		if chanOpts.IncludeRelay {
+		// Run with the relay, unless the user has disabled it.
+		if !chanOpts.DisableRelay {
 			withServer(t, chanOpts.Copy(), f)
 		}
 	}


### PR DESCRIPTION
Instead of opting in to the relay, tests should be forced to use the relay by default, and opt out if they do not work with a relay.