### PR TITLE
Allow introspection calls on the "tchannel" service

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -477,6 +477,7 @@ func (ch *Channel) registerInternal() {
 		{"_gometa_runtime", handleInternalRuntime},
 	}
 
+	tchanSC := ch.GetSubChannel("tchannel")
 	for _, ep := range endpoints {
 		// We need ep in our closure.
 		ep := ep
@@ -494,5 +495,6 @@ func (ch *Channel) registerInternal() {
 			NewArgWriter(call.Response().Arg3Writer()).WriteJSON(ep.handler(arg3))
 		}
 		ch.Register(HandlerFunc(handler), ep.name)
+		tchanSC.Register(HandlerFunc(handler), ep.name)
 	}
 }

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -55,6 +55,16 @@ func TestIntrospection(t *testing.T) {
 			"includeGoStacks": true,
 		}, &resp)
 		require.NoError(t, err, "Call _gometa_runtime failed")
+
+		if !ts.HasRelay() {
+			// Try making the call on the "tchannel" service which is where meta handlers
+			// are registered. This will only work when we call it directly as the relay
+			// will not forward the tchannel service.
+			err = json.CallPeer(ctx, peer, "tchannel", "_gometa_runtime", map[string]interface{}{
+				"includeGoStacks": true,
+			}, &resp)
+			require.NoError(t, err, "Call _gometa_runtime failed")
+		}
 	})
 }
 


### PR DESCRIPTION
We register meta endpoints on the "tchannel" service:
https://github.com/uber/tchannel/blob/master/docs/meta.md

We should register the Go-specific meta endpoints on the same
service name.

This is useful when trying to debug a service given only the host:port.
The introspection endpoints can be used to expose the service name
information.