### PR TITLE
relay: Allow relay.Hosts to return an error selecting peers

### DIFF
--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -32,14 +32,14 @@ type fixedHosts struct {
 	pickI atomic.Int32
 }
 
-func (fh *fixedHosts) Get(call relay.CallFrame) relay.Peer {
+func (fh *fixedHosts) Get(call relay.CallFrame) (relay.Peer, error) {
 	peers := fh.hosts[string(call.Service())]
 	if len(peers) == 0 {
-		return relay.Peer{}
+		return relay.Peer{}, nil
 	}
 
 	pickI := int(fh.pickI.Inc()-1) % len(peers)
-	return relay.Peer{HostPort: peers[pickI]}
+	return relay.Peer{HostPort: peers[pickI]}, nil
 }
 
 type realRelay struct {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -35,7 +35,9 @@ type CallFrame interface {
 // relaying.
 type Hosts interface {
 	// Get returns the peer to forward the given call to.
-	Get(CallFrame) Peer
+	// If a SystemError is returned, the error is forwarded. Otherwise
+	// a Declined error is returned to the caller.
+	Get(CallFrame) (Peer, error)
 }
 
 // CallStats is a reporter for per-request stats.

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -142,6 +142,11 @@ func (ts *TestServer) Relay() *tchannel.Channel {
 	return nil
 }
 
+// RelayHosts returns the stub RelayHosts for mapping service names to peers.
+func (ts *TestServer) RelayHosts() *SimpleRelayHosts {
+	return ts.relayHosts
+}
+
 // HostPort returns the host:port for clients to connect to. Note that this may
 // not be the same as the host:port of the server channel.
 func (ts *TestServer) HostPort() string {


### PR DESCRIPTION
This gives the caller more control over the error, and also allows for
more error types. E.g., use Declined for peer not found, but Busy for
rate limiting errors.