### PR TITLE
Fix use-after-release bug in the relay, add tests to catch frame pooling issues

### DIFF
--- a/benchmark/frame_templates.go
+++ b/benchmark/frame_templates.go
@@ -114,6 +114,7 @@ func getRawCallFrames(timeout time.Duration, svcName string, reqSize int) frames
 		if err != nil {
 			panic(err)
 		}
+		defer relay.Close()
 
 		args := &raw.Args{
 			Arg2: getRequestBytes(reqSize),

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 751995ad9810ebf66707d6db7b75134a59e6350eb2ad7d21fa8b497fdd5337a4
-updated: 2016-06-02T17:21:34.641634433-07:00
+hash: 9950186274c3f039a7a65ea45573abacfca42050b0f40215c956ddfe7cd7f823
+updated: 2016-06-22T14:30:54.982533777-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 39a09ac5e49481d39dd1bcb6757ffe182e3df20a
+  version: 0e9fed1e12ed066865e46c6903782b2ef95f4650
   subpackages:
   - lib/go/thrift
 - name: github.com/bmizerany/perks
@@ -23,6 +23,8 @@ imports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/prashantv/protectmem
+  version: dda468c7a8a992f1642b31604d732590921a30e5
 - name: github.com/samuel/go-thrift
   version: e9042807f4f5bf47563df6992d3ea0857313e2be
   subpackages:
@@ -32,7 +34,7 @@ imports:
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 8d64eb7173c7753d6419fd4a9caf057398611364
+  version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
   - mock
@@ -40,7 +42,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: golang.org/x/net
-  version: c4c3ea71919de159c9e246d7be66deb7f0a39a58
+  version: bc3663df0ac92f928d419e31e0d2af22e683a5a2
   subpackages:
   - context
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,3 +43,4 @@ import:
   subpackages:
   - quantile
 - package: github.com/uber-go/atomic
+- package: github.com/prashantv/protectmem

--- a/relay.go
+++ b/relay.go
@@ -348,9 +348,13 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	}
 	originalID := f.Header.ID
 	f.Header.ID = item.remapID
+
+	// Once we call Receive on the frame, we lose ownership of the frame.
+	finished := finishesCall(f)
+
 	item.destination.Receive(f, frameType)
 
-	if finishesCall(f) {
+	if finished {
 		r.finishRelayItem(items, originalID)
 	}
 	return nil

--- a/relay_test.go
+++ b/relay_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package tchannel_test
 
 import (
@@ -10,6 +30,7 @@ import (
 
 	. "github.com/uber/tchannel-go"
 
+	"github.com/uber/tchannel-go/benchmark"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/relay"
 	"github.com/uber/tchannel-go/testutils"
@@ -294,5 +315,33 @@ func TestTimeoutCallsThenClose(t *testing.T) {
 
 		// Wait for all the callers to end
 		callers.Wait()
+	})
+}
+
+// TestRelayStress makes many concurrent calls and ensures that
+// we don't try to reuse any frames once they've been released.
+func TestRelayConcurrentCalls(t *testing.T) {
+	pool := NewProtectMemFramePool()
+	opts := testutils.NewOpts().SetRelayOnly().SetFramePool(pool)
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		server := benchmark.NewServer(
+			benchmark.WithNoLibrary(),
+			benchmark.WithServiceName("s1"),
+		)
+		defer server.Close()
+		ts.RelayHosts().Add("s1", server.HostPort())
+
+		client := benchmark.NewClient([]string{ts.HostPort()},
+			benchmark.WithNoDurations(),
+			benchmark.WithNoLibrary(),
+			benchmark.WithNumClients(20),
+			benchmark.WithServiceName("s1"),
+			benchmark.WithTimeout(time.Minute),
+		)
+		defer client.Close()
+		require.NoError(t, client.Warmup(), "Client warmup failed")
+
+		_, err := client.RawCall(1000)
+		assert.NoError(t, err, "RawCalls failed")
 	})
 }

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -84,7 +84,7 @@ func NewTestServer(t testing.TB, opts *ChannelOpts) *TestServer {
 
 	ts.NewServer(opts)
 	if opts == nil || !opts.DisableRelay {
-		ts.addRelay(opts.LogVerification)
+		ts.addRelay(opts)
 	}
 
 	return ts
@@ -210,18 +210,16 @@ func (ts *TestServer) NewServer(opts *ChannelOpts) *tchannel.Channel {
 
 // addRelay adds a relay in front of the test server, altering public methods as
 // necessary to route traffic through the relay.
-func (ts *TestServer) addRelay(logOpts LogVerification) {
+func (ts *TestServer) addRelay(parentOpts *ChannelOpts) {
 	ts.relayHosts = NewSimpleRelayHosts(map[string][]string{
 		ts.Server().ServiceName(): []string{ts.Server().PeerInfo().HostPort},
 	})
-	opts := &ChannelOpts{
-		ServiceName: "relay",
-		ChannelOptions: tchannel.ChannelOptions{
-			RelayHosts: ts.relayHosts,
-			RelayStats: ts.relayStats,
-		},
-		LogVerification: logOpts,
-	}
+
+	opts := parentOpts.Copy()
+	opts.ServiceName = "relay"
+	opts.ChannelOptions.RelayHosts = ts.relayHosts
+	opts.RelayStats = ts.relayStats
+
 	ts.addChannel(newServer, opts)
 	ts.relayIdx = len(ts.channels) - 1
 }


### PR DESCRIPTION
Similar to #420 

After debugging the previous issue, I wanted to ensure we don't have more bugs like this in future, so I created the `ProtectMemFramePool` which will use the [protectmem package](http://godoc.org/github.com/prashantv/protectmem) to ensure that frames aren't touched once they're released.

Once we added a test that used the `ProtectMemFramePool` we got the following crash that pinpoints the exact issue:
```
unexpected fault address 0x40f7032
fatal error: fault
[signal 0xa code=0x2 addr=0x40f7032 pc=0xb8484]

goroutine 424 [running]:
runtime.throw(0x631d70, 0x5)
        /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:547 +0x90 fp=0xc8201c3c38 sp=0xc8201c3c20
runtime.sigpanic()
        /usr/local/Cellar/go/1.6.2/libexec/src/runtime/sigpanic_unix.go:21 +0x1e4 fp=0xc8201c3c88 sp=0xc8201c3c38
github.com/uber/tchannel-go.finishesCall(0x40f7000, 0x40f7000)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/relay_messages.go:162 +0x14 fp=0xc8201c3c90 sp=0xc8201c3c88
github.com/uber/tchannel-go.(*Relayer).handleNonCallReq(0xc820238d80, 0x40f7000, 0x0, 0x0)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/relay.go:353 +0x1f7 fp=0xc8201c3d90 sp=0xc8201c3c90
github.com/uber/tchannel-go.(*Relayer).Relay(0xc820238d80, 0x40f7000, 0x0, 0x0)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/relay.go:193 +0x59 fp=0xc8201c3e20 sp=0xc8201c3d90
github.com/uber/tchannel-go.(*Connection).handleFrameRelay(0xc820448a80, 0x40f7000, 0xc820030100)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/connection.go:760 +0x5c fp=0xc8201c3ef0 sp=0xc8201c3e20
github.com/uber/tchannel-go.(*Connection).readFrames(0xc820448a80, 0x46)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/connection.go:749 +0x326 fp=0xc8201c3f90 sp=0xc8201c3ef0
```

This points out relay.go:353 calling finishesRelay which is the exact location of the bug.
