### PR TITLE
Add CallOptions() to IncomingCall for proxying

### DIFF
--- a/calloptions.go
+++ b/calloptions.go
@@ -50,6 +50,10 @@ type CallOptions struct {
 	// RoutingDelegate identifies a service capable of routing a request to its
 	// intended recipient.
 	RoutingDelegate string
+
+	// callerName can only be used when forwarding a request. It can only be set internally,
+	// e.g. by calling (*InboundCall).CallOptions() when forwarding a request
+	callerName string
 }
 
 var defaultCallOptions = &CallOptions{}
@@ -69,6 +73,9 @@ func (c *CallOptions) overrideHeaders(headers transportHeaders) {
 	}
 	if c.RoutingDelegate != "" {
 		headers[RoutingDelegate] = c.RoutingDelegate
+	}
+	if c.callerName != "" {
+		headers[CallerName] = c.callerName
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -59,6 +59,11 @@ type IncomingCall interface {
 	// If the caller is an ephemeral peer, then the HostPort cannot be used to make new
 	// connections to the caller.
 	RemotePeer() PeerInfo
+
+	// CallOptions returns the call options set for the incoming call. It can be useful
+	// if you are forwarding a request and wish to retain the CallerName(), which is not
+	// possible to set manually.
+	CallOptions() *CallOptions
 }
 
 func getTChannelParams(ctx context.Context) *tchannelCtxParams {

--- a/inbound.go
+++ b/inbound.go
@@ -261,6 +261,16 @@ func (call *InboundCall) RemotePeer() PeerInfo {
 	return call.conn.RemotePeerInfo()
 }
 
+// CallOptions returns a CallOptions struct suitable for forwarding a request.
+func (call *InboundCall) CallOptions() *CallOptions {
+	return &CallOptions{
+		callerName:      call.CallerName(),
+		Format:          call.Format(),
+		ShardKey:        call.ShardKey(),
+		RoutingDelegate: call.RoutingDelegate(),
+	}
+}
+
 // Reads the entire method name (arg1) from the request stream.
 func (call *InboundCall) readMethod() error {
 	var arg1 []byte

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -106,39 +106,35 @@ func TestInboundConnection_CallOptions(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	WithVerifiedServer(t, nil, func(serverCh *Channel, serverHostPort string) {
-		testutils.RegisterFunc(serverCh, "test", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+	testutils.WithTestServer(t, nil, func(server *testutils.TestServer) {
+		server.RegisterFunc("test", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 			assert.Equal(t, "client", CurrentCall(ctx).CallerName(), "Expected caller name to be passed through")
 			return &raw.Res{}, nil
 		})
 
-		backendName := serverCh.PeerInfo().ServiceName
+		backendName := server.ServiceName()
 
-		proxyCh, err := testutils.NewServerChannel(&testutils.ChannelOpts{ServiceName: "proxy"})
-		require.NoError(t, err, "Proxy channel creation failed")
+		proxyCh := server.NewServer(&testutils.ChannelOpts{ServiceName: "proxy"})
 		defer proxyCh.Close()
 
 		subCh := proxyCh.GetSubChannel(backendName)
 		subCh.SetHandler(HandlerFunc(func(ctx context.Context, inbound *InboundCall) {
-			outbound, err := proxyCh.BeginCall(ctx, serverHostPort, backendName, inbound.MethodString(), inbound.CallOptions())
+			outbound, err := proxyCh.BeginCall(ctx, server.HostPort(), backendName, inbound.MethodString(), inbound.CallOptions())
 			require.NoError(t, err, "Create outbound call failed")
-
-			require.NoError(t, NewArgWriter(outbound.Arg2Writer()).Write([]byte("hi")), "Write arg2 failed")
-			require.NoError(t, NewArgWriter(outbound.Arg3Writer()).Write([]byte("body")), "Write arg3 failed")
-			var arg2, arg3 []byte
-			require.NoError(t, NewArgReader(outbound.Response().Arg2Reader()).Read(&arg2), "Read arg2 failed")
-			require.NoError(t, NewArgReader(outbound.Response().Arg3Reader()).Read(&arg3), "Read arg3 failed")
-			require.NoError(t, NewArgWriter(inbound.Response().Arg2Writer()).Write(arg2), "Write arg2 failed")
-			require.NoError(t, NewArgWriter(inbound.Response().Arg3Writer()).Write(arg3), "Write arg3 failed")
+			arg2, arg3, _, err := raw.WriteArgs(outbound, []byte("hello"), []byte("world"))
+			require.NoError(t, err, "Write outbound call failed")
+			require.NoError(t, raw.WriteResponse(inbound.Response(), &raw.Res{
+				Arg2: arg2,
+				Arg3: arg3,
+			}), "Write response failed")
 		}))
 
-		clientCh, err := NewChannel("client", nil)
-		require.NoError(t, err, "Create client channel failed")
+		clientCh := server.NewClient(&testutils.ChannelOpts{
+			ServiceName: "client",
+		})
 		defer clientCh.Close()
 
-		clientCh.Peers().Add(proxyCh.PeerInfo().HostPort)
-
-		_, _, _, err = raw.Call(ctx, clientCh, proxyCh.PeerInfo().HostPort, backendName, "test", nil, nil)
+		_, _, _, err := raw.Call(ctx, clientCh, proxyCh.PeerInfo().HostPort, backendName, "test", nil, nil)
 		require.NoError(t, err, "Call through proxy failed")
 	})
 }

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -64,6 +64,14 @@ func (f *FakeIncomingCall) RemotePeer() tchannel.PeerInfo {
 	return f.RemotePeerF
 }
 
+// CallOptions returns the incoming call options suitable for proxying a request.
+func (f *FakeIncomingCall) CallOptions() *tchannel.CallOptions {
+	return &tchannel.CallOptions{
+		ShardKey:        f.ShardKey(),
+		RoutingDelegate: f.RoutingDelegate(),
+	}
+}
+
 // NewIncomingCall creates an incoming call for tests.
 func NewIncomingCall(callerName string) tchannel.IncomingCall {
 	return &FakeIncomingCall{CallerNameF: callerName}


### PR DESCRIPTION
This lets you proxy an incoming request to another node and set the
callerName to that of the original request.