### PR TITLE
relay: Selected peers should only be added to root peers

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -176,7 +176,7 @@ type Relayer struct {
 	// It stores remappings for all response frames read on this connection.
 	inbound *relayItems
 
-	peers   *PeerList
+	peers   *RootPeerList
 	conn    *Connection
 	logger  Logger
 	pending atomic.Uint32
@@ -190,7 +190,7 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 		localHandler: ch.relayLocal,
 		outbound:     newRelayItems(ch.Logger().WithFields(LogField{"relay", "outbound"})),
 		inbound:      newRelayItems(ch.Logger().WithFields(LogField{"relay", "inbound"})),
-		peers:        ch.Peers(),
+		peers:        ch.rootPeers(),
 		conn:         conn,
 		logger:       conn.log,
 	}

--- a/relay_test.go
+++ b/relay_test.go
@@ -489,3 +489,14 @@ func TestRelayConnection(t *testing.T) {
 	require.Error(t, err, "Expected CallEcho to fail")
 	assert.Contains(t, err.Error(), errTest.Error(), "Unexpected error")
 }
+
+func TestRelayUsesRootPeers(t *testing.T) {
+	opts := testutils.NewOpts().SetRelayOnly()
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		testutils.RegisterEcho(ts.Server(), nil)
+		client := testutils.NewClient(t, nil)
+		err := testutils.CallEcho(client, ts.HostPort(), ts.ServiceName(), nil)
+		assert.NoError(t, err, "Echo failed")
+		assert.Len(t, ts.Relay().Peers().Copy(), 0, "Peers should not be modified by relay")
+	})
+}


### PR DESCRIPTION
Previously, the relay was adding the peer returned from RelayHosts.Get
to the shared peer list, which could lead to unexpected results if the
channel's shared peer list is also used to talk to some other service.

We should never add peers to the shared peer list, if the user wants to
add the peer, they can add it to the shared peer list, but the relay
should only access peers through the root peer list.