### PR TITLE
Fix flaky test TestPeerRemoveClosedConnection

### DIFF
--- a/peer_test.go
+++ b/peer_test.go
@@ -172,8 +172,11 @@ func TestPeerRemoveClosedConnection(t *testing.T) {
 
 		c1, err := p.Connect(ctx)
 		require.NoError(t, err, "Failed to connect")
+		require.NoError(t, err, c1.Ping(ctx))
+
 		c2, err := p.Connect(ctx)
 		require.NoError(t, err, "Failed to connect")
+		require.NoError(t, err, c2.Ping(ctx))
 
 		require.NoError(t, c1.Close(), "Failed to close first connection")
 		_, outConns := p.NumConnections()

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -26,6 +26,8 @@ package tchannel
 import (
 	"net"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // MexChannelBufferSize is the size of the message exchange channel buffer.
@@ -57,6 +59,11 @@ func (ch *Channel) SetRandomSeed(seed int64) {
 	for _, sc := range ch.subChannels.subchannels {
 		sc.peers.peerHeap.rng.Seed(seed + int64(len(sc.peers.peersByHostPort)))
 	}
+}
+
+// Ping sends a ping on the specific connection.
+func (c *Connection) Ping(ctx context.Context) error {
+	return c.ping(ctx)
 }
 
 // OutboundConnection returns the underlying connection for an outbound call.


### PR DESCRIPTION
Test was failing with:
```
    <autogenerated>:10: Unexpected log: [Warn]: Failed to add connection
    to peer [{service testService} {process testService-52687} {hostPort
    127.0.0.1:52687} {connID 418} {localAddr 127.0.0.1:52687}
    {remoteAddr 127.0.0.1:54541} {remoteHostPort 127.0.0.1:54541}
    {direction inbound} {error tchannel error ErrCodeNetwork: connection
    is in an invalid state}]
```

The sequence of events was:
p1 creates a connection c1 to p2
once connection is successful, p1 closes c1

On the remote side, p2 has responded to c1 and is about to
mark it active, but the network connection gets closed before
it has been added to the peer's list. When p2 resumes adding
the connection to the peer list, it's now closed due to the underlying
network connection being closed.

We can fix this issue by issuing a ping, which will ensure that the
remote side has processed the connection and has added it to the
peer list before closing the connection.

Verified by setting RunCount = 1000 and ensuring all builds pass:
https://travis-ci.org/uber/tchannel-go/builds/143140663

Fixes #432 