### PR TITLE
Improve logging of connections and peers

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -230,14 +230,14 @@ func (ch *Channel) newOutboundConnection(timeout time.Duration, hostPort string,
 	if err != nil {
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
 			ch.log.WithFields(
-				LogField{"hostPort", hostPort},
+				LogField{"remoteHostPort", hostPort},
 				LogField{"timeout", timeout},
 			).Info("Outbound net.Dial timed out.")
 			err = ErrTimeout
 		} else {
 			ch.log.WithFields(
 				ErrField(err),
-				LogField{"hostPort", hostPort},
+				LogField{"remoteHostPort", hostPort},
 			).Info("Outbound net.Dial failed.")
 		}
 		return nil, err
@@ -282,7 +282,7 @@ func (ch *Channel) newConnection(conn net.Conn, outboundHP string, initialState 
 		{"remoteAddr", conn.RemoteAddr()},
 	}...)
 	peerInfo := ch.PeerInfo()
-	log.Debugf("created for %v (%v) local: %v remote: %v",
+	log.Debugf("Connection created for %v (%v) local: %v remote: %v",
 		peerInfo.ServiceName, peerInfo.ProcessName, conn.LocalAddr(), conn.RemoteAddr())
 	c := &Connection{
 		channelConnectionCommon: ch.channelConnectionCommon,

--- a/root_peer_list.go
+++ b/root_peer_list.go
@@ -102,7 +102,7 @@ func (l *RootPeerList) onClosedConnRemoved(peer *Peer) {
 		delete(l.peersByHostPort, hostPort)
 		l.Unlock()
 		l.channel.Logger().WithFields(
-			LogField{"hostPort", hostPort},
+			LogField{"remoteHostPort", hostPort},
 		).Info("Removed peer from root peer list.")
 	}
 }


### PR DESCRIPTION
Rename "hostPort" to "remoteHostPort" since "hostPort" is already used
by the local channel's listening hostPort (if any).