### PR TITLE
introspection: Only include other channels if requested

### DIFF
--- a/all_channels_test.go
+++ b/all_channels_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestAllChannelsRegistered(t *testing.T) {
+	introspectOpts := &IntrospectionOptions{IncludeOtherChannels: true}
+
 	ch1_1, err := NewChannel("ch1", nil)
 	require.NoError(t, err, "Channel create failed")
 	ch1_2, err := NewChannel("ch1", nil)
@@ -35,19 +37,19 @@ func TestAllChannelsRegistered(t *testing.T) {
 	ch2_1, err := NewChannel("ch2", nil)
 	require.NoError(t, err, "Channel create failed")
 
-	state := ch1_1.IntrospectState(nil)
+	state := ch1_1.IntrospectState(introspectOpts)
 	assert.Equal(t, 1, len(state.OtherChannels["ch1"]))
 	assert.Equal(t, 1, len(state.OtherChannels["ch2"]))
 
 	ch1_2.Close()
 
-	state = ch1_1.IntrospectState(nil)
+	state = ch1_1.IntrospectState(introspectOpts)
 	assert.Equal(t, 0, len(state.OtherChannels["ch1"]))
 	assert.Equal(t, 1, len(state.OtherChannels["ch2"]))
 
 	ch2_2, err := NewChannel("ch2", nil)
 
-	state = ch1_1.IntrospectState(nil)
+	state = ch1_1.IntrospectState(introspectOpts)
 	require.NoError(t, err, "Channel create failed")
 	assert.Equal(t, 0, len(state.OtherChannels["ch1"]))
 	assert.Equal(t, 2, len(state.OtherChannels["ch2"]))
@@ -56,7 +58,7 @@ func TestAllChannelsRegistered(t *testing.T) {
 	ch2_1.Close()
 	ch2_2.Close()
 
-	state = ch1_1.IntrospectState(nil)
+	state = ch1_1.IntrospectState(introspectOpts)
 	assert.Equal(t, 0, len(state.OtherChannels["ch1"]))
 	assert.Equal(t, 0, len(state.OtherChannels["ch2"]))
 }

--- a/introspection.go
+++ b/introspection.go
@@ -39,6 +39,10 @@ type IntrospectionOptions struct {
 
 	// IncludeTombstones will include tombstones when introspecting relays.
 	IncludeTombstones bool `json:"includeTombstones"`
+
+	// IncludeOtherChannels will include basic information about other chanenls
+	// created in the same process as this channel.
+	IncludeOtherChannels bool `json:"includeOtherChannels"`
 }
 
 // RuntimeVersion includes version information about the runtime and
@@ -217,6 +221,10 @@ func (ch *Channel) IntrospectState(opts *IntrospectionOptions) *RuntimeState {
 
 // IntrospectOthers returns the ChannelInfo for all other channels in this process.
 func (ch *Channel) IntrospectOthers(opts *IntrospectionOptions) map[string][]ChannelInfo {
+	if !opts.IncludeOtherChannels {
+		return nil
+	}
+
 	channelMap.Lock()
 	defer channelMap.Unlock()
 

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -368,7 +368,6 @@ func (ts *TestServer) verifyNoGoroutinesLeaked() {
 
 func comparableState(ch *tchannel.Channel, opts *tchannel.IntrospectionOptions) *tchannel.RuntimeState {
 	s := ch.IntrospectState(opts)
-	s.OtherChannels = nil
 	s.SubChannels = nil
 	s.Peers = nil
 	return s


### PR DESCRIPTION
In our internal relaying system, we'll be creating a large number
of relays, and the OtherChannels just floods the output, so disable
it by default. If we're debugging issues where we think there's multiple
channels in a process, we can enable the IncludeOtherChannels at that
point.