### PR TITLE
relay: Use []byte instead of string for Caller/Service/Method

### DIFF
--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -33,7 +33,7 @@ type fixedHosts struct {
 }
 
 func (fh *fixedHosts) Get(call relay.CallFrame) string {
-	peers := fh.hosts[call.Service()]
+	peers := fh.hosts[string(call.Service())]
 	if len(peers) == 0 {
 		return ""
 	}

--- a/relay.go
+++ b/relay.go
@@ -418,7 +418,7 @@ func frameTypeFor(f *Frame) frameType {
 	}
 }
 
-func errUnknownGroup(group string) error {
+func errUnknownGroup(group []byte) error {
 	return NewSystemError(ErrCodeDeclined, "no peers for %q", group)
 }
 

--- a/relay/fakes.go
+++ b/relay/fakes.go
@@ -91,7 +91,7 @@ func NewMockStats() *MockStats {
 
 // Begin starts collecting metrics for an RPC.
 func (m *MockStats) Begin(f CallFrame) CallStats {
-	return m.Add(f.Caller(), f.Service(), f.Method())
+	return m.Add(string(f.Caller()), string(f.Service()), string(f.Method()))
 }
 
 // Add explicitly adds a new call along an edge of the call graph.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -24,11 +24,11 @@ package relay
 // CallFrame is an interface that abstracts access to the call req frame.
 type CallFrame interface {
 	// Caller is the name of the originating service.
-	Caller() string
+	Caller() []byte
 	// Service is the name of the destination service.
-	Service() string
+	Service() []byte
 	// Method is the name of the method being called.
-	Method() string
+	Method() []byte
 }
 
 // Hosts allows external wrappers to inject peer selection logic for

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -81,8 +81,8 @@ func (cr lazyCallRes) OK() bool {
 type lazyCallReq struct {
 	*Frame
 
-	caller string
-	method string
+	caller []byte
+	method []byte
 }
 
 // TODO: Consider pooling lazyCallReq and using pointers to the struct.
@@ -111,7 +111,7 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 		cur += valLen
 
 		if bytes.Equal(key, _callerNameKeyBytes) {
-			cr.caller = string(val)
+			cr.caller = val
 		}
 	}
 
@@ -122,24 +122,24 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 	// arg1~2
 	arg1Len := int(binary.BigEndian.Uint16(f.Payload[cur : cur+2]))
 	cur += 2
-	cr.method = string(f.Payload[cur : cur+arg1Len])
+	cr.method = f.Payload[cur : cur+arg1Len]
 	return cr
 }
 
 // Caller returns the name of the originator of this callReq.
-func (f lazyCallReq) Caller() string {
+func (f lazyCallReq) Caller() []byte {
 	return f.caller
 }
 
 // Service returns the name of the destination service for this callReq.
-func (f lazyCallReq) Service() string {
+func (f lazyCallReq) Service() []byte {
 	l := f.Payload[_serviceLenIndex]
-	return string(f.Payload[_serviceNameIndex : _serviceNameIndex+l])
+	return f.Payload[_serviceNameIndex : _serviceNameIndex+l]
 }
 
 // Method returns the name of the method being called. It panics if called for
 // a non-callReq frame.
-func (f lazyCallReq) Method() string {
+func (f lazyCallReq) Method() []byte {
 	return f.method
 }
 

--- a/relay_messages_benchmark_test.go
+++ b/relay_messages_benchmark_test.go
@@ -30,7 +30,7 @@ func BenchmarkCallReqFrame(b *testing.B) {
 	cr := reqHasAll.req()
 	f := cr.Frame
 
-	var service, caller, method string
+	var service, caller, method []byte
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -206,7 +206,7 @@ func TestLazyCallReqRejectsOtherFrames(t *testing.T) {
 func TestLazyCallReqService(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
 		cr := crt.req()
-		assert.Equal(t, "bankmoji", cr.Service(), "Service name mismatch")
+		assert.Equal(t, "bankmoji", string(cr.Service()), "Service name mismatch")
 	})
 }
 
@@ -214,9 +214,9 @@ func TestLazyCallReqCaller(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
 		cr := crt.req()
 		if crt&reqHasHeaders == 0 {
-			assert.Equal(t, "", cr.Caller(), "Unexpected caller name.")
+			assert.Equal(t, []byte(nil), cr.Caller(), "Unexpected caller name.")
 		} else {
-			assert.Equal(t, "fake-caller", cr.Caller(), "Caller name mismatch")
+			assert.Equal(t, "fake-caller", string(cr.Caller()), "Caller name mismatch")
 		}
 	})
 }
@@ -224,7 +224,7 @@ func TestLazyCallReqCaller(t *testing.T) {
 func TestLazyCallReqMethod(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
 		cr := crt.req()
-		assert.Equal(t, "moneys", cr.Method(), "Method name mismatch")
+		assert.Equal(t, "moneys", string(cr.Method()), "Method name mismatch")
 	})
 }
 

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -72,16 +72,16 @@ type FakeCallFrame struct {
 }
 
 // Service returns the service name field.
-func (f FakeCallFrame) Service() string {
-	return f.ServiceF
+func (f FakeCallFrame) Service() []byte {
+	return []byte(f.ServiceF)
 }
 
 // Method returns the method field.
-func (f FakeCallFrame) Method() string {
-	return f.MethodF
+func (f FakeCallFrame) Method() []byte {
+	return []byte(f.MethodF)
 }
 
 // Caller returns the caller field.
-func (f FakeCallFrame) Caller() string {
-	return f.CallerF
+func (f FakeCallFrame) Caller() []byte {
+	return []byte(f.CallerF)
 }

--- a/testutils/relay_stub.go
+++ b/testutils/relay_stub.go
@@ -49,7 +49,7 @@ func (rh *SimpleRelayHosts) Get(frame relay.CallFrame) string {
 	rh.RLock()
 	defer rh.RUnlock()
 
-	available, ok := rh.peers[frame.Service()]
+	available, ok := rh.peers[string(frame.Service())]
 	if !ok || len(available) == 0 {
 		return ""
 	}


### PR DESCRIPTION
We should avoid converting from `[]byte` to `string` since Go optimizes map lookups which do `map[string(bs)]` to avoid conversions.

This makes `BenchmarkCallReqFrame` much faster, from:
```
BenchmarkCallReqFrame-8 10000000               216 ns/op              48 B/op          5 allocs/op
```

to:
```
BenchmarkCallReqFrame-8 20000000                75.4 ns/op             0 B/op          0 allocs/op
```