### PR TITLE
Check for canceled contexts when making outbound calls

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -489,6 +489,10 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, e
 		OnExchangeUpdated:  ch.exchangeUpdated,
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, GetContextError(err)
+	}
+
 	c, err := ch.newOutboundConnection(getTimeout(ctx), hostPort, events)
 	if err != nil {
 		return nil, err

--- a/outbound.go
+++ b/outbound.go
@@ -63,6 +63,10 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 		return nil, ErrTimeout
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, GetContextError(err)
+	}
+
 	if !c.pendingExchangeMethodAdd() {
 		// Connection is closed, no need to do anything.
 		return nil, ErrInvalidConnectionState

--- a/peer_test.go
+++ b/peer_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/atomic"
+	"golang.org/x/net/context"
 )
 
 func fakePeer(t *testing.T, ch *Channel, hostPort string) *Peer {
@@ -186,6 +187,17 @@ func TestPeerRemoveClosedConnection(t *testing.T) {
 		c, err := p.GetConnection(ctx)
 		require.NoError(t, err, "GetConnection failed")
 		assert.Equal(t, c2, c, "Expected second active connection")
+	})
+}
+
+func TestPeerConnectCanceled(t *testing.T) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
+		ctx, cancel := NewContext(109 * time.Millisecond)
+		cancel()
+
+		_, err := ch.Connect(ctx, "10.255.255.1:1")
+		require.Error(t, err, "Connect should fail")
+		assert.EqualError(t, context.Canceled, err.Error(), "Unknown error")
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/uber/tchannel-go/issues/501