### PR TITLE
Treat hostPorts ending in ":0" in the init headers as ephemeral

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -213,6 +213,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		PeerInfo: PeerInfo{
 			ProcessName: processName,
 			HostPort:    ephemeralHostPort,
+			IsEphemeral: true,
 		},
 		ServiceName: serviceName,
 	}
@@ -250,6 +251,7 @@ func (ch *Channel) Serve(l net.Listener) error {
 	mutable.state = ChannelListening
 
 	mutable.peerInfo.HostPort = l.Addr().String()
+	mutable.peerInfo.IsEphemeral = false
 	ch.log = ch.log.WithFields(LogField{"hostPort", mutable.peerInfo.HostPort})
 
 	peerInfo := mutable.peerInfo

--- a/connection.go
+++ b/connection.go
@@ -55,9 +55,9 @@ func (p PeerInfo) String() string {
 	return fmt.Sprintf("%s(%s)", p.HostPort, p.ProcessName)
 }
 
-// IsEphemeralHostPort returns if hostPort is the default ephemeral hostPort.
+// IsEphemeralHostPort returns whether the connection is from an ephemeral host:port.
 func (p PeerInfo) IsEphemeralHostPort() bool {
-	return p.HostPort == "" || p.HostPort == ephemeralHostPort
+	return p.IsEphemeral
 }
 
 // LocalPeerInfo adds service name to the peer info, only required for the local peer.
@@ -429,10 +429,7 @@ func (c *Connection) handleInitReq(frame *Frame) {
 		c.protocolError(id, fmt.Errorf("header %v is required", InitParamProcessName))
 		return
 	}
-	if c.remotePeerInfo.IsEphemeralHostPort() {
-		c.remotePeerInfo.HostPort = c.conn.RemoteAddr().String()
-		c.remotePeerInfo.IsEphemeral = true
-	}
+
 	c.checkRemoteProcessNamePrefixes()
 	c.parseRemotePeerAddress()
 
@@ -564,10 +561,6 @@ func (c *Connection) handleInitRes(frame *Frame) bool {
 		}
 
 		c.remotePeerInfo.HostPort = res.initParams[InitParamHostPort]
-		if c.remotePeerInfo.IsEphemeralHostPort() {
-			c.remotePeerInfo.HostPort = c.conn.RemoteAddr().String()
-			c.remotePeerInfo.IsEphemeral = true
-		}
 		c.remotePeerInfo.ProcessName = res.initParams[InitParamProcessName]
 		c.checkRemoteProcessNamePrefixes()
 		c.parseRemotePeerAddress()
@@ -1002,6 +995,13 @@ func (c *Connection) checkRemoteProcessNamePrefixes() {
 // parseRemotePeerAddress parses remote peer info into individual components and
 // caches them on the Connection to be used to set peer tags on OpenTracing Span.
 func (c *Connection) parseRemotePeerAddress() {
+	// If the remote host:port is ephemeral, use the socket address as the
+	// host:port and set IsEphemeral to true.
+	if isEphemeralHostPort(c.remotePeerInfo.HostPort) {
+		c.remotePeerInfo.HostPort = c.conn.RemoteAddr().String()
+		c.remotePeerInfo.IsEphemeral = true
+	}
+
 	address := c.remotePeerInfo.HostPort
 	if sHost, sPort, err := net.SplitHostPort(address); err == nil {
 		address = sHost

--- a/peer.go
+++ b/peer.go
@@ -531,3 +531,8 @@ func (p *Peer) callOnUpdateComplete() {
 		f(p)
 	}
 }
+
+// isEphemeralHostPort returns if hostPort is the default ephemeral hostPort.
+func isEphemeralHostPort(hostPort string) bool {
+	return hostPort == "" || hostPort == ephemeralHostPort
+}

--- a/peer.go
+++ b/peer.go
@@ -23,6 +23,7 @@ package tchannel
 import (
 	"container/heap"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -534,5 +535,5 @@ func (p *Peer) callOnUpdateComplete() {
 
 // isEphemeralHostPort returns if hostPort is the default ephemeral hostPort.
 func isEphemeralHostPort(hostPort string) bool {
-	return hostPort == "" || hostPort == ephemeralHostPort
+	return hostPort == "" || hostPort == ephemeralHostPort || strings.HasSuffix(hostPort, ":0")
 }

--- a/peer_internal_test.go
+++ b/peer_internal_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEphemeralHostPort(t *testing.T) {
+	tests := []struct {
+		hostPort string
+		want     bool
+	}{
+		{"", true},
+		{ephemeralHostPort, true},
+		{"127.0.0.1:0", true},
+		{"10.1.1.1:0", true},
+		{"127.0.0.1:1", false},
+		{"10.1.1.1:1", false},
+	}
+
+	for _, tt := range tests {
+		got := isEphemeralHostPort(tt.hostPort)
+		assert.Equal(t, tt.want, got, "Unexpected result for %q", tt.hostPort)
+	}
+}


### PR DESCRIPTION
Includes a refactors some of the logic to reduce code duplication as the first commit.