### PR TITLE
Make the relay.CallStats interface non-fluent

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -65,10 +65,12 @@ type ChannelOptions struct {
 	// The logger to use for this channel
 	Logger Logger
 
-	// The host:port selection implementation to use for relaying.
+	// The host:port selection implementation to use for relaying. This is an
+	// unstable API - breaking changes are likely.
 	RelayHosts relay.Hosts
 
-	// The stats implementation to use for relaying.
+	// The stats implementation to use for relaying. This is an unstable API -
+	// breaking changes are likely.
 	RelayStats relay.Stats
 
 	// The reporter to use for reporting stats for this channel.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -19,6 +19,9 @@
 // THE SOFTWARE.
 
 // Package relay contains relaying interfaces for external use.
+//
+// These interfaces are currently unstable, and aren't covered by the API
+// backwards-compatibility guarantee.
 package relay
 
 // CallFrame is an interface that abstracts access to the call req frame.
@@ -49,12 +52,12 @@ type Hosts interface {
 type CallStats interface {
 	// SetPeer is called once a peer has been selected for this call.
 	// Note: This may not be called if a call fails before peer selection.
-	SetPeer(Peer) CallStats
+	SetPeer(Peer)
 
 	// The call succeeded (possibly after retrying).
-	Succeeded() CallStats
+	Succeeded()
 	// The RPC failed.
-	Failed(reason string) CallStats
+	Failed(reason string)
 	// End stats collection for this RPC. Will be called exactly once.
 	End()
 }


### PR DESCRIPTION
For tests, it's convenient for `relay.CallStats` to have a fluent API.
However, this results in needless allocations along the forwarding path
in production.

Instead, make the call stats interface non-fluent, and wrap it in a
fluent API during tests.