### PR TITLE
Fix assertion that warmup succeeded

### DIFF
--- a/relay_benchmark_test.go
+++ b/relay_benchmark_test.go
@@ -188,7 +188,7 @@ func BenchmarkRelayNoLatencies(b *testing.B) {
 		benchmark.WithTimeout(10*time.Second),
 	)
 	defer client.Close()
-	require.NoError(b, err, client.Warmup(), "client.Warmup failed")
+	require.NoError(b, client.Warmup(), "client.Warmup failed")
 
 	b.ResetTimer()
 	started := time.Now()


### PR DESCRIPTION
In the preamble to this benchmark, we need to successfully warm up each
TCP client. However, this assertion is testing an error created earlier;
fix it so that the benchmark doesn't proceed if we fail warmup.