### PR TITLE
Let relay tables check the remote process name

### DIFF
--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -34,7 +34,7 @@ type fixedHosts struct {
 	pickI atomic.Int32
 }
 
-func (fh *fixedHosts) Get(call relay.CallFrame) (relay.Peer, error) {
+func (fh *fixedHosts) Get(call relay.CallFrame, _ relay.Conn) (relay.Peer, error) {
 	peers := fh.hosts[string(call.Service())]
 	if len(peers) == 0 {
 		return relay.Peer{}, nil

--- a/connection_test.go
+++ b/connection_test.go
@@ -748,3 +748,19 @@ func TestConnectTimeout(t *testing.T) {
 		close(testComplete)
 	})
 }
+
+func TestConnectionProcessPrefixes(t *testing.T) {
+	opts := testutils.NewOpts().NoRelay().SetProcessName("nodejs-hyperbahn")
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		clientOpts := testutils.NewOpts().NoRelay().SetProcessPrefixes("nod", "nodejs-hyperbahn", "", "hyperbahn")
+		client := ts.NewClient(clientOpts)
+
+		ctx, cancel := NewContextBuilder(testutils.Timeout(100 * time.Millisecond)).Build()
+		defer cancel()
+		conn, err := client.Connect(ctx, ts.HostPort())
+		require.NoError(t, err, "Unexpected error connecting to test server.")
+
+		matches := conn.RemoteProcessPrefixMatches()
+		assert.Equal(t, []bool{true, true, true, false}, matches, "Unexpected prefix matches.")
+	})
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -752,10 +752,10 @@ func TestConnectTimeout(t *testing.T) {
 func TestConnectionProcessPrefixes(t *testing.T) {
 	opts := testutils.NewOpts().NoRelay().SetProcessName("nodejs-hyperbahn")
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
-		clientOpts := testutils.NewOpts().NoRelay().SetProcessPrefixes("nod", "nodejs-hyperbahn", "", "hyperbahn")
+		clientOpts := testutils.NewOpts().SetProcessPrefixes("nod", "nodejs-hyperbahn", "", "hyperbahn")
 		client := ts.NewClient(clientOpts)
 
-		ctx, cancel := NewContextBuilder(testutils.Timeout(100 * time.Millisecond)).Build()
+		ctx, cancel := NewContext(time.Second)
 		defer cancel()
 		conn, err := client.Connect(ctx, ts.HostPort())
 		require.NoError(t, err, "Unexpected error connecting to test server.")

--- a/relay.go
+++ b/relay.go
@@ -170,11 +170,10 @@ type Relayer struct {
 	// It stores remappings for all response frames read on this connection.
 	inbound *relayItems
 
-	peers     *PeerList
-	conn      *Connection
-	relayConn relay.Conn // cast and allocate once
-	logger    Logger
-	pending   atomic.Uint32
+	peers   *PeerList
+	conn    *Connection
+	logger  Logger
+	pending atomic.Uint32
 }
 
 // NewRelayer constructs a Relayer.
@@ -187,7 +186,6 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 		inbound:      newRelayItems(ch.Logger().WithFields(LogField{"relay", "inbound"})),
 		peers:        ch.Peers(),
 		conn:         conn,
-		relayConn:    relay.Conn(conn),
 		logger:       conn.log,
 	}
 }
@@ -268,7 +266,7 @@ func (r *Relayer) getDestination(f lazyCallReq, cs relay.CallStats) (*Connection
 	}
 
 	// Get the destination
