### PR TITLE
Support routing key transport header and call option

### DIFF
--- a/calloptions.go
+++ b/calloptions.go
@@ -47,8 +47,13 @@ type CallOptions struct {
 	// RequestState stores request state across retry attempts.
 	RequestState *RequestState
 
-	// RoutingDelegate identifies a service capable of routing a request to its
-	// intended recipient.
+	// RoutingKey identifies the destined traffic group. Relays may favor the
+	// routing key over the service name to route the request to a specialized
+	// traffic group.
+	RoutingKey string
+
+	// RoutingDelegate identifies a traffic group capable of routing a request
+	// to an instance of the intended service.
 	RoutingDelegate string
 
 	// callerName can only be used when forwarding a request. It can only be set internally,
@@ -70,6 +75,9 @@ func (c *CallOptions) overrideHeaders(headers transportHeaders) {
 	}
 	if c.ShardKey != "" {
 		headers[ShardKey] = c.ShardKey
+	}
+	if c.RoutingKey != "" {
+		headers[RoutingKey] = c.RoutingKey
 	}
 	if c.RoutingDelegate != "" {
 		headers[RoutingDelegate] = c.RoutingDelegate

--- a/calloptions_test.go
+++ b/calloptions_test.go
@@ -30,6 +30,7 @@ func TestSetHeaders(t *testing.T) {
 	tests := []struct {
 		format          Format
 		routingDelegate string
+		routingKey      string
 		expectedHeaders transportHeaders
 	}{
 		{
@@ -49,12 +50,21 @@ func TestSetHeaders(t *testing.T) {
 				RoutingDelegate: "xpr",
 			},
 		},
+		{
+			format:     JSON,
+			routingKey: "canary",
+			expectedHeaders: transportHeaders{
+				ArgScheme:  JSON.String(),
+				RoutingKey: "canary",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		callOpts := &CallOptions{
 			Format:          tt.format,
 			RoutingDelegate: tt.routingDelegate,
+			RoutingKey:      tt.routingKey,
 		}
 		headers := make(transportHeaders)
 		callOpts.setHeaders(headers)

--- a/context.go
+++ b/context.go
@@ -52,6 +52,10 @@ type IncomingCall interface {
 	// ShardKey returns the shard key from the ShardKey transport header.
 	ShardKey() string
 
+	// RoutingKey returns the routing key (referring to a traffic group) from
+	// RoutingKey transport header.
+	RoutingKey() string
+
 	// RoutingDelegate returns the routing delegate from RoutingDelegate
 	// transport header.
 	RoutingDelegate() string

--- a/context_builder.go
+++ b/context_builder.go
@@ -115,6 +115,15 @@ func (cb *ContextBuilder) SetFormat(f Format) *ContextBuilder {
 	return cb
 }
 
+// SetRoutingKey sets the RoutingKey call options ("rk" transport header).
+func (cb *ContextBuilder) SetRoutingKey(rk string) *ContextBuilder {
+	if cb.CallOptions == nil {
+		cb.CallOptions = new(CallOptions)
+	}
+	cb.CallOptions.RoutingKey = rk
+	return cb
+}
+
 // SetRoutingDelegate sets the RoutingDelegate call options ("rd" transport header).
 func (cb *ContextBuilder) SetRoutingDelegate(rd string) *ContextBuilder {
 	if cb.CallOptions == nil {

--- a/inbound.go
+++ b/inbound.go
@@ -239,6 +239,11 @@ func (call *InboundCall) ShardKey() string {
 	return call.headers[ShardKey]
 }
 
+// RoutingKey returns the routing key from the RoutingKey transport header.
+func (call *InboundCall) RoutingKey() string {
+	return call.headers[RoutingKey]
+}
+
 // RoutingDelegate returns the routing delegate from the RoutingDelegate transport header.
 func (call *InboundCall) RoutingDelegate() string {
 	return call.headers[RoutingDelegate]
@@ -256,6 +261,7 @@ func (call *InboundCall) CallOptions() *CallOptions {
 		Format:          call.Format(),
 		ShardKey:        call.ShardKey(),
 		RoutingDelegate: call.RoutingDelegate(),
+		RoutingKey:      call.RoutingKey(),
 	}
 }
 

--- a/messages.go
+++ b/messages.go
@@ -168,6 +168,11 @@ const (
 	// RoutingDelegate header identifies an intermediate service which knows
 	// how to route the request to the intended recipient.
 	RoutingDelegate TransportHeaderName = "rd"
+
+	// RoutingKey header identifies a traffic group containing instances of the
+	// requested service. A relay may use the routing key over the service if
+	// it knows about traffic groups.
+	RoutingKey TransportHeaderName = "rk"
 )
 
 // transportHeaders are passed as part of a CallReq/CallRes

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -47,6 +47,9 @@ type CallFrame interface {
 	Method() []byte
 	// RoutingDelegate is the name of the routing delegate, if any.
 	RoutingDelegate() []byte
+	// RoutingKey may refer to an alternate traffic group instead of the
+	// traffic group identified by the service name.
+	RoutingKey() []byte
 }
 
 // Hosts allows external wrappers to inject peer selection logic for

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -30,6 +30,7 @@ import (
 var (
 	_callerNameKeyBytes      = []byte(CallerName)
 	_routingDelegateKeyBytes = []byte(RoutingDelegate)
+	_routingKeyKeyBytes      = []byte(RoutingKey)
 )
 
 const (
@@ -86,7 +87,7 @@ func (cr lazyCallRes) OK() bool {
 type lazyCallReq struct {
 	*Frame
 
-	caller, method, delegate []byte
+	caller, method, delegate, key []byte
 }
 
 // TODO: Consider pooling lazyCallReq and using pointers to the struct.
@@ -118,6 +119,8 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 			cr.caller = val
 		} else if bytes.Equal(key, _routingDelegateKeyBytes) {
 			cr.delegate = val
+		} else if bytes.Equal(key, _routingKeyKeyBytes) {
+			cr.key = val
 		}
 	}
 
@@ -151,6 +154,11 @@ func (f lazyCallReq) Method() []byte {
 // RoutingDelegate returns the routing delegate for this call req, if any.
 func (f lazyCallReq) RoutingDelegate() []byte {
 	return f.delegate
+}
+
+// RoutingKey returns the routing delegate for this call req, if any.
+func (f lazyCallReq) RoutingKey() []byte {
+	return f.key
 }
 
 // TTL returns the time to live for this callReq.

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -37,6 +37,9 @@ type FakeIncomingCall struct {
 	// RemotePeerF is the calling service's peer info.
 	RemotePeerF tchannel.PeerInfo
 
+	// RoutingKeyF is the routing key.
+	RoutingKeyF string
+
 	// RoutingDelegateF is the routing delegate.
 	RoutingDelegateF string
 }
@@ -49,6 +52,11 @@ func (f *FakeIncomingCall) CallerName() string {
 // ShardKey returns the shard key as specified in the fake call.
 func (f *FakeIncomingCall) ShardKey() string {
 	return f.ShardKeyF
+}
+
+// RoutingKey returns the routing delegate as specified in the fake call.
+func (f *FakeIncomingCall) RoutingKey() string {
+	return f.RoutingKeyF
 }
 
 // RoutingDelegate returns the routing delegate as specified in the fake call.
@@ -65,6 +73,7 @@ func (f *FakeIncomingCall) RemotePeer() tchannel.PeerInfo {
 func (f *FakeIncomingCall) CallOptions() *tchannel.CallOptions {
 	return &tchannel.CallOptions{
 		ShardKey:        f.ShardKey(),
+		RoutingKey:      f.RoutingKey(),
 		RoutingDelegate: f.RoutingDelegate(),
 	}
 }
@@ -76,7 +85,7 @@ func NewIncomingCall(callerName string) tchannel.IncomingCall {
 
 // FakeCallFrame is a stub implementation of the CallFrame interface.
 type FakeCallFrame struct {
-	ServiceF, MethodF, CallerF, RoutingDelegateF string
+	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF string
 }
 
 var _ relay.CallFrame = FakeCallFrame{}
@@ -94,6 +103,11 @@ func (f FakeCallFrame) Method() []byte {
 // Caller returns the caller field.
 func (f FakeCallFrame) Caller() []byte {
 	return []byte(f.CallerF)
+}
+
+// RoutingKey returns the routing delegate field.
+func (f FakeCallFrame) RoutingKey() []byte {
+	return []byte(f.RoutingKeyF)
 }
 
 // RoutingDelegate returns the routing delegate field.


### PR DESCRIPTION
We’ve encountered a need for a third way to address RPC, by service name, by the service name of a routing delegate, and now by a routing key, all of which now refer to traffic groups with the new traffic control system. This change allows us to thread a routing key through from TChannel call options into the corresponding transport header such that it can be examined by a relay.

r @prashantv 