### PR TITLE
Reorder fields to make structs smaller

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -184,10 +184,10 @@ type Connection struct {
 	// remotePeerAddress is used as a cache for remote peer address parsed into individual
 	// components that can be used to set peer tags on OpenTracing Span.
 	remotePeerAddress struct {
+		port     uint16
 		ipv4     uint32
 		ipv6     string
 		hostname string
-		port     uint16
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -37,11 +37,11 @@ const (
 
 type tchannelCtxParams struct {
 	tracingDisabled         bool
+	hideListeningOnOutbound bool
 	call                    IncomingCall
 	options                 *CallOptions
 	retryOptions            *RetryOptions
 	connectTimeout          time.Duration
-	hideListeningOnOutbound bool
 }
 
 // IncomingCall exposes properties for incoming calls through the context.

--- a/context_builder.go
+++ b/context_builder.go
@@ -29,6 +29,18 @@ import (
 // ContextBuilder stores all TChannel-specific parameters that will
 // be stored inside of a context.
 type ContextBuilder struct {
+	// TracingDisabled disables trace reporting for calls using this context.
+	TracingDisabled bool
+
+	// hideListeningOnOutbound disables sending the listening server's host:port
+	// when creating new outgoing connections.
+	hideListeningOnOutbound bool
+
+	// replaceParentHeaders is set to true when SetHeaders() method is called.
+	// It forces headers from ParentContext to be ignored. When false, parent
+	// headers will be merged with headers accumulated by the builder.
+	replaceParentHeaders bool
+
 	// If Timeout is zero, Build will default to defaultTimeout.
 	Timeout time.Duration
 
@@ -38,18 +50,11 @@ type ContextBuilder struct {
 	// CallOptions are TChannel call options for the specific call.
 	CallOptions *CallOptions
 
-	// TracingDisabled disables trace reporting for calls using this context.
-	TracingDisabled bool
-
 	// RetryOptions are the retry options for this call.
 	RetryOptions *RetryOptions
 
 	// ConnectTimeout is the timeout for creating a TChannel connection.
 	ConnectTimeout time.Duration
-
-	// hideListeningOnOutbound disables sending the listening server's host:port
-	// when creating new outgoing connections.
-	hideListeningOnOutbound bool
 
 	// ParentContext to build the new context from. If empty, context.Background() is used.
 	// The new (child) context inherits a number of properties from the parent context:
@@ -59,11 +64,6 @@ type ContextBuilder struct {
 
 	// Hidden fields: we do not want users outside of tchannel to set these.
 	incomingCall IncomingCall
-
-	// replaceParentHeaders is set to true when SetHeaders() method is called.
-	// It forces headers from ParentContext to be ignored. When false, parent
-	// headers will be merged with headers accumulated by the builder.
-	replaceParentHeaders bool
 }
 
 // NewContextBuilder returns a builder that can be used to create a Context.

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -40,12 +40,12 @@ var (
 )
 
 type readableFragment struct {
+	isDone       bool
 	flags        byte
 	checksumType ChecksumType
 	checksum     []byte
 	contents     *typed.ReadBuffer
 	onDone       func()
-	isDone       bool
 }
 
 func (f *readableFragment) done() {

--- a/relay.go
+++ b/relay.go
@@ -49,11 +49,11 @@ type relayConn Connection
 type relayItem struct {
 	*time.Timer
 
-	stats       relay.CallStats
 	remapID     uint32
-	destination *Relayer
 	tomb        bool
 	local       bool
+	stats       relay.CallStats
+	destination *Relayer
 	span        Span
 }
 


### PR DESCRIPTION
Used [maligned](https://github.com/mdempsky/maligned) to find structs that could be smaller. Pre-change:
```
  connection.go:145:17: struct of size 488 could be 480
  connection.go:186:20: struct of size 48 could be 40
  context.go:38:24: struct of size 56 could be 48
  context_builder.go:31:21: struct of size 96 could be 80
  fragmenting_reader.go:42:23: struct of size 56 could be 48
  introspection.go:137:29: struct of size 216 could be 208
  relay.go:49:16: struct of size 80 could be 72
```
Post-change:
```
  connection.go:145:17: struct of size 488 could be 480
  introspection.go:137:29: struct of size 216 could be 208
```

I only made changes when the structs are small and it matters -- e.g,
connection is already huge, so I'd rather keep the fields in a logical
order. Introspection struct doesn't matter to perf.

No changes except for field reorderings in this change.