### PR TITLE
Add tracing span to errors on inbound calls and on relay errors

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -322,3 +322,10 @@ type pingRes struct {
 
 func (c *pingRes) ID() uint32               { return c.id }
 func (c *pingRes) messageType() messageType { return messageTypePingRes }
+
+func callReqSpan(f *Frame) Span {
+	rdr := typed.NewReadBuffer(f.Payload[_spanIndex : _spanIndex+_spanLength])
+	var s Span
+	s.read(rdr)
+	return s
+}

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -36,7 +36,9 @@ const (
 	// For call req.
 	_ttlIndex         = 1
 	_ttlLen           = 4
-	_serviceLenIndex  = 1 /* flags */ + _ttlLen + 25 /* tracing */
+	_spanIndex        = _ttlIndex + _ttlLen
+	_spanLength       = 25
+	_serviceLenIndex  = _spanIndex + _spanLength
 	_serviceNameIndex = _serviceLenIndex + 1
 
 	// For call res and call res continue.
@@ -147,6 +149,11 @@ func (f lazyCallReq) Method() []byte {
 func (f lazyCallReq) TTL() time.Duration {
 	ttl := binary.BigEndian.Uint32(f.Payload[_ttlIndex : _ttlIndex+_ttlLen])
 	return time.Duration(ttl) * time.Millisecond
+}
+
+// Span returns the Span
+func (f lazyCallReq) Span() Span {
+	return callReqSpan(f.Frame)
 }
 
 // finishesCall checks whether this frame is the last one we should expect for


### PR DESCRIPTION
I don't know how strictly necessary this is, since the span can be determined by the ID which uniquely identifies the `callReq`, and the span is the same as the contents of the `callReq`.

However to be consistent, we should send the span that we receive.