### PR TITLE
Add relay metrics assertions to connection tests

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -31,12 +31,13 @@ import (
 	"time"
 
 	. "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/relay"
+	"github.com/uber/tchannel-go/testutils"
+	"github.com/uber/tchannel-go/testutils/testreader"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/raw"
-	"github.com/uber/tchannel-go/testutils"
-	"github.com/uber/tchannel-go/testutils/testreader"
 	"golang.org/x/net/context"
 )
 
@@ -548,7 +549,7 @@ func TestWriteAfterConnectionError(t *testing.T) {
 	// Closing network connections can lead to warnings in many places.
 	// TODO: Relay is disabled due to https://github.com/uber/tchannel-go/issues/390
 	// Enabling relay causes the test to be flaky.
-	opts := testutils.NewOpts().DisableLogVerification()
+	opts := testutils.NewOpts().DisableLogVerification().NoRelay()
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 		server := ts.Server()

--- a/relay/fakes.go
+++ b/relay/fakes.go
@@ -48,6 +48,9 @@ func (n noopCallStats) End()                      {}
 
 // MockCallStats is a testing spy for the CallStats interface.
 type MockCallStats struct {
+	// Store ints and slices instead of bools and strings so that we can assert
+	// the actual sequence of calls (in case we expect to call both Succeeded
+	// and Failed). The real implementation will have the first writer win.
 	succeeded  int
 	failedMsgs []string
 	ended      int
@@ -143,6 +146,10 @@ func (m *MockStats) assertCallEqual(t testing.TB, expected *MockCallStats, actua
 	assert.Equal(t, expected.succeeded, actual.succeeded, "Unexpected number of successes.")
 	assert.Equal(t, expected.failedMsgs, actual.failedMsgs, "Unexpected reasons for RPC failure.")
 	assert.Equal(t, expected.ended, actual.ended, "Unexpected number of calls to End.")
+	if t.Failed() {
+		// The default testify output is often insufficient.
+		t.Logf("\nExpected relayed stats were:\n\t%+v\nActual relayed stats were:\n\t%+v\n", expected, actual)
+	}
 }
 
 func (m *MockStats) tripleToKey(caller, callee, procedure string) string {


### PR DESCRIPTION
Test relay stats collection in the connection tests. (Also pulls in a flaky test fix/TODO and some documentation improvements for the mock stats.)