### PR TITLE
relay: Move fakes into relaytest package

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -32,7 +32,7 @@ import (
 
 	. "github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
-	"github.com/uber/tchannel-go/relay"
+	"github.com/uber/tchannel-go/relay/relaytest"
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/testutils/testreader"
 
@@ -283,7 +283,7 @@ func TestBadRequest(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Equal(t, ErrCodeBadRequest, GetSystemErrorCode(err))
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "Noone").Failed("bad-request").End()
 		ts.AssertRelayStats(calls)
 	})
@@ -297,7 +297,7 @@ func TestNoTimeout(t *testing.T) {
 		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), "svc", "Echo", []byte("Headers"), []byte("Body"))
 		assert.Equal(t, ErrTimeoutRequired, err)
 
-		ts.AssertRelayStats(relay.NewMockStats())
+		ts.AssertRelayStats(relaytest.NewMockStats())
 	})
 }
 
@@ -309,7 +309,7 @@ func TestNoServiceNaming(t *testing.T) {
 		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), "", "Echo", []byte("Headers"), []byte("Body"))
 		assert.Equal(t, ErrNoServiceName, err)
 
-		ts.AssertRelayStats(relay.NewMockStats())
+		ts.AssertRelayStats(relaytest.NewMockStats())
 	})
 }
 
@@ -329,7 +329,7 @@ func TestServerBusy(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Equal(t, ErrCodeBusy, GetSystemErrorCode(err), "err: %v", err)
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "busy").Failed("busy").End()
 		ts.AssertRelayStats(calls)
 	})
@@ -354,7 +354,7 @@ func TestUnexpectedHandlerError(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Equal(t, ErrCodeUnexpected, GetSystemErrorCode(err), "err: %v", err)
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "nope").Failed("unexpected-error").End()
 		ts.AssertRelayStats(calls)
 	})
@@ -393,7 +393,7 @@ func TestTimeout(t *testing.T) {
 			t.Errorf("Server did not receive call, may need higher timeout")
 		}
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "block").Failed("timeout").End()
 		ts.AssertRelayStats(calls)
 	})
@@ -420,7 +420,7 @@ func TestLargeTimeout(t *testing.T) {
 		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), ts.ServiceName(), "echo", testArg2, testArg3)
 		assert.NoError(t, err, "Call failed")
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "echo").Succeeded().End()
 		ts.AssertRelayStats(calls)
 	})
@@ -448,7 +448,7 @@ func TestFragmentation(t *testing.T) {
 		assert.Equal(t, arg2, respArg2)
 		assert.Equal(t, arg3, respArg3)
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "echo").Succeeded().End()
 		ts.AssertRelayStats(calls)
 	})
@@ -488,7 +488,7 @@ func TestFragmentationSlowReader(t *testing.T) {
 			t.Errorf("Handler not called, context timeout may be too low")
 		}
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "echo").Failed("timeout").End()
 		ts.AssertRelayStats(calls)
 	})
@@ -532,7 +532,7 @@ func TestWriteArg3AfterTimeout(t *testing.T) {
 		case <-timedOut:
 		}
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "call").Failed("timeout").Succeeded().End()
 		ts.AssertRelayStats(calls)
 	})
@@ -566,7 +566,7 @@ func TestWriteErrorAfterTimeout(t *testing.T) {
 			t.Errorf("Handler not called, timeout may be too low")
 		}
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "call").Failed("timeout").End()
 		ts.AssertRelayStats(calls)
 	})
@@ -621,7 +621,7 @@ func TestReadTimeout(t *testing.T) {
 
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		sn := ts.ServiceName()
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 
 		for i := 0; i < 10; i++ {
 			ctx, cancel := NewContext(time.Second)
@@ -659,7 +659,7 @@ func TestWriteTimeout(t *testing.T) {
 		_, err = io.Copy(writer, testreader.Looper([]byte{1}))
 		assert.Equal(t, ErrTimeout, err, "Write should fail with timeout")
 
-		ts.AssertRelayStats(relay.NewMockStats())
+		ts.AssertRelayStats(relaytest.NewMockStats())
 	})
 }
 
@@ -676,7 +676,7 @@ func TestGracefulClose(t *testing.T) {
 		assert.NoError(t, ch2.Ping(ctx, ts.HostPort()), "Ping from ch2 -> ch1 failed")
 
 		// No stats for pings.
-		ts.AssertRelayStats(relay.NewMockStats())
+		ts.AssertRelayStats(relaytest.NewMockStats())
 	})
 }
 

--- a/relay/noop.go
+++ b/relay/noop.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package relay
+
+type noopStats struct{}
+
+// NewNoopStats returns a no-op implementation of Stats.
+func NewNoopStats() Stats {
+	return noopStats{}
+}
+
+func (n noopStats) Begin(_ CallFrame) CallStats {
+	return noopCallStats{}
+}
+
+type noopCallStats struct{}
+
+func (n noopCallStats) Succeeded()      {}
+func (n noopCallStats) Failed(_ string) {}
+func (n noopCallStats) SetPeer(_ Peer)  {}
+func (n noopCallStats) End()            {}

--- a/relay/relaytest/fakes.go
+++ b/relay/relaytest/fakes.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package relay
+package relaytest
 
 import (
 	"fmt"
@@ -27,25 +27,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/relay"
 )
