### PR TITLE
Fix import ordering

### DIFF
--- a/benchmark/matrix_test.go
+++ b/benchmark/matrix_test.go
@@ -24,9 +24,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/uber/tchannel-go"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
 )
 
 // combinations will call f with every combination of selecting elements

--- a/connection_bench_test.go
+++ b/connection_bench_test.go
@@ -28,10 +28,11 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/streadway/quantile"
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/streadway/quantile"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 

--- a/context_test.go
+++ b/context_test.go
@@ -25,10 +25,11 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/testutils/goroutines"
+
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 

--- a/examples/bench/server/server.go
+++ b/examples/bench/server/server.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
+
 	"golang.org/x/net/context"
 )
 

--- a/examples/hyperbahn/echo-server/main.go
+++ b/examples/hyperbahn/echo-server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/hyperbahn"
 	"github.com/uber/tchannel-go/raw"
+
 	"golang.org/x/net/context"
 )
 

--- a/fragmentation_test.go
+++ b/fragmentation_test.go
@@ -27,9 +27,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/uber/tchannel-go/typed"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/typed"
 )
 
 const (

--- a/frame_pool_test.go
+++ b/frame_pool_test.go
@@ -33,12 +33,13 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/testutils/goroutines"
 	"github.com/uber/tchannel-go/testutils/testreader"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 

--- a/frame_test.go
+++ b/frame_test.go
@@ -27,10 +27,11 @@ import (
 	"testing"
 	"testing/iotest"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils/testreader"
 	"github.com/uber/tchannel-go/typed"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func fakeHeader() FrameHeader {

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -32,11 +32,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 

--- a/hyperbahn/advertise_test.go
+++ b/hyperbahn/advertise_test.go
@@ -26,12 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitialAdvertiseFailedRetryBackoff(t *testing.T) {

--- a/hyperbahn/client_test.go
+++ b/hyperbahn/client_test.go
@@ -27,9 +27,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
 

--- a/hyperbahn/discover_test.go
+++ b/hyperbahn/discover_test.go
@@ -25,10 +25,11 @@ import (
 
 	. "github.com/uber/tchannel-go/hyperbahn"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/testutils/mockhyperbahn"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func withSetup(t *testing.T, f func(mh *mockhyperbahn.Mock, client *Client)) {

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -25,13 +25,14 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	. "github.com/uber/tchannel-go"
+
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/testutils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/raw"
-	"github.com/uber/tchannel-go/testutils"
+	"golang.org/x/net/context"
 )
 
 func TestActiveCallReq(t *testing.T) {

--- a/incoming_test.go
+++ b/incoming_test.go
@@ -26,8 +26,9 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPeersIncomingConnection(t *testing.T) {

--- a/json/context.go
+++ b/json/context.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/uber/tchannel-go"
+
 	"golang.org/x/net/context"
 )
 

--- a/json/handler.go
+++ b/json/handler.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 
 	"github.com/uber/tchannel-go"
+
 	"golang.org/x/net/context"
 )
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/tchannel-go"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
 	"golang.org/x/net/context"
 )
 

--- a/json/retry_test.go
+++ b/json/retry_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRetryJSONCall(t *testing.T) {

--- a/largereq_test.go
+++ b/largereq_test.go
@@ -28,9 +28,10 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLargeRequest(t *testing.T) {

--- a/messages_test.go
+++ b/messages_test.go
@@ -26,9 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/tchannel-go/typed"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/typed"
 )
 
 func TestInitReq(t *testing.T) {

--- a/peer_bench_test.go
+++ b/peer_bench_test.go
@@ -26,8 +26,9 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/require"
 )
 
 func benchmarkGetConnection(b *testing.B, numIncoming, numOutgoing int) {

--- a/peer_test.go
+++ b/peer_test.go
@@ -29,11 +29,12 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/testutils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/atomic"
-	"github.com/uber/tchannel-go/raw"
-	"github.com/uber/tchannel-go/testutils"
 )
 
 func fakePeer(t *testing.T, ch *Channel, hostPort string) *Peer {

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -22,11 +22,11 @@ package pprof
 
 import (
 	"net/http"
-
 	_ "net/http/pprof" // So pprof endpoints are registered on DefaultServeMux.
 
 	"github.com/uber/tchannel-go"
 	thttp "github.com/uber/tchannel-go/http"
+
 	"golang.org/x/net/context"
 )
 

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	thttp "github.com/uber/tchannel-go/http"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPProfEndpoint(t *testing.T) {

--- a/raw/call.go
+++ b/raw/call.go
@@ -23,8 +23,9 @@ package raw
 import (
 	"errors"
 
-	"github.com/uber/tchannel-go"
 	"golang.org/x/net/context"
+
+	"github.com/uber/tchannel-go"
 )
 
 // ErrAppError is returned if the application sets an error response.

--- a/raw/handler.go
+++ b/raw/handler.go
@@ -21,8 +21,9 @@
 package raw
 
 import (
-	"github.com/uber/tchannel-go"
 	"golang.org/x/net/context"
+
+	"github.com/uber/tchannel-go"
 )
 
 // Handler is the interface for a raw handler.

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -3,8 +3,9 @@ package tchannel
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/typed"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFinishesCallResponses(t *testing.T) {

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/typed"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testCallReq int

--- a/retry_request_test.go
+++ b/retry_request_test.go
@@ -26,9 +26,10 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -27,9 +27,10 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
+	"github.com/uber/tchannel-go/testutils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/testutils"
 	"golang.org/x/net/context"
 )
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -26,14 +26,14 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	. "github.com/uber/tchannel-go"
+
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/testutils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/raw"
-	"github.com/uber/tchannel-go/testutils"
+	"golang.org/x/net/context"
 )
 
 func tagsForOutboundCall(serverCh *Channel, clientCh *Channel, method string) map[string]string {

--- a/stream_test.go
+++ b/stream_test.go
@@ -31,9 +31,10 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
+	"github.com/uber/tchannel-go/testutils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/testutils"
 	"golang.org/x/net/context"
 )
 

--- a/testutils/channel_t.go
+++ b/testutils/channel_t.go
@@ -23,8 +23,9 @@ package testutils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
+
+	"github.com/stretchr/testify/require"
 )
 
 func updateOptsLogger(opts *ChannelOpts) {

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 // CallEcho calls the "echo" endpoint from the given src to target.

--- a/testutils/mockhyperbahn/hyperbahn_test.go
+++ b/testutils/mockhyperbahn/hyperbahn_test.go
@@ -23,11 +23,12 @@ package mockhyperbahn_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/hyperbahn"
 	"github.com/uber/tchannel-go/testutils/mockhyperbahn"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var config = struct {

--- a/thrift/client.go
+++ b/thrift/client.go
@@ -21,8 +21,9 @@
 package thrift
 
 import (
-	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/uber/tchannel-go"
+
+	"github.com/apache/thrift/lib/go/thrift"
 	"golang.org/x/net/context"
 )
 

--- a/thrift/context_test.go
+++ b/thrift/context_test.go
@@ -27,11 +27,12 @@ import (
 
 	. "github.com/uber/tchannel-go/thrift"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
 	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
+
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 

--- a/thrift/errors_test.go
+++ b/thrift/errors_test.go
@@ -25,16 +25,17 @@ import (
 	"time"
 
 	// Test is in a separate package to avoid circular dependencies.
-	"github.com/uber/tchannel-go/raw"
 	. "github.com/uber/tchannel-go/thrift"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/raw"
+	"github.com/uber/tchannel-go/testutils"
+	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
+	"github.com/uber/tchannel-go/thrift/mocks"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/testutils"
-	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
-	"github.com/uber/tchannel-go/thrift/mocks"
 )
 
 func serializeStruct(t *testing.T, s thrift.TStruct) []byte {

--- a/thrift/meta_test.go
+++ b/thrift/meta_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/thrift/gen-go/meta"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultHealth(t *testing.T) {

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/apache/thrift/lib/go/thrift"
 	tchannel "github.com/uber/tchannel-go"
+
+	"github.com/apache/thrift/lib/go/thrift"
 	"golang.org/x/net/context"
 )
 

--- a/thrift/struct_test.go
+++ b/thrift/struct_test.go
@@ -26,13 +26,14 @@ import (
 	"sync"
 	"testing"
 
+	. "github.com/uber/tchannel-go/thrift"
+
 	"github.com/uber/tchannel-go/testutils/testreader"
 	"github.com/uber/tchannel-go/testutils/testwriter"
-	. "github.com/uber/tchannel-go/thrift"
+	"github.com/uber/tchannel-go/thrift/gen-go/test"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/tchannel-go/thrift/gen-go/test"
 )
 
 var structTest = struct {

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -32,14 +32,15 @@ import (
 	// Test is in a separate package to avoid circular dependencies.
 	. "github.com/uber/tchannel-go/thrift"
 
-	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	tchannel "github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
 	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
 	"github.com/uber/tchannel-go/thrift/mocks"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Generate the service mocks using go generate.

--- a/thrift/transport_test.go
+++ b/thrift/transport_test.go
@@ -25,9 +25,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/testutils/testreader"
 	"github.com/uber/tchannel-go/testutils/testwriter"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func writeByte(writer io.Writer, b byte) error {

--- a/trace/reporter_test.go
+++ b/trace/reporter_test.go
@@ -24,15 +24,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/thrift"
 	gen "github.com/uber/tchannel-go/trace/thrift/gen-go/tcollector"
 	"github.com/uber/tchannel-go/trace/thrift/mocks"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTraceReporterFactory(t *testing.T) {

--- a/tracing_internal_test.go
+++ b/tracing_internal_test.go
@@ -23,9 +23,10 @@ package tchannel
 import (
 	"testing"
 
+	"github.com/uber/tchannel-go/typed"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/typed"
 )
 
 func TestTracingSpanEncoding(t *testing.T) {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -28,11 +28,12 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/json"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 


### PR DESCRIPTION
Imports are ordered:
- standard imports
- optional dot import for package being tested
- internal tchannel-go imports
- external imports