### PR TITLE
Update relay.CallStats docs

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -58,7 +58,8 @@ type Hosts interface {
 	Get(CallFrame, Conn) (Peer, error)
 }
 
-// CallStats is a reporter for per-request stats.
+// CallStats is a reporter for per-request stats. The Succeeded, Failed, and End
+// methods should be safe for concurrent use.
 //
 // Because call res frames don't include the OK bit, we can't wait until the
 // last frame of a relayed RPC to decide whether or not the RPC succeeded.


### PR DESCRIPTION
Update the documentation for the relay.CallStats interface to clarify
the concurrency requirements.