### PR TITLE
Add a Zone field to Peer

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -69,7 +69,11 @@ type Peer struct {
 	// HostPort of the peer that was selected.
 	HostPort string
 
-	// Assignment allows the peer selection to specify a group that this
-	// Peer belongs to, which may be useful when reporting stats.
-	Assignment string
+	// Pool allows the peer selection to specify a pool that this Peer belongs
+	// to, which may be useful when reporting stats.
+	Pool string
+
+	// Zone allows the peer selection to specify the zone that this Peer belongs
+	// to, which is also useful for stats.
+	Zone string
 }

--- a/testutils/relay_stub.go
+++ b/testutils/relay_stub.go
@@ -74,17 +74,18 @@ func (rh *SimpleRelayHosts) Get(frame relay.CallFrame) (relay.Peer, error) {
 
 // Add adds a host:port for a routing key.
 func (rh *SimpleRelayHosts) Add(service, hostPort string) {
-	rh.AddAssignment(service, hostPort, "")
+	rh.AddPeer(service, hostPort, "", "")
 }
 
-// AddAssignment adds a host:port with an assignment for a routing key.
-func (rh *SimpleRelayHosts) AddAssignment(service, hostPort, assignment string) {
+// AddPeer adds a host:port with all the associated Peer information.
+func (rh *SimpleRelayHosts) AddPeer(service, hostPort, pool, zone string) {
 	rh.Lock()
 	defer rh.Unlock()
 
 	rh.peers[service] = append(rh.peers[service], relay.Peer{
-		HostPort:   hostPort,
-		Assignment: assignment,
+		HostPort: hostPort,
+		Pool:     pool,
+		Zone:     zone,
 	})
 }
 

--- a/testutils/relay_stub_test.go
+++ b/testutils/relay_stub_test.go
@@ -76,10 +76,10 @@ func TestSimpleRelayHosts(t *testing.T) {
 
 func TestSimpleRelayHostsPeer(t *testing.T) {
 	hosts := NewSimpleRelayHosts(nil)
-	hosts.AddAssignment("svc", "1.1.1.1:1", "a1")
+	hosts.AddPeer("svc", "1.1.1.1:1", "a1", "sjc1")
 	peer, err := hosts.Get(FakeCallFrame{ServiceF: "svc"})
 	require.NoError(t, err, "Get failed")
-	assert.Equal(t, relay.Peer{HostPort: "1.1.1.1:1", Assignment: "a1"}, peer, "Unexpected peer")
+	assert.Equal(t, relay.Peer{HostPort: "1.1.1.1:1", Pool: "a1", Zone: "sjc1"}, peer, "Unexpected peer")
 }
 
 func TestSimpleRelayHostsPeerError(t *testing.T) {


### PR DESCRIPTION
To integrate with TC, we need more information available on the Peer
struct. Along the way, remove the word "Assignment" - it's too similar
to terms used in the rest of our architecture.