### PR TITLE
Create context inside of the test function

### DIFF
--- a/peer_test.go
+++ b/peer_test.go
@@ -385,11 +385,11 @@ func TestPeerSelectionPreferIncoming(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := NewContext(time.Second)
-	defer cancel()
-
 	for _, tt := range tests {
 		WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+			ctx, cancel := NewContext(time.Second)
+			defer cancel()
+
 			selectedIncoming := make(map[string]int)
 			selectedOutgoing := make(map[string]int)
 			selectedUnconnected := make(map[string]int)


### PR DESCRIPTION
Avoid timeouts if a previous test failed, since the context may now
already be past the deadline and will cause future failures