### PR TITLE
Add call validation, and fix flaky call validation tests

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -314,8 +314,19 @@ func TestNoTimeout(t *testing.T) {
 
 		ctx := context.Background()
 		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), "svc", "Echo", []byte("Headers"), []byte("Body"))
-		require.NotNil(t, err)
 		assert.Equal(t, ErrTimeoutRequired, err)
+
+		ts.AssertRelayStats(relay.NewMockStats())
+	})
+}
+
+func TestNoServiceNaming(t *testing.T) {
+	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+		ctx, cancel := NewContext(time.Second)
+		defer cancel()
+
+		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), "", "Echo", []byte("Headers"), []byte("Body"))
+		assert.Equal(t, ErrNoServiceName, err)
 
 		ts.AssertRelayStats(relay.NewMockStats())
 	})

--- a/peer.go
+++ b/peer.go
@@ -455,6 +455,10 @@ func (p *Peer) BeginCall(ctx context.Context, serviceName, methodName string, ca
 	}
 	callOptions.RequestState.AddSelectedPeer(p.HostPort())
 
+	if err := validateCall(ctx, serviceName, methodName, callOptions); err != nil {
+		return nil, err
+	}
+
 	conn, err := p.GetConnection(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, we only validated that a timeout was set, not that a
servicename was specified when making an outbound call.

Add validation, and do it before we get a connection. This avoids
creating a connection that will not be used.

Previously, we would create a connection, do validation, and close the
connection immediately. On the inbound side, this led to a new
connection that was closed almost immediately, and so sometimes the test
would cause a:
"Failed to add connection to peer" "connection is in an invalid state"

By doing validation before we create a connection we make TestNoTimeout
less flaky, while also returning errors earlier and faster.

See test failure:
https://gist.github.com/prashantv/269a2c2f1242e8e2aff9ae2b201cac96