-
-type noopStats struct{}
-
-// NewNoopStats returns a no-op implementation of Stats.
-func NewNoopStats() Stats {
-	return noopStats{}
-}
-
-func (n noopStats) Begin(_ CallFrame) CallStats {
-	return noopCallStats{}
-}
-
-type noopCallStats struct{}
-
-func (n noopCallStats) Succeeded()      {}
-func (n noopCallStats) Failed(_ string) {}
-func (n noopCallStats) SetPeer(_ Peer)  {}
-func (n noopCallStats) End()            {}
 
 // MockCallStats is a testing spy for the CallStats interface.
 type MockCallStats struct {
@@ -55,7 +38,7 @@ type MockCallStats struct {
 	succeeded  int
 	failedMsgs []string
 	ended      int
-	peer       *Peer
+	peer       *relay.Peer
 	wg         *sync.WaitGroup
 
 	// By default, we don't verify peers, as we get unique host:ports and
@@ -74,7 +57,7 @@ func (m *MockCallStats) Failed(reason string) {
 }
 
 // SetPeer sets the peer for the current call.
-func (m *MockCallStats) SetPeer(peer Peer) {
+func (m *MockCallStats) SetPeer(peer relay.Peer) {
 	m.verifyPeer = true
 	m.peer = &peer
 }
@@ -103,7 +86,7 @@ func (f *FluentMockCallStats) Failed(reason string) *FluentMockCallStats {
 }
 
 // SetPeer sets the peer for the current call.
-func (f *FluentMockCallStats) SetPeer(peer Peer) *FluentMockCallStats {
+func (f *FluentMockCallStats) SetPeer(peer relay.Peer) *FluentMockCallStats {
 	f.MockCallStats.SetPeer(peer)
 	return f
 }
@@ -123,7 +106,7 @@ func NewMockStats() *MockStats {
 }
 
 // Begin starts collecting metrics for an RPC.
-func (m *MockStats) Begin(f CallFrame) CallStats {
+func (m *MockStats) Begin(f relay.CallFrame) relay.CallStats {
 	return m.Add(string(f.Caller()), string(f.Service()), string(f.Method())).MockCallStats
 }
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber/tchannel-go/benchmark"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/relay"
+	"github.com/uber/tchannel-go/relay/relaytest"
 	"github.com/uber/tchannel-go/testutils"
 
 	"github.com/stretchr/testify/assert"
@@ -79,7 +80,7 @@ func TestRelay(t *testing.T) {
 			assert.Equal(t, tt.body, string(arg3), "Body was mangled during relay.")
 		}
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		peer := relay.Peer{HostPort: ts.Server().PeerInfo().HostPort}
 		for _ = range tests {
 			calls.Add("client", "test", "echo").SetPeer(peer).Succeeded().End()
@@ -124,7 +125,7 @@ func TestRelayConnectionCloseDrainsRelayItems(t *testing.T) {
 
 		testutils.AssertEcho(t, s2, ts.HostPort(), "s1")
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add("s2", "s1", "echo").Succeeded().End()
 		ts.AssertRelayStats(calls)
 	})
@@ -215,7 +216,7 @@ func TestRelayErrorsOnGetPeer(t *testing.T) {
 
 			assert.Equal(t, tt.wantErr, err, "%v: unexpected error", tt.desc)
 
-			calls := relay.NewMockStats()
+			calls := relaytest.NewMockStats()
 			calls.Add(client.PeerInfo().ServiceName, "svc", "echo").
 				SetPeer(tt.statsPeer).
 				Failed(tt.statsKey).End()
@@ -242,7 +243,7 @@ func TestErrorFrameEndsRelay(t *testing.T) {
 
 		assert.Equal(t, ErrCodeBadRequest, se.Code(), "Expected BadRequest error")
 
-		calls := relay.NewMockStats()
+		calls := relaytest.NewMockStats()
 		calls.Add(client.PeerInfo().ServiceName, "svc", "echo").Failed("bad-request").End()
 		ts.AssertRelayStats(calls)
 	})

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"
-	"github.com/uber/tchannel-go/relay"
+	"github.com/uber/tchannel-go/relay/relaytest"
 	"github.com/uber/tchannel-go/testutils/goroutines"
 
 	"github.com/davecgh/go-spew/spew"
@@ -55,7 +55,7 @@ type TestServer struct {
 	relayHosts *SimpleRelayHosts
 
 	// relayStats is the channel's relaying stats (if any).
-	relayStats *relay.MockStats
+	relayStats *relaytest.MockStats
 
 	// channels is the list of channels created for this TestServer. The first
 	// element is always the initial server.
@@ -75,7 +75,7 @@ func NewTestServer(t testing.TB, opts *ChannelOpts) *TestServer {
 	ts := &TestServer{
 		TB:            t,
 		channelStates: make(map[*tchannel.Channel]*tchannel.RuntimeState),
-		relayStats:    relay.NewMockStats(),
+		relayStats:    relaytest.NewMockStats(),
 		introspectOpts: &tchannel.IntrospectionOptions{
 			IncludeExchanges:  true,
 			IncludeTombstones: true,
@@ -186,7 +186,7 @@ func (ts *TestServer) CloseAndVerify() {
 
 // AssertRelayStats checks that the relayed call graph matches expectations. If
 // there's no relay, AssertRelayStats is a no-op.
-func (ts *TestServer) AssertRelayStats(expected *relay.MockStats) {
+func (ts *TestServer) AssertRelayStats(expected *relaytest.MockStats) {
 	if !ts.HasRelay() {
 		return
 	}


### PR DESCRIPTION
The production tchannel-go package depends on the relay package, which
has a dependency on the testing package. We do not want production
binaries to depend on testing (this also brings in testing flags into
prod binaries), so move all fakes into a separate relaytest package.

This is a pure refactoring change with no logic changes.