### PR TITLE
Expose routing delegates through relay.CallFrame

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -40,6 +40,8 @@ type CallFrame interface {
 	Service() []byte
 	// Method is the name of the method being called.
 	Method() []byte
+	// RoutingDelegate is the name of the routing delegate, if any.
+	RoutingDelegate() []byte
 }
 
 // Hosts allows external wrappers to inject peer selection logic for

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -27,7 +27,10 @@ import (
 	"time"
 )
 
-var _callerNameKeyBytes = []byte(CallerName)
+var (
+	_callerNameKeyBytes      = []byte(CallerName)
+	_routingDelegateKeyBytes = []byte(RoutingDelegate)
+)
 
 const (
 	// Common to many frame types.
@@ -83,8 +86,7 @@ func (cr lazyCallRes) OK() bool {
 type lazyCallReq struct {
 	*Frame
 
-	caller []byte
-	method []byte
+	caller, method, delegate []byte
 }
 
 // TODO: Consider pooling lazyCallReq and using pointers to the struct.
@@ -114,6 +116,8 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 
 		if bytes.Equal(key, _callerNameKeyBytes) {
 			cr.caller = val
+		} else if bytes.Equal(key, _routingDelegateKeyBytes) {
+			cr.delegate = val
 		}
 	}
 
@@ -139,10 +143,14 @@ func (f lazyCallReq) Service() []byte {
 	return f.Payload[_serviceNameIndex : _serviceNameIndex+l]
 }
 
-// Method returns the name of the method being called. It panics if called for
-// a non-callReq frame.
+// Method returns the name of the method being called.
 func (f lazyCallReq) Method() []byte {
 	return f.method
+}
+
+// RoutingDelegate returns the routing delegate for this call req, if any.
+func (f lazyCallReq) RoutingDelegate() []byte {
+	return f.delegate
 }
 
 // TTL returns the time to live for this callReq.

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -25,9 +25,6 @@ import (
 	"github.com/uber/tchannel-go/relay"
 )
 
-// This file contains test setup logic, and is named with a _test.go suffix to
-// ensure it's only compiled with tests.
-
 // FakeIncomingCall implements IncomingCall interface.
 // Note: the F suffix for the fields is to clash with the method name.
 type FakeIncomingCall struct {
@@ -79,7 +76,7 @@ func NewIncomingCall(callerName string) tchannel.IncomingCall {
 
 // FakeCallFrame is a stub implementation of the CallFrame interface.
 type FakeCallFrame struct {
-	ServiceF, MethodF, CallerF string
+	ServiceF, MethodF, CallerF, RoutingDelegateF string
 }
 
 var _ relay.CallFrame = FakeCallFrame{}
@@ -97,4 +94,9 @@ func (f FakeCallFrame) Method() []byte {
 // Caller returns the caller field.
 func (f FakeCallFrame) Caller() []byte {
 	return []byte(f.CallerF)
+}
+
+// RoutingDelegate returns the routing delegate field.
+func (f FakeCallFrame) RoutingDelegate() []byte {
+	return []byte(f.RoutingDelegateF)
 }


### PR DESCRIPTION
To make forwarding decisions, implementations of `relay.Hosts` need access to the
`rd` transport header. Expose it via the `relay.CallFrame` interface.