### PR TITLE
json: Fix incorrect error message on connect failures

### DIFF
--- a/json/call.go
+++ b/json/call.go
@@ -107,7 +107,8 @@ func (c *Client) Call(ctx Context, method string, arg, resp interface{}) error {
 	)
 
 	err := c.ch.RunWithRetry(ctx, func(ctx context.Context, rs *tchannel.RequestState) error {
-		respHeaders, respErr, errAt, isOK = nil, nil, "", false
+		respHeaders, respErr, isOK = nil, nil, false
+		errAt = "connect"
 
 		call, err := c.startCall(ctx, method, &tchannel.CallOptions{
 			Format:       tchannel.JSON,
@@ -121,6 +122,7 @@ func (c *Client) Call(ctx Context, method string, arg, resp interface{}) error {
 		return err
 	})
 	if err != nil {
+		// TODO: Don't lose the error type here.
 		return fmt.Errorf("%s: %v", errAt, err)
 	}
 	if !isOK {


### PR DESCRIPTION
JSON prepends context on failures, but there was no context if
the connection failed. Add "connect" as the context when starting
the call.