### PR TITLE
Fix flaky test TestResponseClosedBeforeRequest

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -306,7 +306,12 @@ func TestResponseClosedBeforeRequest(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				assert.NoError(t, writeFlushBytes(arg3Writer, []byte{1}), "Write failed")
 			}
-			assert.NoError(t, writeFlushBytes(arg3Writer, []byte{streamRequestClose}), "Write failed")
+
+			// Ignore the error of writeFlushBytes here since once we flush, the
+			// remote side could receive and close the response before we've created
+			// a new fragment (see fragmentingWriter.Flush). This could result
+			// in the Flush returning a "mex is already shutdown" error.
+			writeFlushBytes(arg3Writer, []byte{streamRequestClose})
 
 			// Wait until our reader gets the EOF.
 			<-responseClosed


### PR DESCRIPTION
On the writer side, the last flush of the "closeRequest" byte would fail
with "mex has been shutdown". The following sequence of events was
causing the issue:

 - Flush calls flushFragment, which sends a frame with the "closeRequest" byte
 - The remote side receives the byte, and closes the response
 - Sender receives the last response frame, and shuts down the mex
 - Original goroutine in Flush calls newFragment (since previous
   fragment) has been sent
 - newFragment fails since the mex has been shutdown

Since this is a valid sequence of events, we ignore the error from
Flush when writing out the closeRequest byte. This issue is unlikely
to happen in production, since the network calls to send and receive
frames should take longer than scheduling the goroutine running Flush.


cc @akshayjshah
Fixes #431 