### PR TITLE
Only track active connections in peers

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -525,7 +525,12 @@ func (ch *Channel) exchangeUpdated(c *Connection) {
 		// Hostport is unknown until we get init resp.
 		return
 	}
-	p := ch.rootPeers().GetOrAdd(c.remotePeerInfo.HostPort)
+
+	p, ok := ch.rootPeers().Get(c.remotePeerInfo.HostPort)
+	if !ok {
+		return
+	}
+
 	ch.updatePeer(p)
 }
 
@@ -593,6 +598,7 @@ func (ch *Channel) outboundConnectionActive(c *Connection) {
 }
 
 // removeClosedConn removes a connection if it's closed.
+// Until a connection is fully closed, the channel must keep track of it.
 func (ch *Channel) removeClosedConn(c *Connection) {
 	if c.readState() != connectionClosed {
 		return

--- a/connection.go
+++ b/connection.go
@@ -972,6 +972,11 @@ func (c *Connection) Close() error {
 		return err
 	}
 
+	c.log.WithFields(
+		LogField{"newState", c.readState()},
+	).Info("Connection state updated in Close.")
+	c.callOnCloseStateChange()
+
 	// Check all in-flight requests to see whether we can transition the Close state.
 	c.checkExchanges()
 

--- a/peer.go
+++ b/peer.go
@@ -440,8 +440,10 @@ func (p *Peer) removeConnection(connsPtr *[]*Connection, changed *Connection) bo
 }
 
 // connectionStateChanged is called when one of the peers' connections states changes.
+// All non-active connections are removed from the peer. The connection will
+// still be tracked by the channel until it's completely closed.
 func (p *Peer) connectionCloseStateChange(changed *Connection) {
-	if changed.readState() != connectionClosed {
+	if changed.IsActive() {
 		return
 	}
 


### PR DESCRIPTION
Connections that are closing should only be tracked by the channel.
The peer's connection list is used for scoring the peer and for making
new outbound calls, so we should not be tracking non-active connections
that cannot be used for new outbound calls.

Connections going through shutdown will still be tracked by the channel.