### PR TITLE
relay: Improve error when handling calls on inactive connections

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -508,8 +508,8 @@ func (c *Connection) handlePingReq(frame *Frame) {
 	}
 	defer c.pendingExchangeMethodDone()
 
-	if c.readState() != connectionActive {
-		c.protocolError(frame.Header.ID, fmt.Errorf("connection state is not active"))
+	if state := c.readState(); state != connectionActive {
+		c.protocolError(frame.Header.ID, errConnNotActive{"ping on incoming", state})
 		return
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -200,3 +200,12 @@ func GetSystemErrorMessage(err error) string {
 
 	return err.Error()
 }
+
+type errConnNotActive struct {
+	info  string
+	state connectionState
+}
+
+func (e errConnNotActive) Error() string {
+	return fmt.Sprintf("%v connection is not active: %v", e.info, e.state)
+}

--- a/relay.go
+++ b/relay.go
@@ -261,8 +261,11 @@ func (r *Relayer) Receive(f *Frame, fType frameType) {
 }
 
 func (r *Relayer) canHandleNewCall() (bool, connectionState) {
-	var canHandle bool
-	var curState connectionState
+	var (
+		canHandle bool
+		curState  connectionState
+	)
+
 	r.conn.withStateRLock(func() error {
 		curState = r.conn.state
 		canHandle = curState == connectionActive


### PR DESCRIPTION
Currently, we use a "channel-closed" message which is not correct since
the channel may be active, but the connection could be closing (e.g.,
because it hit a network error).

Return an error frame to the remote side so they see a declined rather than
a timeout.