### PR TITLE
relay: Support for handling unfragmented calls on the relay channel

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -73,6 +73,10 @@ type ChannelOptions struct {
 	// breaking changes are likely.
 	RelayStats relay.Stats
 
+	// The list of service names that should be handled locally by this channel.
+	// This is an unstable API - breaking changes are likely.
+	RelayLocalHandlers []string
+
 	// The reporter to use for reporting stats for this channel.
 	StatsReporter StatsReporter
 
@@ -144,6 +148,7 @@ type Channel struct {
 type channelConnectionCommon struct {
 	log             Logger
 	relayStats      relay.Stats
+	relayLocal      map[string]struct{}
 	statsReporter   StatsReporter
 	traceReporter   TraceReporter
 	subChannels     *subChannelMap
@@ -199,6 +204,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 				LogField{"service", serviceName},
 				LogField{"process", processName}),
 			relayStats:      relayStats,
+			relayLocal:      toStringSet(opts.RelayLocalHandlers),
 			statsReporter:   statsReporter,
 			subChannels:     &subChannelMap{},
 			timeNow:         timeNow,
@@ -712,4 +718,12 @@ func (ch *Channel) Close() {
 // RelayHosts returns the channel's relay hosts, if any.
 func (ch *Channel) RelayHosts() relay.Hosts {
 	return ch.relayHosts
+}
+
+func toStringSet(ss []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		set[s] = struct{}{}
+	}
+	return set
 }

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -156,6 +156,11 @@ func (f lazyCallReq) Span() Span {
 	return callReqSpan(f.Frame)
 }
 
+// HasMoreFragments returns whether the callReq has more fragments.
+func (f lazyCallReq) HasMoreFragments() bool {
+	return f.Payload[_flagsIndex]&hasMoreFragmentsFlag != 0
+}
+
 // finishesCall checks whether this frame is the last one we should expect for
 // this RPC req-res.
 func finishesCall(f *Frame) bool {

--- a/relay_test.go
+++ b/relay_test.go
@@ -395,7 +395,7 @@ func TestRelayHandleLocalCall(t *testing.T) {
 		testutils.RegisterEcho(s2, nil)
 
 		client := ts.NewClient(nil)
-		require.NoError(t, testutils.CallEcho(client, ts.HostPort(), "s2", nil), "CallEcho to relayed service failed")
+		testutils.AssertEcho(t, client, ts.HostPort(), "s2")
 
 		testutils.RegisterEcho(ts.Relay(), nil)
 		testutils.AssertEcho(t, client, ts.HostPort(), "relay")

--- a/relay_test.go
+++ b/relay_test.go
@@ -387,7 +387,7 @@ func TestRelayOutgoingConnectionsEphemeral(t *testing.T) {
 
 func TestRelayHandleLocalCall(t *testing.T) {
 	opts := testutils.NewOpts().SetRelayOnly().
-		SetRelayLocal([]string{"relay", "tchannel", "test"}).
+		SetRelayLocal("relay", "tchannel", "test").
 		// We make a call to "test" for an unknown method.
 		AddLogFilter("Couldn't find handler.", 1)
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
@@ -412,7 +412,7 @@ func TestRelayHandleLocalCall(t *testing.T) {
 
 func TestRelayHandleLargeLocalCall(t *testing.T) {
 	opts := testutils.NewOpts().SetRelayOnly().
-		SetRelayLocal([]string{"relay"}).
+		SetRelayLocal("relay").
 		AddLogFilter("Received fragmented callReq", 1).
 		// Expect 4 callReqContinues for 256 kb payload that we cannot relay.
 		AddLogFilter("Failed to relay frame.", 4)

--- a/relay_test.go
+++ b/relay_test.go
@@ -428,5 +428,11 @@ func TestRelayHandleLargeLocalCall(t *testing.T) {
 		if assert.Equal(t, ErrCodeBadRequest, GetSystemErrorCode(err), "Expected BadRequest for large call to relay") {
 			assert.Contains(t, err.Error(), "cannot receive fragmented calls")
 		}
+
+		// We may get an error before the call is finished flushing.
+		// Do a ping to ensure everything has been flushed.
+		ctx, cancel := NewContext(time.Second)
+		defer cancel()
+		require.NoError(t, client.Ping(ctx, ts.HostPort()), "Ping failed")
 	})
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -384,3 +384,49 @@ func TestRelayOutgoingConnectionsEphemeral(t *testing.T) {
 		require.NoError(t, testutils.CallEcho(ts.Server(), ts.HostPort(), "s2", nil), "CallEcho failed")
 	})
 }
+
+func TestRelayHandleLocalCall(t *testing.T) {
+	opts := testutils.NewOpts().SetRelayOnly().
+		SetRelayLocal([]string{"relay", "tchannel", "test"}).
+		// We make a call to "test" for an unknown method.
+		AddLogFilter("Couldn't find handler.", 1)
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		s2 := ts.NewServer(serviceNameOpts("s2"))
+		testutils.RegisterEcho(s2, nil)
+
+		client := ts.NewClient(nil)
+		require.NoError(t, testutils.CallEcho(client, ts.HostPort(), "s2", nil), "CallEcho to relayed service failed")
+
+		testutils.RegisterEcho(ts.Relay(), nil)
+		testutils.AssertEcho(t, client, ts.HostPort(), "relay")
+
+		// Sould get a bad request for "test" since the channel does not handle it.
+		err := testutils.CallEcho(client, ts.HostPort(), "test", nil)
+		assert.Equal(t, ErrCodeBadRequest, GetSystemErrorCode(err), "Expected BadRequest for test")
+
+		// But an unknown service causes declined
+		err = testutils.CallEcho(client, ts.HostPort(), "unknown", nil)
+		assert.Equal(t, ErrCodeDeclined, GetSystemErrorCode(err), "Expected Declined for unknown")
+	})
+}
+
+func TestRelayHandleLargeLocalCall(t *testing.T) {
+	opts := testutils.NewOpts().SetRelayOnly().
+		SetRelayLocal([]string{"relay"}).
+		AddLogFilter("Received fragmented callReq", 1).
+		// Expect 4 callReqContinues for 256 kb payload that we cannot relay.
+		AddLogFilter("Failed to relay frame.", 4)
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		client := ts.NewClient(nil)
+		testutils.RegisterEcho(ts.Relay(), nil)
+
+		// This large call should fail with a bad request.
+		err := testutils.CallEcho(client, ts.HostPort(), "relay", &raw.Args{
+			Arg2: testutils.RandBytes(128 * 1024),
+			Arg3: testutils.RandBytes(128 * 1024),
+		})
+		if assert.Equal(t, ErrCodeBadRequest, GetSystemErrorCode(err), "Expected BadRequest for large call to relay") {
+			assert.Contains(t, err.Error(), "cannot receive fragmented calls")
+		}
+	})
+}

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -193,6 +193,13 @@ func (o *ChannelOpts) SetRelayHosts(rh relay.Hosts) *ChannelOpts {
 	return o
 }
 
+// SetRelayLocal sets the channel's relay local handlers for service names
+// that should be handled by the relay channel itself.
+func (o *ChannelOpts) SetRelayLocal(relayLocal []string) *ChannelOpts {
+	o.ChannelOptions.RelayLocalHandlers = relayLocal
+	return o
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -195,7 +195,7 @@ func (o *ChannelOpts) SetRelayHosts(rh relay.Hosts) *ChannelOpts {
 
 // SetRelayLocal sets the channel's relay local handlers for service names
 // that should be handled by the relay channel itself.
-func (o *ChannelOpts) SetRelayLocal(relayLocal []string) *ChannelOpts {
+func (o *ChannelOpts) SetRelayLocal(relayLocal ...string) *ChannelOpts {
 	o.ChannelOptions.RelayLocalHandlers = relayLocal
 	return o
 }


### PR DESCRIPTION
This allows users to register methods directly on the relay channel
itself rather than forwarding methods. This is required for methods like
the hyperbahn advertise which need information about the caller's
host:port as speciifed in the connection to the relay.

Since this is only intended to be used for hyperbahn's ad and for
TChannel introspection requests, both of which are extremely small, we
are keeping the implementation simple and only handling calls that are
not fragmented. This requires no extra tracking or references between
the relay item and mex.

Fragmented calls are rejected with a BadRequest error code.