### PR TITLE
Restore the original Registrar interface

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -300,9 +300,6 @@ type Registrar interface {
 
 	// Peers returns the peer list for this Registrar.
 	Peers() *PeerList
-
-	// Tracer returns OpenTracing Tracer this channel was configured with
-	Tracer() opentracing.Tracer
 }
 
 // Register registers a handler for a method.

--- a/json/handler.go
+++ b/json/handler.go
@@ -113,10 +113,8 @@ func Register(registrar tchannel.Registrar, funcs Handlers, onError func(context
 		if err != nil {
 			return fmt.Errorf("%v cannot be used as a handler: %v", m, err)
 		}
-		if tracerProvider, ok := registrar.(tchannel.TracerProvider); ok {
-			h.tracer = tracerProvider.Tracer
-		} else {
-			h.tracer = opentracing.GlobalTracer
+		h.tracer = func() {
+			return tchannel.TracerFromRegistrar(registrar)
 		}
 		handlers[m] = h
 		registrar.Register(handler, m)

--- a/json/handler.go
+++ b/json/handler.go
@@ -113,7 +113,7 @@ func Register(registrar tchannel.Registrar, funcs Handlers, onError func(context
 		if err != nil {
 			return fmt.Errorf("%v cannot be used as a handler: %v", m, err)
 		}
-		h.tracer = func() {
+		h.tracer = func() opentracing.Tracer {
 			return tchannel.TracerFromRegistrar(registrar)
 		}
 		handlers[m] = h

--- a/json/handler.go
+++ b/json/handler.go
@@ -113,7 +113,11 @@ func Register(registrar tchannel.Registrar, funcs Handlers, onError func(context
 		if err != nil {
 			return fmt.Errorf("%v cannot be used as a handler: %v", m, err)
 		}
-		h.tracer = registrar.Tracer
+		if tracerProvider, ok := registrar.(tchannel.TracerProvider); ok {
+			h.tracer = tracerProvider.Tracer
+		} else {
+			h.tracer = opentracing.GlobalTracer
+		}
 		handlers[m] = h
 		registrar.Register(handler, m)
 	}

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -28,7 +28,6 @@ import (
 	tchannel "github.com/uber/tchannel-go"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 
@@ -126,13 +125,7 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 		return err
 	}
 
-	var tracer opentracing.Tracer
-	if tracerProvider, ok := s.ch.(tchannel.TracerProvider); ok {
-		tracer = tracerProvider.Tracer()
-	} else {
-		tracer = opentracing.GlobalTracer()
-	}
-
+	tracer := tchannel.TracerFromRegistrar(s.ch)
 	origCtx = tchannel.ExtractInboundSpan(origCtx, call, headers, tracer)
 	ctx := s.ctxFn(origCtx, method, headers)
 

--- a/tracing.go
+++ b/tracing.go
@@ -34,6 +34,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+// TracerProvider returns an OpenTracing Tracer
+type TracerProvider interface {
+	Tracer() opentracing.Tracer
+}
+
 // zipkinSpanFormat defines a name for OpenTracing carrier format that tracer may support.
 // It is used to extract zipkin-style trace/span IDs from the OpenTracing Span, which are
 // otherwise not exposed explicitly.

--- a/tracing.go
+++ b/tracing.go
@@ -34,11 +34,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// TracerProvider returns an OpenTracing Tracer
-type TracerProvider interface {
-	Tracer() opentracing.Tracer
-}
-
 // zipkinSpanFormat defines a name for OpenTracing carrier format that tracer may support.
 // It is used to extract zipkin-style trace/span IDs from the OpenTracing Span, which are
 // otherwise not exposed explicitly.
@@ -262,4 +257,17 @@ func setPeerHostPort(span opentracing.Span, hostPort string) {
 			ext.PeerPort.Set(span, uint16(p))
 		}
 	}
+}
+
+type tracerProvider interface {
+	Tracer() opentracing.Tracer
+}
+
+// TracerFromRegistrar returns an OpenTracing Tracer embedded in the Registrar,
+// assuming that Registrar has a Tracer() method. Otherwise it returns default Global Tracer.
+func TracerFromRegistrar(registrar Registrar) opentracing.Tracer {
+	if tracerProvider, ok := registrar.(tracerProvider); ok {
+		return tracerProvider.Tracer()
+	}
+	return opentracing.GlobalTracer()
 }


### PR DESCRIPTION
Extending Registrar interface in #426 caused compile errors in ringpop-go. This change restores the original Registrar interface and pulls the tracer from it by casting to TracerProvider