### PR TITLE
mockhyperbahn: use tchannel relaying to implement in-memory forwarding

### DIFF
--- a/testutils/mockhyperbahn/advertise_table.go
+++ b/testutils/mockhyperbahn/advertise_table.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mockhyperbahn
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/relay"
+)
+
+type advertisedTable struct {
+	sync.RWMutex
+
+	serviceMapping map[string][]string
+}
+
+func newAdvertisedTable() *advertisedTable {
+	return &advertisedTable{serviceMapping: make(map[string][]string)}
+}
+
+func (t *advertisedTable) addPeer(svc, hostPort string) {
+	t.Lock()
+	defer t.Unlock()
+
+	hostPorts := t.serviceMapping[svc]
+
+	// If the host:port already exists, then we should skip it.
+	i := sort.SearchStrings(hostPorts, hostPort)
+	if i < len(hostPorts) && hostPorts[i] == hostPort {
+		return
+	}
+
+	hostPorts = append(hostPorts, hostPort)
+	sort.Strings(hostPorts)
+	t.serviceMapping[svc] = hostPorts
+}
+
+func (t *advertisedTable) Get(call relay.CallFrame) (relay.Peer, error) {
+	t.RLock()
+	defer t.RUnlock()
+
+	peers := t.serviceMapping[string(call.Service())]
+	if len(peers) == 0 {
+		return relay.Peer{}, tchannel.NewSystemError(tchannel.ErrCodeDeclined, fmt.Sprintf("unknown service name: %s", call.Service()))
+	}
+
+	return relay.Peer{
+		HostPort: peers[rand.Intn(len(peers))],
+	}, nil
+}

--- a/testutils/mockhyperbahn/advertise_table_test.go
+++ b/testutils/mockhyperbahn/advertise_table_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mockhyperbahn
+
+import (
+	"testing"
+
+	"github.com/uber/tchannel-go/testutils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdvertisedTable(t *testing.T) {
+	table := newAdvertisedTable()
+	table.addPeer("a", "1")
+	table.addPeer("a", "2")
+	table.addPeer("a", "2")
+	table.addPeer("a", "2")
+	table.addPeer("c", "3")
+	table.addPeer("d", "4")
+
+	tests := []struct {
+		svc  string
+		want []string
+	}{
+		{
+			svc:  "a",
+			want: []string{"1", "2"},
+		},
+		{
+			svc:  "c",
+			want: []string{"3"},
+		},
+		// Service that would be between "a" and "c" in the sorted list.
+		{
+			svc: "b",
+		},
+		// Service that would be inserted at the end.
+		{
+			svc: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		gotPeer, err := table.Get(testutils.FakeCallFrame{ServiceF: tt.svc})
+		if len(tt.want) == 0 {
+			assert.Error(t, err, "Expected error for %v", tt.svc)
+			continue
+		}
+
+		assert.Len(t, table.serviceMapping[tt.svc], len(tt.want), "Unexpected number of peers in table for %v", tt.svc)
+		assert.Contains(t, tt.want, gotPeer.HostPort, "Invalid host:port for %v", tt.svc)
+	}
+}


### PR DESCRIPTION
Now that we have inbuilt relaying and ability to handle calls on relays, we can implement a simple in-memory Hyperbahn in the mockhyperbahn package!