### PR TITLE
Add crossdock tests for tracing context propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@ GO_VERSION := $(shell go version | awk '{ print $$3 }')
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
 LINTABLE_MINOR_VERSIONS := 5 6
 FMTABLE_MINOR_VERSIONS := 6
+XDOCKABLE_MINOR_VERSIONS := 6
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif
 ifneq ($(filter $(FMTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT_FMT := true
+endif
+ifneq ($(filter $(XDOCKABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
+SHOULD_XDOCK := true
 endif
 
 PATH := $(GOPATH)/bin:$(PATH)
@@ -34,6 +38,8 @@ export GOPATH := $(VENDOR_PATH):$(GOPATH)
 # Cross language test args
 TEST_HOST=127.0.0.1
 TEST_PORT=0
+
+-include crossdock/rules.mk
 
 all: test examples
 

--- a/crossdock/.gitignore
+++ b/crossdock/.gitignore
@@ -1,0 +1,1 @@
+/crossdock

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang
+ADD crossdock /
+CMD ["/crossdock"]
+EXPOSE 8080-8082

--- a/crossdock/behavior/trace/api.go
+++ b/crossdock/behavior/trace/api.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package trace
+
+// Request instructs the server to call another server recursively if Downstream != nil,
+// and return the results of the downstream call as well as the current tracing span it
+// observes in its Context.
+type Request struct {
+	ServerRole string      `json:"serverRole"`
+	Downstream *Downstream `json:"downstream,omitempty"`
+}
+
+// Downstream describes which downstream service to call recursively.
+type Downstream struct {
+	ServiceName string      `json:"serviceName"`
+	ServerRole  string      `json:"serverRole"`
+	Encoding    string      `json:"encoding"`
+	HostPort    string      `json:"hostPort"`
+	Downstream  *Downstream `json:"downstream,omitempty"`
+}
+
+// Response contains the span observed by the server and nested downstream response.
+type Response struct {
+	Span       *ObservedSpan `json:"span,omitempty"`
+	Downstream *Response     `json:"downstream,omitempty"`
+}
+
+// ObservedSpan describes the tracing span observed by the server
+type ObservedSpan struct {
+	TraceID string `json:"traceId"`
+	Sampled bool   `json:"sampled"`
+	Baggage string `json:"baggage"`
+}

--- a/crossdock/behavior/trace/behavior.go
+++ b/crossdock/behavior/trace/behavior.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package trace
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/uber/tchannel-go"
+
+	"github.com/crossdock/crossdock-go"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/utils"
+	"golang.org/x/net/context"
+)
+
+// Different parameter keys and values used by the system
+const (
+	BehaviorName = "trace"
+)
+
+// Behavior is an implementation of "trace behavior", that verifies
+// that a tracing context and baggage are properly propagated through
+// two level of servers.
+type Behavior struct {
+	ServerPort    string
+	Tracer        opentracing.Tracer
+	ServiceToHost func(string) string
+	ch            *tchannel.Channel
+	thriftCall    DownstreamCall
+	jsonCall      DownstreamCall
+}
+
+// DownstreamCall is an encoding-agnostic abstraction of calling a downstream service.
+type DownstreamCall func(ctx context.Context, target *Downstream) (*Response, error)
+
+// Register function adds JSON and Thrift handlers to the server channel ch
+func (b *Behavior) Register(ch *tchannel.Channel) {
+	b.registerThrift(ch)
+	b.registerJSON(ch)
+}
+
+// Run executes the trace behavior
+func (b *Behavior) Run(t crossdock.T) {
+	logParams(t)
+	sampled, err := strconv.ParseBool(t.Param(sampledParam))
+	if err != nil {
+		t.Fatalf("Malformed param %s: %s", sampledParam, err)
+	}
+	baggage := randomBaggage()
+
+	level1 := &Request{
+		ServerRole: RoleS1,
+	}
+	server1 := t.Param(server1NameParam)
+
+	level2 := &Downstream{
+		ServiceName: t.Param(server2NameParam),
+		ServerRole:  RoleS2,
+		HostPort: fmt.Sprintf("%s:%s",
+			b.serviceToHost(t.Param(server2NameParam)),
+			b.ServerPort,
+		),
+		Encoding: t.Param(server2EncodingParam),
+	}
+	level1.Downstream = level2
+
+	level3 := &Downstream{
+		ServiceName: t.Param(server3NameParam),
+		ServerRole:  RoleS3,
+		HostPort: fmt.Sprintf("%s:%s",
+			b.serviceToHost(t.Param(server3NameParam)),
+			b.ServerPort,
+		),
+		Encoding: t.Param(server3EncodingParam),
+	}
+	level2.Downstream = level3
+
+	resp, err := b.startTrace(t, level1, sampled, baggage)
+	if err != nil {
+		t.Errorf("Failed to startTrace in S1(%s): %s", server1, err.Error())
+		return
+	}
+
+	log.Printf("Response: span=%+v, downstream=%+v", resp.Span, resp.Downstream)
+	traceID := resp.Span.TraceID
+
+	require := crossdock.Require(t)
+	require.NotEmpty(traceID, "Trace ID should not be empty in S1(%s)", server1)
+
+	if validateTrace(t, level1.Downstream, resp, server1, 1, traceID, sampled, baggage) {
+		t.Successf("trace checks out")
+		log.Println("PASS")
+	} else {
+		log.Println("FAIL")
+	}
+}
+
+func logParams(t crossdock.T) {
+	keys := []string{
+		sampledParam,
+		server1NameParam,
+		server2NameParam,
+		server2EncodingParam,
+		server3NameParam,
+		server3EncodingParam,
+	}
+	out := "Execute"
+	for _, key := range keys {
+		out = fmt.Sprintf("%s %s=%s", out, key, t.Param(key))
+	}
+	log.Println(out)
+}
+
+func (b *Behavior) serviceToHost(service string) string {
+	if b.ServiceToHost != nil {
+		return b.ServiceToHost(service)
+	}
+	return service
+}
+
+func (b *Behavior) startTrace(t crossdock.T, req *Request, sampled bool, baggage string) (*Response, error) {
+	span := b.Tracer.StartSpan(req.ServerRole)
+	if sampled {
+		ext.SamplingPriority.Set(span, 1)
+	}
+	span.SetBaggageItem(BaggageKey, baggage)
+	defer span.Finish()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	return b.prepareResponse(t, ctx, req.Downstream)
+}
+
+func validateTrace(
+	t crossdock.T,
+	target *Downstream,
+	resp *Response,
+	service string,
+	level int,
+	traceID string,
+	sampled bool,
+	baggage string,
+) bool {
+	service = fmt.Sprintf("S%d(%s)", level, service)
+	checks := crossdock.Assert(t)
+	s := true
+	s = checks.Equal(traceID, resp.Span.TraceID, "Trace ID must match in %s", service) && s
+	s = checks.Equal(baggage, resp.Span.Baggage, "Baggage must match in %s", service) && s
+	s = checks.Equal(sampled, resp.Span.Sampled, "Sampled must match in %s", service) && s
+	if target != nil {
+		if resp.Downstream == nil {
+			t.Errorf("Should have downstream in S%d(%s)", level, service)
+			s = false
+		} else {
+			s = validateTrace(t, target.Downstream, resp.Downstream,
+				target.HostPort, level+1, traceID, sampled, baggage) && s
+		}
+	} else if resp.Downstream != nil {
+		s = checks.Nil(resp.Downstream, "Should not have downstream in %s", service) && s
+	}
+	return s
+}
+
+func randomBaggage() string {
+	r := utils.NewRand(time.Now().UnixNano())
+	n := uint64(r.Int63())
+	return fmt.Sprintf("%x", n)
+}
+
+func (b *Behavior) prepareResponse(t crossdock.T, ctx context.Context, reqDwn *Downstream) (*Response, error) {
+	log.Printf("prepareResponse: reqDwn=%v", reqDwn)
+	logSpan(ctx)
+	observedSpan, err := observeSpan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &Response{
+		Span: observedSpan,
+	}
+
+	if reqDwn != nil {
+		downstreamResp, err := b.callDownstream(ctx, reqDwn)
+		if err != nil {
+			if t != nil {
+				t.Errorf("Error when calling downstream %+v: %s", reqDwn, err)
+			}
+			return nil, err
+		}
+		resp.Downstream = downstreamResp
+	}
+
+	return resp, nil
+}
+
+func (b *Behavior) callDownstream(ctx context.Context, downstream *Downstream) (*Response, error) {
+	switch tchannel.Format(downstream.Encoding) {
+	case tchannel.JSON:
+		return b.jsonCall(ctx, downstream)
+	case tchannel.Thrift:
+		return b.thriftCall(ctx, downstream)
+	default:
+		return nil, errUnsupportedEncoding
+	}
+}
+
+func observeSpan(ctx context.Context) (*ObservedSpan, error) {
+	span := opentracing.SpanFromContext(ctx)
+	if span == nil {
+		return nil, errNoSpanObserved
+	}
+	sc, ok := span.Context().(jaeger.SpanContext)
+	if !ok {
+		return &ObservedSpan{}, nil
+	}
+	observedSpan := &ObservedSpan{
+		TraceID: fmt.Sprintf("%x", sc.TraceID()),
+		Sampled: sc.IsSampled(),
+		Baggage: span.BaggageItem(BaggageKey),
+	}
+	log.Printf("Observed span %+v", observedSpan)
+	return observedSpan, nil
+}
+
+func logSpan(ctx context.Context) {
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		log.Printf("Span %s", span)
+	}
+}

--- a/crossdock/behavior/trace/behavior.go
+++ b/crossdock/behavior/trace/behavior.go
@@ -167,7 +167,7 @@ func validateTrace(
 	baggage string,
 ) bool {
 	service = fmt.Sprintf("S%d(%s)", level, service)
-	checks := crossdock.Assert(t)
+	checks := crossdock.Checks(t)
 	s := true
 	s = checks.Equal(traceID, resp.Span.TraceID, "Trace ID must match in %s", service) && s
 	s = checks.Equal(baggage, resp.Span.Baggage, "Baggage must match in %s", service) && s

--- a/crossdock/behavior/trace/behavior.go
+++ b/crossdock/behavior/trace/behavior.go
@@ -22,11 +22,11 @@ package trace
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"time"
 
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/crossdock/log"
 
 	"github.com/crossdock/crossdock-go"
 	"github.com/opentracing/opentracing-go"

--- a/crossdock/behavior/trace/behavior_test.go
+++ b/crossdock/behavior/trace/behavior_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package trace
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/crossdock/client"
+	"github.com/uber/tchannel-go/crossdock/common"
+	"github.com/uber/tchannel-go/crossdock/server"
+
+	"github.com/crossdock/crossdock-go"
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-client-go"
+	"golang.org/x/net/context"
+)
+
+func TestTraceBehavior(t *testing.T) {
+	tracer, tCloser := jaeger.NewTracer(
+		"crossdock",
+		jaeger.NewConstSampler(false),
+		jaeger.NewNullReporter())
+	defer tCloser.Close()
+
+	s := &server.Server{
+		HostPort: "127.0.0.1:0",
+		Tracer:   tracer,
+	}
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	behavior := &Behavior{
+		ServerPort:    s.Port(),
+		Tracer:        tracer,
+		ServiceToHost: func(server string) string { return "localhost" },
+	}
+	behavior.Register(s.Ch)
+
+	c := &client.Client{
+		ClientHostPort: "127.0.0.1:0",
+		Behaviors: crossdock.Behaviors{
+			BehaviorName: behavior.Run,
+		},
+	}
+	err = c.Start()
+	require.NoError(t, err)
+	defer c.Close()
+
+	crossdock.Wait(t, c.URL(), 10)
+
+	behaviors := []struct {
+		name string
+		axes map[string][]string
+	}{
+		{
+			name: BehaviorName,
+			axes: map[string][]string{
+				server1NameParam:     {common.DefaultServiceName},
+				sampledParam:         {"true", "false"},
+				server2NameParam:     {common.DefaultServiceName},
+				server2EncodingParam: {string(tchannel.JSON), string(tchannel.Thrift)},
+				server3NameParam:     {common.DefaultServiceName},
+				server3EncodingParam: {string(tchannel.JSON), string(tchannel.Thrift)},
+			},
+		},
+	}
+
+	for _, bb := range behaviors {
+		for _, entry := range crossdock.Combinations(bb.axes) {
+			entryArgs := url.Values{}
+			for k, v := range entry {
+				entryArgs.Set(k, v)
+			}
+			// test via real HTTP call
+			crossdock.Call(t, c.URL(), bb.name, entryArgs)
+		}
+	}
+}
+
+func TestNoSpanObserved(t *testing.T) {
+	_, err := observeSpan(context.Background())
+	assert.Equal(t, errNoSpanObserved, err)
+}
+
+func TestPrepareResponseErrors(t *testing.T) {
+	b := &Behavior{}
+	ctx := context.Background()
+	_, err := b.prepareResponse(nil, ctx, nil)
+	assert.Equal(t, errNoSpanObserved, err)
+
+	span := opentracing.GlobalTracer().StartSpan("test")
+	ctx = opentracing.ContextWithSpan(ctx, span)
+	res, err := b.prepareResponse(nil, ctx, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "", res.Span.TraceID)
+
+	_, err = b.prepareResponse(nil, ctx, &Downstream{
+		Encoding: "invalid",
+	})
+	assert.Equal(t, errUnsupportedEncoding, err)
+}
+
+func TestTraceBehaviorRunErrors(t *testing.T) {
+	b := &Behavior{}
+	entries := crossdock.Run(crossdock.Params{
+		sampledParam: "not a boolean",
+	}, b.Run)
+	assertFailedEntry(t, "Malformed param sampled", entries)
+
+	params := crossdock.Params{
+		server1NameParam:     common.DefaultServiceName,
+		sampledParam:         "true",
+		server2NameParam:     common.DefaultServiceName,
+		server2EncodingParam: string(tchannel.JSON),
+		server3NameParam:     common.DefaultServiceName,
+		server3EncodingParam: string(tchannel.JSON),
+	}
+
+	b.Tracer = opentracing.GlobalTracer()
+	b.jsonCall = func(ctx context.Context, downstream *Downstream) (*Response, error) {
+		return nil, fmt.Errorf("made-up bad response")
+	}
+	entries = crossdock.Run(params, b.Run)
+	assertFailedEntry(t, "Failed to startTrace", entries)
+
+	b.jsonCall = func(ctx context.Context, downstream *Downstream) (*Response, error) {
+		return &Response{
+			Span: &ObservedSpan{},
+		}, nil
+	}
+	entries = crossdock.Run(params, b.Run)
+	assertFailedEntry(t, "Trace ID should not be empty", entries)
+}
+
+func assertFailedEntry(t *testing.T, expected string, entries []crossdock.Entry) {
+	require.True(t, len(entries) > 0, "Must have some entries %+v", entries)
+	entry := entries[len(entries)-1]
+	require.EqualValues(t, "failed", entry["status"], "Entries: %v", entries)
+	require.NotEmpty(t, entry["output"], "Entries: %v", entries)
+	output := entry["output"].(string)
+	assert.True(t, strings.Contains(output, expected), "Output must contain %s: %s", expected, output)
+}

--- a/crossdock/behavior/trace/constants.go
+++ b/crossdock/behavior/trace/constants.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package trace
+
+import "errors"
+
+const (
+	// S1 instructions
+	sampledParam     = "sampled"
+	server1NameParam = "s1name"
+
+	// S1->S2 instructions
+	server2NameParam     = "s2name"
+	server2EncodingParam = "s2encoding"
+
+	// S2->S3 instructions
+	server3NameParam     = "s3name"
+	server3EncodingParam = "s3encoding"
+
+	// RoleS1 is the name of the role for server S1
+	RoleS1 = "S1"
+
+	// RoleS2 is the name of the role for server S2
+	RoleS2 = "S2"
+
+	// RoleS3 is the name of the role for server S3
+	RoleS3 = "S3"
+
+	// BaggageKey is the key used to pass baggage item
+	BaggageKey = "crossdock-baggage-key"
+)
+
+var (
+	errNoSpanObserved      = errors.New("no span found in Context")
+	errUnsupportedEncoding = errors.New("unsupported encoding for downstream call")
+)

--- a/crossdock/behavior/trace/json.go
+++ b/crossdock/behavior/trace/json.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package trace
+
+import (
+	"log"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/json"
+
+	"golang.org/x/net/context"
+)
+
+const jsonEndpoint = "trace"
+
+func (b *Behavior) registerJSON(ch *tchannel.Channel) {
+	handler := &jsonHandler{b: b, ch: ch}
+	json.Register(ch, json.Handlers{jsonEndpoint: handler.handleJSON}, handler.onError)
+	b.jsonCall = handler.callDownstream
+}
+
+type jsonHandler struct {
+	ch *tchannel.Channel
+	b  *Behavior
+}
+
+func (h *jsonHandler) callDownstream(ctx context.Context, target *Downstream) (*Response, error) {
+	req := &Request{
+		ServerRole: target.ServerRole,
+		Downstream: target.Downstream,
+	}
+	jctx := json.Wrap(ctx)
+	response := new(Response)
+	log.Printf("Calling JSON service %s (%s)", target.ServiceName, target.HostPort)
+	peer := h.ch.Peers().GetOrAdd(target.HostPort)
+	if err := json.CallPeer(jctx, peer, target.ServiceName, jsonEndpoint, req, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (h *jsonHandler) handleJSON(ctx json.Context, req *Request) (*Response, error) {
+	return h.b.prepareResponse(nil, ctx, req.Downstream)
+}
+
+func (h *jsonHandler) onError(ctx context.Context, err error) {
+	panic(err.Error())
+}

--- a/crossdock/behavior/trace/json.go
+++ b/crossdock/behavior/trace/json.go
@@ -21,9 +21,8 @@
 package trace
 
 import (
-	"log"
-
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/crossdock/log"
 	"github.com/uber/tchannel-go/json"
 
 	"golang.org/x/net/context"

--- a/crossdock/behavior/trace/thrift.go
+++ b/crossdock/behavior/trace/thrift.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package trace
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
+	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
+
+	"golang.org/x/net/context"
+)
+
+func (b *Behavior) registerThrift(ch *tchannel.Channel) {
+	handler := &thriftHandler{b: b, ch: ch}
+	server := thrift.NewServer(ch)
+	server.Register(gen.NewTChanSimpleServiceServer(handler))
+	b.thriftCall = handler.callDownstream
+}
+
+type thriftHandler struct {
+	ch *tchannel.Channel
+	b  *Behavior
+}
+
+func (h *thriftHandler) Call(ctx thrift.Context, arg *gen.Data) (*gen.Data, error) {
+	req, err := requestFromThrift(arg)
+	if err != nil {
+		return nil, err
+	}
+	res, err := h.b.prepareResponse(nil, ctx, req.Downstream)
+	if err != nil {
+		return nil, err
+	}
+	return responseToThrift(res)
+}
+
+func (h *thriftHandler) Simple(ctx thrift.Context) error {
+	panic("Simple not implemented")
+}
+
+func (h *thriftHandler) callDownstream(ctx context.Context, target *Downstream) (*Response, error) {
+	req := &Request{
+		ServerRole: target.ServerRole,
+		Downstream: target.Downstream,
+	}
+	opts := &thrift.ClientOptions{HostPort: target.HostPort}
+	thriftClient := thrift.NewClient(h.ch, target.ServiceName, opts)
+	serviceClient := gen.NewTChanSimpleServiceClient(thriftClient)
+	tReq, err := requestToThrift(req)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Calling Thrift service %s (%s)", target.ServiceName, target.HostPort)
+	tctx := thrift.Wrap(ctx)
+	res, err := serviceClient.Call(tctx, tReq)
+	if err != nil {
+		return nil, err
+	}
+	return responseFromThrift(res)
+}
+
+func requestFromThrift(req *gen.Data) (*Request, error) {
+	var r Request
+	if err := json.Unmarshal([]byte(req.S2), &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func requestToThrift(r *Request) (*gen.Data, error) {
+	jsonBytes, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	return &gen.Data{S2: string(jsonBytes)}, nil
+}
+
+func responseFromThrift(res *gen.Data) (*Response, error) {
+	var r Response
+	if err := json.Unmarshal([]byte(res.S2), &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func responseToThrift(r *Response) (*gen.Data, error) {
+	jsonBytes, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	return &gen.Data{S2: string(jsonBytes)}, nil
+}

--- a/crossdock/behavior/trace/thrift.go
+++ b/crossdock/behavior/trace/thrift.go
@@ -22,9 +22,9 @@ package trace
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/crossdock/log"
 	"github.com/uber/tchannel-go/thrift"
 	gen "github.com/uber/tchannel-go/thrift/gen-go/test"
 

--- a/crossdock/client/client.go
+++ b/crossdock/client/client.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/uber/tchannel-go/crossdock/common"
+
+	"github.com/crossdock/crossdock-go"
+)
+
+// Client is a controller for the tests
+type Client struct {
+	ClientHostPort string
+	ServerPort     string
+	listener       net.Listener
+	mux            *http.ServeMux
+	Behaviors      crossdock.Behaviors
+}
+
+// Start begins a Crossdock client in the background.
+func (c *Client) Start() error {
+	if err := c.listen(); err != nil {
+		return err
+	}
+	go func() {
+		http.Serve(c.listener, c.mux)
+	}()
+	return nil
+}
+
+// Listen initializes the server
+func (c *Client) listen() error {
+	c.setDefaultPort(&c.ClientHostPort, ":"+common.DefaultClientPortHTTP)
+	c.setDefaultPort(&c.ServerPort, common.DefaultServerPort)
+
+	c.mux = http.NewServeMux() // Using default mux creates problem in unit tests
+	c.mux.Handle("/", crossdock.Handler(c.Behaviors, true))
+
+	listener, err := net.Listen("tcp", c.ClientHostPort)
+	if err != nil {
+		return err
+	}
+	c.listener = listener
+	c.ClientHostPort = listener.Addr().String() // override in case it was ":0"
+	return nil
+}
+
+// Close stops the client
+func (c *Client) Close() error {
+	return c.listener.Close()
+}
+
+// URL returns a URL that the client can be accessed on
+func (c *Client) URL() string {
+	return fmt.Sprintf("http://%s/", c.ClientHostPort)
+}
+
+func (c *Client) setDefaultPort(port *string, defaultPort string) {
+	if *port == "" {
+		*port = defaultPort
+	}
+}

--- a/crossdock/client/client_test.go
+++ b/crossdock/client/client_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/crossdock/crossdock-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientErrors(t *testing.T) {
+	c := &Client{
+		ClientHostPort: "127.0.0.1:xxx",
+	}
+	assert.Error(t, c.Start())
+}
+
+func TestClientWithBehavior(t *testing.T) {
+	r := struct {
+		calledA bool
+		calledB bool
+	}{}
+	c := &Client{
+		ClientHostPort: "127.0.0.1:0",
+		Behaviors: crossdock.Behaviors{
+			"hello": func(t crossdock.T) {
+				if t.Param("param") == "a" {
+					t.Successf("good")
+					r.calledA = true
+				}
+				if t.Param("param") == "b" {
+					t.Skipf("not so good")
+					r.calledB = true
+				}
+			},
+		},
+	}
+	require.NoError(t, c.Start())
+	defer c.Close()
+	crossdock.Wait(t, c.URL(), 10)
+
+	axes := map[string][]string{
+		"param": {"a", "b"},
+	}
+	for _, entry := range crossdock.Combinations(axes) {
+		entryArgs := url.Values{}
+		for k, v := range entry {
+			entryArgs.Set(k, v)
+		}
+		// test via real HTTP call
+		crossdock.Call(t, c.URL(), "hello", entryArgs)
+	}
+	assert.True(t, r.calledA)
+	assert.True(t, r.calledB)
+}

--- a/crossdock/common/constants.go
+++ b/crossdock/common/constants.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+const (
+	// DefaultClientPortHTTP is the port where the client (controller) runs
+	DefaultClientPortHTTP = "8080"
+
+	// DefaultServerPort is the port of TChannel server
+	DefaultServerPort = "8081"
+
+	// DefaultServiceName is the service name used by TChannel server
+	DefaultServiceName = "go"
+)

--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+
+services:
+    crossdock:
+        image: crossdock/crossdock
+        links:
+            - go
+        environment:
+            - WAIT_FOR=go
+
+            - AXIS_CLIENT=go
+            - AXIS_S1NAME=go
+            - AXIS_SAMPLED=true,false
+            - AXIS_S2NAME=go
+            - AXIS_S2ENCODING=json,thrift
+            - AXIS_S3NAME=go
+            - AXIS_S3ENCODING=json,thrift
+
+            - BEHAVIOR_TRACE=client,s1name,sampled,s2name,s2encoding,s3name,s3encoding
+
+    go:
+        build: .
+        ports:
+            - "8080-8082"
+
+    python:
+        image: crossdock_python
+            - "8080-8082"

--- a/crossdock/log/logging.go
+++ b/crossdock/log/logging.go
@@ -18,58 +18,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package log
 
 import (
-	"io"
-
-	"github.com/uber/tchannel-go/crossdock/client"
-	"github.com/uber/tchannel-go/crossdock/log"
-	"github.com/uber/tchannel-go/crossdock/server"
-
-	"github.com/crossdock/crossdock-go"
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber/jaeger-client-go"
-	"github.com/uber/tchannel-go/crossdock/behavior/trace"
-	"github.com/uber/tchannel-go/crossdock/common"
+	stdlog "log"
 )
 
-func main() {
-	log.Enabled = true
+// Enabled controls logging
+var Enabled = false
 
-	tracer, tCloser := initTracer()
-	defer tCloser.Close()
-
-	server := &server.Server{Tracer: tracer}
-	if err := server.Start(); err != nil {
-		panic(err.Error())
+// Println is the equivalent of standard log.Println gated by Enabled flag
+func Println(msg string) {
+	if Enabled {
+		stdlog.Println(msg)
 	}
-	defer server.Close()
-
-	behavior := &trace.Behavior{
-		ServerPort: common.DefaultServerPort,
-		Tracer:     tracer,
-	}
-	behavior.Register(server.Ch)
-
-	client := &client.Client{
-		Behaviors: crossdock.Behaviors{
-			trace.BehaviorName: behavior.Run,
-		},
-	}
-
-	if err := client.Start(); err != nil {
-		panic(err.Error())
-	}
-	defer client.Close()
-
-	select {}
 }
 
-func initTracer() (opentracing.Tracer, io.Closer) {
-	t, c := jaeger.NewTracer(
-		"crossdock-go",
-		jaeger.NewConstSampler(false),
-		jaeger.NewLoggingReporter(jaeger.StdLogger))
-	return t, c
+// Printf is the equivalent of standard log.Printf gated by Enabled flag
+func Printf(format string, v ...interface{}) {
+	if Enabled {
+		stdlog.Printf(format, v...)
+	}
 }

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"io"
+
+	"github.com/uber/tchannel-go/crossdock/client"
+	"github.com/uber/tchannel-go/crossdock/server"
+
+	"github.com/crossdock/crossdock-go"
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/tchannel-go/crossdock/behavior/trace"
+	"github.com/uber/tchannel-go/crossdock/common"
+)
+
+func main() {
+	tracer, tCloser := initTracer()
+	defer tCloser.Close()
+
+	server := &server.Server{Tracer: tracer}
+	if err := server.Start(); err != nil {
+		panic(err.Error())
+	}
+	defer server.Close()
+
+	behavior := &trace.Behavior{
+		ServerPort: common.DefaultServerPort,
+		Tracer:     tracer,
+	}
+	behavior.Register(server.Ch)
+
+	client := &client.Client{
+		Behaviors: crossdock.Behaviors{
+			trace.BehaviorName: behavior.Run,
+		},
+	}
+
+	if err := client.Start(); err != nil {
+		panic(err.Error())
+	}
+	defer client.Close()
+
+	select {}
+}
+
+func initTracer() (opentracing.Tracer, io.Closer) {
+	t, c := jaeger.NewTracer(
+		"crossdock-go",
+		jaeger.NewConstSampler(false),
+		jaeger.NewLoggingReporter(jaeger.StdLogger))
+	return t, c
+}

--- a/crossdock/rules.mk
+++ b/crossdock/rules.mk
@@ -1,0 +1,52 @@
+XDOCK_YAML=crossdock/docker-compose.yml
+
+.PHONY: crossdock-linux-bin
+crossdock-linux-bin:
+	CGO_ENABLED=0 GOOS=linux time go build -a -installsuffix cgo -o crossdock/crossdock ./crossdock
+
+.PHONY: crossdock
+crossdock: crossdock-linux-bin
+	docker-compose -f $(XDOCK_YAML) kill go
+	docker-compose -f $(XDOCK_YAML) rm -f go
+	docker-compose -f $(XDOCK_YAML) build go
+	docker-compose -f $(XDOCK_YAML) run crossdock
+
+
+.PHONY: crossdock-fresh
+crossdock-fresh: crossdock-linux-bin
+	docker-compose -f $(XDOCK_YAML) kill
+	docker-compose -f $(XDOCK_YAML) rm --force
+	docker-compose -f $(XDOCK_YAML) pull
+	docker-compose -f $(XDOCK_YAML) build
+	docker-compose -f $(XDOCK_YAML) run crossdock
+
+.PHONY: crossdock-logs
+crossdock-logs:
+	docker-compose -f $(XDOCK_YAML) logs
+
+.PHONY: install_docker_ci
+install_docker_ci:
+ifdef SHOULD_XDOCK
+	@echo "Installing Docker $${DOCKER_VERSION:?'DOCKER_VERSION env not set'}"
+	apt-cache madison docker-engine
+	sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=$${DOCKER_VERSION}
+	docker version
+	@echo "Installing docker-compose $${DOCKER_COMPOSE_VERSION:?'DOCKER_COMPOSE_VERSION env not set'}"
+	sudo rm /usr/local/bin/docker-compose
+	curl -L https://github.com/docker/compose/releases/download/$${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+	chmod +x docker-compose
+	sudo mv docker-compose /usr/local/bin
+	docker-compose version
+endif
+
+.PHONY: crossdock_ci
+crossdock_ci:
+ifdef SHOULD_XDOCK
+	$(MAKE) crossdock
+endif
+
+.PHONY: crossdock_logs_ci
+crossdock_logs_ci:
+ifdef SHOULD_XDOCK
+	docker-compose -f $(XDOCK_YAML) logs
+endif

--- a/crossdock/server/server.go
+++ b/crossdock/server/server.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package server
+
+import (
+	"log"
+	"strings"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/crossdock/common"
+)
+
+// Server implements S2-S3 servers
+type Server struct {
+	HostPort string
+	Tracer   opentracing.Tracer
+	Ch       *tchannel.Channel
+}
+
+// Start starts the test server called by the Client and other upstream servers.
+func (s *Server) Start() error {
+	if s.HostPort == "" {
+		s.HostPort = ":" + common.DefaultServerPort
+	}
+	channelOpts := &tchannel.ChannelOptions{
+		Tracer: s.Tracer,
+	}
+	ch, err := tchannel.NewChannel(common.DefaultServiceName, channelOpts)
+	if err != nil {
+		return err
+	}
+
+	if err := ch.ListenAndServe(s.HostPort); err != nil {
+		return err
+	}
+	s.HostPort = ch.PeerInfo().HostPort // override in case it was ":0"
+	log.Printf("Started tchannel server at %s\n", s.HostPort)
+	s.Ch = ch
+	return nil
+}
+
+// Close stops the server
+func (s *Server) Close() {
+	s.Ch.Close()
+}
+
+// Port returns the actual port the server listens to
+func (s *Server) Port() string {
+	hostPortSplit := strings.Split(s.HostPort, ":")
+	port := hostPortSplit[len(hostPortSplit)-1]
+	return port
+}

--- a/crossdock/server/server.go
+++ b/crossdock/server/server.go
@@ -40,13 +40,13 @@
 package server
 
 import (
-	"log"
 	"strings"
 
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/crossdock/common"
+	"github.com/uber/tchannel-go/crossdock/log"
 )
 
 // Server implements S2-S3 servers

--- a/crossdock/server/server_test.go
+++ b/crossdock/server/server_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package server
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer(t *testing.T) {
+	tracer := mocktracer.New()
+
+	s := &Server{HostPort: "127.0.0.1:0", Tracer: tracer}
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	assert.Equal(t, tracer, s.Ch.Tracer())
+	port, err := strconv.Atoi(s.Port())
+	assert.NoError(t, err)
+	assert.True(t, port > 0)
+}
+
+func TestServerErrors(t *testing.T) {
+	s := &Server{HostPort: "127.0.0.1:xxx"}
+	err := s.Start()
+	require.Error(t, err)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -13,6 +13,11 @@ imports:
   version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
   subpackages:
   - statsd
+- name: github.com/crossdock/crossdock-go
+  version: 228792ab861c86f8900b2db0439577feef9ec9d8
+  subpackages:
+  - assert
+  - require
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -58,6 +63,7 @@ imports:
   version: b400c2eff1badec7022a8c8f5bea058b6315eed7
   subpackages:
   - context
+  - context/ctxhttp
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -46,3 +46,4 @@ import:
 - package: github.com/prashantv/protectmem
 - package: github.com/opentracing/opentracing-go
 - package: github.com/uber/jaeger-client-go
+- package: github.com/crossdock/crossdock-go


### PR DESCRIPTION
This change adds the logic to run tracing interop tests via [crossdock](http://github.com/crossdock/crossdock). At the moment there are no travis changes to publish docker images, I would like to add those as separate PRs once the corresponding Python changes are available. In the mean time I can test the interop by pushing the images manually.