### PR TITLE
Handle host:port mismatches between peer.Connect and remote peer

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -125,6 +125,7 @@ type ConnectionRuntimeState struct {
 	ConnectionState  string                  `json:"connectionState"`
 	LocalHostPort    string                  `json:"localHostPort"`
 	RemoteHostPort   string                  `json:"remoteHostPort"`
+	OutboundHostPort string                  `json:"outboundHostPort"`
 	IsEphemeral      bool                    `json:"isEphemeral"`
 	InboundExchange  ExchangeSetRuntimeState `json:"inboundExchange"`
 	OutboundExchange ExchangeSetRuntimeState `json:"outboundExchange"`
@@ -314,6 +315,7 @@ func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRunti
 		ConnectionState:  c.state.String(),
 		LocalHostPort:    c.conn.LocalAddr().String(),
 		RemoteHostPort:   c.conn.RemoteAddr().String(),
+		OutboundHostPort: c.outboundHP,
 		IsEphemeral:      c.remotePeerInfo.IsEphemeral,
 		InboundExchange:  c.inbound.IntrospectState(opts),
 		OutboundExchange: c.outbound.IntrospectState(opts),


### PR DESCRIPTION
Currently, if we conect to peer as "a:1" and it sends us an init req
header with host:port set to "b:2", we only add it under the peer "b:2".

After this change, the connection will be added under both peers so that
future calls to "a:1" will be able to use the same connection.

When this happens, we log the host:port mismatch under a debug log.
In future, we may want to emit metrics when this happens.

This information (outboundHostPort vs remoteHostPort) is also exposed
via introspection.

Fixes #450

Note: tests will fail till #451 is landed