### PR TITLE
Release 1.0.6 with trace span encoding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+# 1.0.6
+
+* Fix trace span encoding fields in the wrong order
+
 # 1.0.5
 
 * Use `context.Context` storage for headers so `thrift.Context` and

--- a/tracing.go
+++ b/tracing.go
@@ -51,17 +51,17 @@ func (s Span) String() string {
 }
 
 func (s *Span) read(r *typed.ReadBuffer) error {
-	s.traceID = r.ReadUint64()
-	s.parentID = r.ReadUint64()
 	s.spanID = r.ReadUint64()
+	s.parentID = r.ReadUint64()
+	s.traceID = r.ReadUint64()
 	s.flags = r.ReadSingleByte()
 	return r.Err()
 }
 
 func (s *Span) write(w *typed.WriteBuffer) error {
-	w.WriteUint64(s.traceID)
-	w.WriteUint64(s.parentID)
 	w.WriteUint64(s.spanID)
+	w.WriteUint64(s.parentID)
+	w.WriteUint64(s.traceID)
 	w.WriteSingleByte(s.flags)
 	return w.Err()
 }

--- a/tracing_internal_test.go
+++ b/tracing_internal_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/typed"
+)
+
+func TestTracingSpanEncoding(t *testing.T) {
+	s1 := Span{
+		traceID:  1,
+		parentID: 2,
+		spanID:   3,
+		flags:    4,
+	}
+	// Encoding is: spanid:8 parentid:8 traceid:8 traceflags:1
+	// http://tchannel.readthedocs.io/en/latest/protocol/#tracing
+	encoded := []byte{
+		0, 0, 0, 0, 0, 0, 0, 3, /* spanID */
+		0, 0, 0, 0, 0, 0, 0, 2, /* parentID */
+		0, 0, 0, 0, 0, 0, 0, 1, /* traceID */
+		4, /* flags */
+	}
+
+	buf := make([]byte, len(encoded))
+	writer := typed.NewWriteBuffer(buf)
+	require.NoError(t, s1.write(writer), "Failed to encode span")
+
+	assert.Equal(t, encoded, buf, "Encoded span mismatch")
+
+	var s2 Span
+	reader := typed.NewReadBuffer(buf)
+	require.NoError(t, s2.read(reader), "Failed to decode span")
+
+	assert.Equal(t, s1, s2, "Roundtrip of span failed")
+}

--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ package tchannel
 // VersionInfo identifies the version of the TChannel library.
 // Due to lack of proper package management, this version string will
 // be maintained manually.
-const VersionInfo = "1.0.5"
+const VersionInfo = "1.0.6"


### PR DESCRIPTION
This is a cherry-pick off the dev branch, there are no other changes in this release.