### PR TITLE
relay: Expose RemoteHostPort() on relay.Conn

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -985,14 +985,3 @@ func (c *Connection) checkRemoteProcessNamePrefixes() {
 		c.remoteProcessPrefixMatches[i] = strings.HasPrefix(c.remotePeerInfo.ProcessName, prefix)
 	}
 }
-
-// RemoteProcessPrefixMatches returns a slice of bools indicating whether the
-// remote peer's process name matches the prefixes specified in the connection
-// options. It's the caller's responsibility to match indices between the two
-// slices. Callers shouldn't mutate the returned slice.
-//
-// This method isn't covered by tchannel-go's API stability guarantee, and is
-// intended only for use in some relaying implementations.
-func (c *Connection) RemoteProcessPrefixMatches() []bool {
-	return c.remoteProcessPrefixMatches
-}

--- a/connection_test.go
+++ b/connection_test.go
@@ -748,19 +748,3 @@ func TestConnectTimeout(t *testing.T) {
 		close(testComplete)
 	})
 }
-
-func TestConnectionProcessPrefixes(t *testing.T) {
-	opts := testutils.NewOpts().NoRelay().SetProcessName("nodejs-hyperbahn")
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
-		clientOpts := testutils.NewOpts().SetProcessPrefixes("nod", "nodejs-hyperbahn", "", "hyperbahn")
-		client := ts.NewClient(clientOpts)
-
-		ctx, cancel := NewContext(time.Second)
-		defer cancel()
-		conn, err := client.Connect(ctx, ts.HostPort())
-		require.NoError(t, err, "Unexpected error connecting to test server.")
-
-		matches := conn.RemoteProcessPrefixMatches()
-		assert.Equal(t, []bool{true, true, true, false}, matches, "Unexpected prefix matches.")
-	})
-}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -33,8 +33,7 @@ type Conn interface {
 	// slices. Callers shouldn't mutate the returned slice.
 	RemoteProcessPrefixMatches() []bool
 
-	// RemotePeerInfo returns the peer info for the remote peer which contains
-	// the process name and host:port.
+	// RemoteHostPort returns the host:port of the remote peer.
 	RemoteHostPort() string
 }
 

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -28,8 +28,14 @@ package relay
 // connection.
 type Conn interface {
 	// RemoteProcessPrefixMatches checks whether the remote peer's process name
-	// matches a preconfigured list of prefixes.
+	// matches a preconfigured list of prefixes specified in the connection
+	// options. It's the caller's responsibility to match indices between the two
+	// slices. Callers shouldn't mutate the returned slice.
 	RemoteProcessPrefixMatches() []bool
+
+	// RemotePeerInfo returns the peer info for the remote peer which contains
+	// the process name and host:port.
+	RemoteHostPort() string
 }
 
 // CallFrame is an interface that abstracts access to the call req frame.


### PR DESCRIPTION
This also unexports RemoteProcessPrefixMatches from the Connection type.

This is required if we need to make relay decisions based on the host:port that is making the call.