### PR TITLE
relay: Always set Zone/Pool on stats, even on errors

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -259,6 +259,7 @@ func (r *Relayer) getDestination(f lazyCallReq, cs relay.CallStats) (*Connection
 
 	// Get the destination
 	selectedPeer, err := r.hosts.Get(f)
+	cs.SetPeer(selectedPeer)
 	if err == nil && selectedPeer.HostPort == "" {
 		err = errInvalidPeerForGroup(f.Service())
 	}
@@ -271,7 +272,6 @@ func (r *Relayer) getDestination(f lazyCallReq, cs relay.CallStats) (*Connection
 		return nil, false, nil
 	}
 
-	cs.SetPeer(selectedPeer)
 	peer := r.peers.GetOrAdd(selectedPeer.HostPort)
 
 	// TODO: Should connections use the call timeout? Or a separate timeout?

--- a/relay/fakes.go
+++ b/relay/fakes.go
@@ -82,13 +82,6 @@ func (m *MockCallStats) SetPeer(peer Peer) CallStats {
 	return m
 }
 
-// ExpectNoPeer ensures that no call to SetPeer is made.
-func (m *MockCallStats) ExpectNoPeer() CallStats {
-	m.verifyPeer = true
-	m.peer = nil
-	return m
-}
-
 // End halts timer and metric collection for the RPC.
 func (m *MockCallStats) End() {
 	m.ended++


### PR DESCRIPTION
It's possible that a pool was selected, but there were no peers
in that pool, in which case the errors should be attributed to
the specified pool.

