### PR TITLE
relay: Send ephemeral host:port on outbound relay connections

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -346,7 +346,11 @@ func (c *Connection) sendInit(ctx context.Context) error {
 	initMsgID := c.NextMessageID()
 	req := initReq{initMessage{id: initMsgID}}
 	req.Version = CurrentProtocolVersion
+
 	req.initParams = c.getInitParams()
+	if params := getTChannelParams(ctx); params != nil && params.hideListeningOnOutbound {
+		req.initParams[InitParamHostPort] = ephemeralHostPort
+	}
 
 	if !c.pendingExchangeMethodAdd() {
 		// Connection is closed, no need to do anything.

--- a/connection_test.go
+++ b/connection_test.go
@@ -162,16 +162,6 @@ func TestRemotePeer(t *testing.T) {
 			name:   "ephemeral client",
 			remote: func(ts *testutils.TestServer) *Channel { return ts.NewClient(nil) },
 			expectedFn: func(state *RuntimeState, ts *testutils.TestServer) PeerInfo {
-				if ts.HasRelay() {
-					// The server should see a call from the relay. Connections from relays
-					// to the receiving service shouldn't be ephemeral.
-					relayInfo := ts.Relay().PeerInfo()
-					return PeerInfo{
-						HostPort:    relayInfo.HostPort,
-						IsEphemeral: false,
-						ProcessName: relayInfo.ProcessName,
-					}
-				}
 				return PeerInfo{
 					HostPort:    state.RootPeers[ts.HostPort()].OutboundConnections[0].LocalHostPort,
 					IsEphemeral: true,
@@ -183,15 +173,6 @@ func TestRemotePeer(t *testing.T) {
 			name:   "listening server",
 			remote: func(ts *testutils.TestServer) *Channel { return ts.NewServer(nil) },
 			expectedFn: func(state *RuntimeState, ts *testutils.TestServer) PeerInfo {
-				if ts.HasRelay() {
-					// Same as above.
-					relayInfo := ts.Relay().PeerInfo()
-					return PeerInfo{
-						HostPort:    relayInfo.HostPort,
-						IsEphemeral: false,
-						ProcessName: relayInfo.ProcessName,
-					}
-				}
 				return PeerInfo{
 					HostPort:    state.LocalPeer.HostPort,
 					IsEphemeral: false,
@@ -205,7 +186,7 @@ func TestRemotePeer(t *testing.T) {
 	defer cancel()
 
 	for _, tt := range tests {
-		opts := testutils.NewOpts().SetServiceName("fake-service")
+		opts := testutils.NewOpts().SetServiceName("fake-service").NoRelay()
 		testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 			remote := tt.remote(ts)
 			defer remote.Close()

--- a/context.go
+++ b/context.go
@@ -36,11 +36,12 @@ const (
 )
 
 type tchannelCtxParams struct {
-	span           *Span
-	call           IncomingCall
-	options        *CallOptions
-	retryOptions   *RetryOptions
-	connectTimeout time.Duration
+	span                    *Span
+	call                    IncomingCall
+	options                 *CallOptions
+	retryOptions            *RetryOptions
+	connectTimeout          time.Duration
+	hideListeningOnOutbound bool
 }
 
 // IncomingCall exposes properties for incoming calls through the context.

--- a/context_builder.go
+++ b/context_builder.go
@@ -47,6 +47,10 @@ type ContextBuilder struct {
 	// ConnectTimeout is the timeout for creating a TChannel connection.
 	ConnectTimeout time.Duration
 
+	// hideListeningOnOutbound disables sending the listening server's host:port
+	// when creating new outgoing connections.
+	hideListeningOnOutbound bool
+
 	// ParentContext to build the new context from. If empty, context.Background() is used.
 	// The new (child) context inherits a number of properties from the parent context:
 	//   - the tracing Span, unless replaced via SetExternalSpan()
@@ -127,6 +131,13 @@ func (cb *ContextBuilder) SetRoutingDelegate(rd string) *ContextBuilder {
 // timeout only applies to creating a new connection.
 func (cb *ContextBuilder) SetConnectTimeout(d time.Duration) *ContextBuilder {
 	cb.ConnectTimeout = d
+	return cb
+}
+
+// HideListeningOnOutbound hides the host:port when creating new outbound
+// connections.
+func (cb *ContextBuilder) HideListeningOnOutbound() *ContextBuilder {
+	cb.hideListeningOnOutbound = true
 	return cb
 }
 
@@ -227,11 +238,12 @@ func (cb *ContextBuilder) Build() (ContextWithHeaders, context.CancelFunc) {
 	}
 
 	params := &tchannelCtxParams{
-		options:        cb.CallOptions,
-		span:           span,
-		call:           cb.incomingCall,
-		retryOptions:   cb.RetryOptions,
-		connectTimeout: cb.ConnectTimeout,
+		options:                 cb.CallOptions,
+		span:                    span,
+		call:                    cb.incomingCall,
+		retryOptions:            cb.RetryOptions,
+		connectTimeout:          cb.ConnectTimeout,
+		hideListeningOnOutbound: cb.hideListeningOnOutbound,
 	}
 
 	parent := cb.ParentContext

--- a/relay.go
+++ b/relay.go
@@ -275,7 +275,7 @@ func (r *Relayer) getDestination(f lazyCallReq, cs relay.CallStats) (*Connection
 	peer := r.peers.GetOrAdd(selectedPeer.HostPort)
 
 	// TODO: Should connections use the call timeout? Or a separate timeout?
-	remoteConn, err := peer.getConnectionTimeout(f.TTL())
+	remoteConn, err := peer.getConnectionRelay(f.TTL())
 	if err != nil {
 		r.logger.WithFields(
 			ErrField(err),

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -23,7 +23,10 @@ package tchannel
 // This file contains functions for tests to access internal tchannel state.
 // Since it has a _test.go suffix, it is only compiled with tests in this package.
 
-import "net"
+import (
+	"net"
+	"time"
+)
 
 // MexChannelBufferSize is the size of the message exchange channel buffer.
 const MexChannelBufferSize = mexChannelBufferSize
@@ -39,6 +42,11 @@ func (p *Peer) SetOnUpdate(f func(*Peer)) {
 	p.Lock()
 	p.onUpdate = f
 	p.Unlock()
+}
+
+// GetConnectionRelay exports the getConnectionRelay for tests.
+func (p *Peer) GetConnectionRelay(timeout time.Duration) (*Connection, error) {
+	return p.getConnectionRelay(timeout)
 }
 
 // SetRandomSeed seeds all the random number generators in the channel so that


### PR DESCRIPTION
Currently, we send the listening host:port, which causes some services
to assume that we're Hyperbahn, and send traffic intended for Hyperbahn
over the connection we opened.

In general, destination services do not need to know our host:port so
hide it in all outbound connections from the relay.