### PR TITLE
Move context to first param to make golint happy

### DIFF
--- a/crossdock/behavior/trace/behavior.go
+++ b/crossdock/behavior/trace/behavior.go
@@ -153,7 +153,7 @@ func (b *Behavior) startTrace(t crossdock.T, req *Request, sampled bool, baggage
 	defer cancel()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
-	return b.prepareResponse(t, ctx, req.Downstream)
+	return b.prepareResponse(ctx, t, req.Downstream)
 }
 
 func validateTrace(
@@ -192,7 +192,7 @@ func randomBaggage() string {
 	return fmt.Sprintf("%x", n)
 }
 
-func (b *Behavior) prepareResponse(t crossdock.T, ctx context.Context, reqDwn *Downstream) (*Response, error) {
+func (b *Behavior) prepareResponse(ctx context.Context, t crossdock.T, reqDwn *Downstream) (*Response, error) {
 	log.Printf("prepareResponse: reqDwn=%v", reqDwn)
 	logSpan(ctx)
 	observedSpan, err := observeSpan(ctx)

--- a/crossdock/behavior/trace/behavior_test.go
+++ b/crossdock/behavior/trace/behavior_test.go
@@ -110,16 +110,16 @@ func TestNoSpanObserved(t *testing.T) {
 func TestPrepareResponseErrors(t *testing.T) {
 	b := &Behavior{}
 	ctx := context.Background()
-	_, err := b.prepareResponse(nil, ctx, nil)
+	_, err := b.prepareResponse(ctx, nil, nil)
 	assert.Equal(t, errNoSpanObserved, err)
 
 	span := opentracing.GlobalTracer().StartSpan("test")
 	ctx = opentracing.ContextWithSpan(ctx, span)
-	res, err := b.prepareResponse(nil, ctx, nil)
+	res, err := b.prepareResponse(ctx, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "", res.Span.TraceID)
 
-	_, err = b.prepareResponse(nil, ctx, &Downstream{
+	_, err = b.prepareResponse(ctx, nil, &Downstream{
 		Encoding: "invalid",
 	})
 	assert.Equal(t, errUnsupportedEncoding, err)

--- a/crossdock/behavior/trace/json.go
+++ b/crossdock/behavior/trace/json.go
@@ -57,7 +57,7 @@ func (h *jsonHandler) callDownstream(ctx context.Context, target *Downstream) (*
 }
 
 func (h *jsonHandler) handleJSON(ctx json.Context, req *Request) (*Response, error) {
-	return h.b.prepareResponse(nil, ctx, req.Downstream)
+	return h.b.prepareResponse(ctx, nil, req.Downstream)
 }
 
 func (h *jsonHandler) onError(ctx context.Context, err error) {

--- a/crossdock/behavior/trace/thrift.go
+++ b/crossdock/behavior/trace/thrift.go
@@ -48,7 +48,7 @@ func (h *thriftHandler) Call(ctx thrift.Context, arg *gen.Data) (*gen.Data, erro
 	if err != nil {
 		return nil, err
 	}
-	res, err := h.b.prepareResponse(nil, ctx, req.Downstream)
+	res, err := h.b.prepareResponse(ctx, nil, req.Downstream)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Golint recently added a rule to ensure context is the first argument.
While this doesn't always make sense (e.g., when using testing.T), it
doesn't seem like this will change any time soon.