### PR TITLE
Use structured logging for all Info logs

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -330,7 +330,7 @@ func (ch *Channel) createCommonStats() {
 	}
 	host, err := os.Hostname()
 	if err != nil {
-		ch.log.Infof("channel failed to get host: %v", err)
+		ch.log.WithFields(ErrField(err)).Info("Channel creation failed to get host.")
 		return
 	}
 	ch.commonStatsTags["host"] = host
@@ -576,7 +576,7 @@ func (ch *Channel) addConnectionToPeer(hostPort string, c *Connection, direction
 			LogField{"remoteHostPort", c.remotePeerInfo.HostPort},
 			LogField{"direction", direction},
 			ErrField(err),
-		).Warn("Failed to add connection to peer")
+		).Warn("Failed to add connection to peer.")
 	}
 
 	ch.updatePeer(p)
@@ -676,7 +676,7 @@ func (ch *Channel) State() ChannelState {
 // 2. When all incoming connections are drained, the connection blocks new outgoing calls.
 // 3. When all connections are drainged, the channel's state is updated to Closed.
 func (ch *Channel) Close() {
-	ch.Logger().Infof("Channel.Close called")
+	ch.Logger().Info("Channel.Close called.")
 	var connections []*Connection
 	ch.mutable.Lock()
 

--- a/outbound.go
+++ b/outbound.go
@@ -294,7 +294,13 @@ func (c *Connection) handleError(frame *Frame) bool {
 	}
 
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
-		c.log.Infof("Failed to forward error frame %v to mex, error: %v", frame.Header, errMsg)
+		c.log.WithFields(
+			LogField{"frameHeader", frame.Header.String()},
+			LogField{"id", errMsg.id},
+			LogField{"errorMessage", errMsg.message},
+			LogField{"errorCode", errMsg.errCode},
+			ErrField(err),
+		).Info("Failed to forward error frame.")
 		return true
 	}
 

--- a/relay.go
+++ b/relay.go
@@ -279,7 +279,7 @@ func (r *Relayer) getDestination(f lazyCallReq, cs relay.CallStats) (*Connection
 			LogField{"source", string(f.Caller())},
 			LogField{"dest", string(f.Service())},
 			LogField{"method", string(f.Method())},
-		).Warn("received duplicate callReq")
+		).Warn("Received duplicate callReq.")
 		cs.Failed("relay-" + ErrCodeProtocol.MetricsKey())
 		// TODO: this is a protocol error, kill the connection.
 		return nil, false, errors.New("callReq with already active ID")

--- a/retry.go
+++ b/retry.go
@@ -232,12 +232,16 @@ func (ch *Channel) RunWithRetry(runCtx context.Context, f RetriableFunc) error {
 		}
 		if !opts.RetryOn.CanRetry(err) {
 			if ch.log.Enabled(LogLevelInfo) {
-				ch.log.Infof("Failed after non-retriable error: %v", err)
+				ch.log.WithFields(ErrField(err)).Info("Failed after non-retriable error.")
 			}
 			return err
 		}
 
-		ch.log.Infof("Retrying request after it failed with error %v on attempt %v/%v", err, rs.Attempt, opts.MaxAttempts)
+		ch.log.WithFields(
+			ErrField(err),
+			LogField{"attempt", rs.Attempt},
+			LogField{"maxAttempts", opts.MaxAttempts},
+		).Info("Retrying request after retryable error.")
 	}
 
 	// Too many retries, return the last error

--- a/root_peer_list.go
+++ b/root_peer_list.go
@@ -101,7 +101,9 @@ func (l *RootPeerList) onClosedConnRemoved(peer *Peer) {
 		l.Lock()
 		delete(l.peersByHostPort, hostPort)
 		l.Unlock()
-		l.channel.Logger().Infof("Removed peer %s from root peer list", hostPort)
+		l.channel.Logger().WithFields(
+			LogField{"hostPort", hostPort},
+		).Info("Removed peer from root peer list.")
 	}
 }
 


### PR DESCRIPTION
Since we enable Info logs by default in our relays, we should use
structured logging to improve the ELK experience.