-	selectedPeer, err := r.hosts.Get(f, r.relayConn)
+	selectedPeer, err := r.hosts.Get(f, r.conn)
 	cs.SetPeer(selectedPeer)
 	if err == nil && selectedPeer.HostPort == "" {
 		err = errInvalidPeerForGroup(f.Service())

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -24,6 +24,14 @@
 // backwards-compatibility guarantee.
 package relay
 
+// Conn is an interface that exposes a bit of information about the underlying
+// connection.
+type Conn interface {
+	// RemoteProcessPrefixMatches checks whether the remote peer's process name
+	// matches a preconfigured list of prefixes.
+	RemoteProcessPrefixMatches() []bool
+}
+
 // CallFrame is an interface that abstracts access to the call req frame.
 type CallFrame interface {
 	// Caller is the name of the originating service.
@@ -40,7 +48,7 @@ type Hosts interface {
 	// Get returns the peer to forward the given call to.
 	// If a SystemError is returned, the error is forwarded. Otherwise
 	// a Declined error is returned to the caller.
-	Get(CallFrame) (Peer, error)
+	Get(CallFrame, Conn) (Peer, error)
 }
 
 // CallStats is a reporter for per-request stats.

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -131,6 +131,12 @@ func (o *ChannelOpts) SetFramePool(framePool tchannel.FramePool) *ChannelOpts {
 	return o
 }
 
+// SetProcessPrefixes sets CheckProcessPrefixes in DefaultConnectionOptions.
+func (o *ChannelOpts) SetProcessPrefixes(prefixes ...string) *ChannelOpts {
+	o.DefaultConnectionOptions.CheckedProcessPrefixes = prefixes
+	return o
+}
+
 // SetTimeNow sets TimeNow in ChannelOptions.
 func (o *ChannelOpts) SetTimeNow(timeNow func() time.Time) *ChannelOpts {
 	o.TimeNow = timeNow

--- a/testutils/mockhyperbahn/advertise_table.go
+++ b/testutils/mockhyperbahn/advertise_table.go
@@ -57,7 +57,7 @@ func (t *advertisedTable) addPeer(svc, hostPort string) {
 	t.serviceMapping[svc] = hostPorts
 }
 
-func (t *advertisedTable) Get(call relay.CallFrame) (relay.Peer, error) {
+func (t *advertisedTable) Get(call relay.CallFrame, _ relay.Conn) (relay.Peer, error) {
 	t.RLock()
 	defer t.RUnlock()
 

--- a/testutils/mockhyperbahn/advertise_table_test.go
+++ b/testutils/mockhyperbahn/advertise_table_test.go
@@ -60,7 +60,7 @@ func TestAdvertisedTable(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		gotPeer, err := table.Get(testutils.FakeCallFrame{ServiceF: tt.svc})
+		gotPeer, err := table.Get(testutils.FakeCallFrame{ServiceF: tt.svc}, nil)
 		if len(tt.want) == 0 {
 			assert.Error(t, err, "Expected error for %v", tt.svc)
 			continue

--- a/testutils/relay_stub.go
+++ b/testutils/relay_stub.go
@@ -56,7 +56,7 @@ func NewSimpleRelayHosts(peerHostPorts map[string][]string) *SimpleRelayHosts {
 }
 
 // Get takes a routing key and returns the best host:port for that key.
-func (rh *SimpleRelayHosts) Get(frame relay.CallFrame) (relay.Peer, error) {
+func (rh *SimpleRelayHosts) Get(frame relay.CallFrame, _ relay.Conn) (relay.Peer, error) {
 	rh.RLock()
 	defer rh.RUnlock()
 

--- a/testutils/relay_stub_test.go
+++ b/testutils/relay_stub_test.go
@@ -60,7 +60,7 @@ func TestSimpleRelayHosts(t *testing.T) {
 	for _, tt := range tests {
 		// Since we use random, run the test a few times.
 		for i := 0; i < 5; i++ {
-			got, err := rh.Get(tt.call)
+			got, err := rh.Get(tt.call, nil)
 			require.NoError(t, err, "Get failed")
 			if tt.wantOneOf == nil {
 				assert.Equal(t, "", got.HostPort, "Expected %v to find no hosts", tt.call)
@@ -77,7 +77,7 @@ func TestSimpleRelayHosts(t *testing.T) {
 func TestSimpleRelayHostsPeer(t *testing.T) {
 	hosts := NewSimpleRelayHosts(nil)
 	hosts.AddPeer("svc", "1.1.1.1:1", "a1", "sjc1")
-	peer, err := hosts.Get(FakeCallFrame{ServiceF: "svc"})
+	peer, err := hosts.Get(FakeCallFrame{ServiceF: "svc"}, nil)
 	require.NoError(t, err, "Get failed")
 	assert.Equal(t, relay.Peer{HostPort: "1.1.1.1:1", Pool: "a1", Zone: "sjc1"}, peer, "Unexpected peer")
 }
@@ -86,7 +86,7 @@ func TestSimpleRelayHostsPeerError(t *testing.T) {
 	wantErr := errors.New("test error")
 	hosts := NewSimpleRelayHosts(nil)
 	hosts.AddError("svc", wantErr)
-	peer, err := hosts.Get(FakeCallFrame{ServiceF: "svc"})
+	peer, err := hosts.Get(FakeCallFrame{ServiceF: "svc"}, nil)
 	assert.Equal(t, relay.Peer{}, peer, "Unexpected peer")
 	assert.Equal(t, wantErr, err, "Unexpected error")
 }

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -211,7 +211,7 @@ func (ts *TestServer) NewServer(opts *ChannelOpts) *tchannel.Channel {
 // addRelay adds a relay in front of the test server, altering public methods as
 // necessary to route traffic through the relay.
 func (ts *TestServer) addRelay(parentOpts *ChannelOpts) {
-	ts.relayHosts = NewSimpleRelayHosts(map[string][]string{
+	ts.relayHosts = NewSimpleRelayHosts(ts, map[string][]string{
 		ts.Server().ServiceName(): []string{ts.Server().PeerInfo().HostPort},
 	})
 


### PR DESCRIPTION
In order to build some internal TChannel relays, we need the relay table to behave differently depending on who the remote peer is. Since this use case is only for a short-term migration, we'll identify the remote peer by process name. This PR makes two small changes:

* It adds an efficient way for connections to check whether the remote peer matches one of a pre-configured list of process name prefixes. This is checked only once, when the connection is established.
* It adds a narrow `relay.Conn` interface to expose this new method, and passes the connection into the routing table's `Get` method.