### PR TITLE
Add Peer struct to represent a peer, pass it to stats

### DIFF
--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -32,14 +32,14 @@ type fixedHosts struct {
 	pickI atomic.Int32
 }
 
-func (fh *fixedHosts) Get(call relay.CallFrame) string {
+func (fh *fixedHosts) Get(call relay.CallFrame) relay.Peer {
 	peers := fh.hosts[string(call.Service())]
 	if len(peers) == 0 {
-		return ""
+		return relay.Peer{}
 	}
 
 	pickI := int(fh.pickI.Inc()-1) % len(peers)
-	return peers[pickI]
+	return relay.Peer{HostPort: peers[pickI]}
 }
 
 type realRelay struct {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -34,8 +34,8 @@ type CallFrame interface {
 // Hosts allows external wrappers to inject peer selection logic for
 // relaying.
 type Hosts interface {
-	// Get returns the host:port of the best peer for the given call.
-	Get(CallFrame) string
+	// Get returns the peer to forward the given call to.
+	Get(CallFrame) Peer
 }
 
 // CallStats is a reporter for per-request stats.
@@ -45,6 +45,10 @@ type Hosts interface {
 // Instead, we mark the call successful or failed as we see the relevant frame,
 // but we wait to end any timers until the last frame of the response.
 type CallStats interface {
+	// SetPeer is called once a peer has been selected for this call.
+	// Note: This may not be called if a call fails before peer selection.
+	SetPeer(Peer) CallStats
+
 	// The call succeeded (possibly after retrying).
 	Succeeded() CallStats
 	// The RPC failed.
@@ -56,4 +60,14 @@ type CallStats interface {
 // Stats is a CallStats factory.
 type Stats interface {
 	Begin(CallFrame) CallStats
+}
+
+// Peer represents the destination selected for a call.
+type Peer struct {
+	// HostPort of the peer that was selected.
+	HostPort string
+
+	// Assignment allows the peer selection to specify a group that this
+	// Peer belongs to, which may be useful when reporting stats.
+	Assignment string
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -57,8 +57,9 @@ func TestRelay(t *testing.T) {
 		}
 
 		calls := relay.NewMockStats()
+		peer := relay.Peer{HostPort: ts.Server().PeerInfo().HostPort}
 		for _ = range tests {
-			calls.Add("client", "test", "echo").Succeeded().End()
+			calls.Add("client", "test", "echo").SetPeer(peer).Succeeded().End()
 		}
 		ts.AssertRelayStats(calls)
 	})
@@ -155,7 +156,8 @@ func TestRelayErrorUnknownPeer(t *testing.T) {
 		assert.Contains(t, err.Error(), `no peers for "random-service"`, "Unexpected error")
 
 		calls := relay.NewMockStats()
-		calls.Add(client.PeerInfo().ServiceName, "random-service", "echo").Failed("relay-declined").End()
+		calls.Add(client.PeerInfo().ServiceName, "random-service", "echo").
+			ExpectNoPeer().Failed("relay-declined").End()
 		ts.AssertRelayStats(calls)
 	})
 }

--- a/testutils/relay_stub_test.go
+++ b/testutils/relay_stub_test.go
@@ -60,13 +60,20 @@ func TestSimpleRelayHosts(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			got := rh.Get(tt.call)
 			if tt.wantOneOf == nil {
-				assert.Equal(t, "", got, "Expected %v to find no hosts", tt.call)
+				assert.Equal(t, "", got.HostPort, "Expected %v to find no hosts", tt.call)
 				continue
 			}
 
 			wantOneOf := StrMap(tt.wantOneOf...)
-			_, found := wantOneOf[got]
+			_, found := wantOneOf[got.HostPort]
 			assert.True(t, found, "Got unexpected hostPort %q, want one of: %v", got, tt.wantOneOf)
 		}
 	}
+}
+
+func TestSimpleRelayHostsPeer(t *testing.T) {
+	hosts := NewSimpleRelayHosts(nil)
+	hosts.AddAssignment("svc", "1.1.1.1:1", "a1")
+	peer := hosts.Get(FakeCallFrame{ServiceF: "svc"})
+	assert.Equal(t, relay.Peer{HostPort: "1.1.1.1:1", Assignment: "a1"}, peer, "Unexpected peer")
 }


### PR DESCRIPTION
We may select a peer as part of some group (e.g. canary), and we want to
track the fact that this is a canary peer through stats. Allow users to
return an assignment as part of the relay.Hosts.Get method and set this
peer with assignment on the stats object.