### PR TITLE
Remove an argument from AssertRelayStats

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -60,7 +60,7 @@ func TestRelay(t *testing.T) {
 		for _ = range tests {
 			calls.Add("client", "test", "echo").Succeeded().End()
 		}
-		ts.AssertRelayStats(t, calls)
+		ts.AssertRelayStats(calls)
 	})
 }
 
@@ -102,7 +102,7 @@ func TestRelayConnectionCloseDrainsRelayItems(t *testing.T) {
 
 		calls := relay.NewMockStats()
 		calls.Add("s2", "s1", "echo").Succeeded().End()
-		ts.AssertRelayStats(t, calls)
+		ts.AssertRelayStats(calls)
 	})
 }
 
@@ -156,7 +156,7 @@ func TestRelayErrorUnknownPeer(t *testing.T) {
 
 		calls := relay.NewMockStats()
 		calls.Add(client.PeerInfo().ServiceName, "random-service", "echo").Failed("relay-declined").End()
-		ts.AssertRelayStats(t, calls)
+		ts.AssertRelayStats(calls)
 	})
 }
 
@@ -180,7 +180,7 @@ func TestErrorFrameEndsRelay(t *testing.T) {
 
 		calls := relay.NewMockStats()
 		calls.Add(client.PeerInfo().ServiceName, "svc", "echo").Failed("bad-request").End()
-		ts.AssertRelayStats(t, calls)
+		ts.AssertRelayStats(calls)
 	})
 }
 

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -181,11 +181,11 @@ func (ts *TestServer) CloseAndVerify() {
 
 // AssertRelayStats checks that the relayed call graph matches expectations. If
 // there's no relay, AssertRelayStats is a no-op.
-func (ts *TestServer) AssertRelayStats(t testing.TB, expected *relay.MockStats) {
+func (ts *TestServer) AssertRelayStats(expected *relay.MockStats) {
 	if !ts.HasRelay() {
 		return
 	}
-	ts.relayStats.AssertEqual(t, expected)
+	ts.relayStats.AssertEqual(ts, expected)
 }
 
 // NewClient returns a client that with log verification.


### PR DESCRIPTION
The test server itself implements `testing.TB`, so there's no need for
the caller to pass one into `AssertRelayStats`.