### PR TITLE
lazyCallReq: Only parse transport headers once

### DIFF
--- a/relay_messages.go
+++ b/relay_messages.go
@@ -21,12 +21,13 @@
 package tchannel
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"time"
-
-	"github.com/uber/tchannel-go/typed"
 )
+
+var callerNameKeyBytes = []byte(CallerName)
 
 const (
 	// Common to many frame types.
@@ -76,32 +77,58 @@ func (cr lazyCallRes) OK() bool {
 	return cr.Payload[_resCodeIndex] == _resCodeOK
 }
 
+// TODO: Use []byte instead of string to avoid allocations.
 type lazyCallReq struct {
 	*Frame
+
+	caller []byte
+	method []byte
 }
+
+// TODO: Consider pooling lazyCallReq and using pointers to the struct.
 
 func newLazyCallReq(f *Frame) lazyCallReq {
 	if msgType := f.Header.messageType; msgType != messageTypeCallReq {
 		panic(fmt.Errorf("newLazyCallReq called for wrong messageType: %v", msgType))
 	}
-	return lazyCallReq{f}
+
+	cr := lazyCallReq{Frame: f}
+
+	serviceLen := f.Payload[_serviceLenIndex]
+	// nh:1 (hk~1 hv~1){nh}
+	headerStart := _serviceLenIndex + 1 /* length byte */ + serviceLen
+	numHeaders := int(f.Payload[headerStart])
+	cur := int(headerStart) + 1
+	for i := 0; i < numHeaders; i++ {
+		keyLen := int(f.Payload[cur])
+		cur++
+		key := f.Payload[cur : cur+keyLen]
+		cur += keyLen
+
+		valLen := int(f.Payload[cur])
+		cur++
+		val := f.Payload[cur : cur+valLen]
+		cur += valLen
+
+		if bytes.Equal(key, callerNameKeyBytes) {
+			cr.caller = val
+		}
+	}
+
+	// csumtype:1 (csum:4){0,1} arg1~2 arg2~2 arg3~2
+	checkSumType := ChecksumType(f.Payload[cur])
+	cur += 1 /* checksum */ + checkSumType.ChecksumSize()
+
+	// arg1~2
+	arg1Len := int(binary.BigEndian.Uint16(f.Payload[cur : cur+2]))
+	cur += 2
+	cr.method = f.Payload[cur : cur+arg1Len]
+	return cr
 }
 
 // Caller returns the name of the originator of this callReq.
 func (f lazyCallReq) Caller() string {
-	serviceLen := f.Payload[_serviceLenIndex]
-	// nh:1 (hk~1 hv~1){nh}
-	headerStart := _serviceLenIndex + 1 /* length byte */ + serviceLen
-	buf := typed.NewReadBuffer(f.Payload[headerStart:])
-	nh := buf.ReadSingleByte()
-	for i := 0; i < int(nh); i++ {
-		k := TransportHeaderName(buf.ReadLen8String())
-		v := buf.ReadLen8String()
-		if k == CallerName {
-			return v
-		}
-	}
-	return ""
+	return string(f.caller)
 }
 
 // Service returns the name of the destination service for this callReq.
@@ -113,26 +140,7 @@ func (f lazyCallReq) Service() string {
 // Method returns the name of the method being called. It panics if called for
 // a non-callReq frame.
 func (f lazyCallReq) Method() string {
-	serviceLen := f.Payload[_serviceLenIndex]
-
-	// nh:1 (hk~1 hv~1){nh}
-	headerStart := _serviceLenIndex + 1 /* length byte */ + serviceLen
-	numHeaders := int(f.Payload[headerStart])
-	cur := int(headerStart) + 1
-	for i := 0; i < numHeaders*2; i++ {
-		sLen := f.Payload[cur]
-		cur += 1 + int(sLen)
-	}
-
-	// csumtype:1 (csum:4){0,1} arg1~2 arg2~2 arg3~2
-	checkSumType := ChecksumType(f.Payload[cur])
-	cur += 1 /* checksum */ + checkSumType.ChecksumSize()
-
-	// arg1~2
-	arg1Len := int(binary.BigEndian.Uint16(f.Payload[cur : cur+2]))
-	cur += 2
-	arg1 := f.Payload[cur : cur+arg1Len]
-	return string(arg1)
+	return string(f.method)
 }
 
 // TTL returns the time to live for this callReq.

--- a/relay_messages_benchmark_test.go
+++ b/relay_messages_benchmark_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+)
+
+func BenchmarkCallReqFrame(b *testing.B) {
+	cr := reqHasAll.req()
+	f := cr.Frame
+
+	var service, caller, method string
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cr := newLazyCallReq(f)
+
+		// Multiple calls due to peer selection, stats, etc.
+		for i := 0; i < 3; i++ {
+			service = cr.Service()
+			caller = cr.Caller()
+			method = cr.Method()
+		}
+	}
+	b.StopTimer()
+
+	fmt.Fprint(ioutil.Discard, service, caller, method)
+}

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -35,6 +35,7 @@ const (
 	reqHasHeaders testCallReq = (1 << iota)
 	reqHasChecksum
 	reqTotalCombinations
+	reqHasAll testCallReq = reqTotalCombinations - 1
 )
 
 func (cr testCallReq) req() lazyCallReq {


### PR DESCRIPTION
I'm parsing the frame bytes explicitly instead of using `typed` to avoid extra allocations from creating strings for each header.

Benchmark comparison:
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkCallReqFrame-8     1046          214           -79.54%

benchmark                   old allocs     new allocs     delta
BenchmarkCallReqFrame-8     24             5              -79.17%

benchmark                   old bytes     new bytes     delta
BenchmarkCallReqFrame-8     120           48            -60.00%
```