### PR TITLE
relay: Add RateLimitDropError to drop traffic instead of relaying it

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -99,3 +99,15 @@ type Peer struct {
 	// to, which is also useful for stats.
 	Zone string
 }
+
+// RateLimitDropError is the error that should be returned from
+// RelayHosts.Get if the request should be dropped silently.
+// This is bit of a hack, because rate limiting of this nature isn't part of
+// the actual TChannel protocol.
+// The relayer will record that it has dropped the packet, but *won't* notify
+// the client.
+type RateLimitDropError struct{}
+
+func (e RateLimitDropError) Error() string {
+	return "frame dropped silently due to rate limiting"
+}

--- a/relay_test.go
+++ b/relay_test.go
@@ -542,8 +542,12 @@ func TestRelayRejectsDuringClose(t *testing.T) {
 }
 
 func TestRelayRateLimitDrop(t *testing.T) {
+	droppedPeer := relay.Peer{
+		Pool: "$dropped",
+		Zone: "zone",
+	}
 	getHost := func(call relay.CallFrame, conn relay.Conn) (relay.Peer, error) {
-		return relay.Peer{}, relay.RateLimitDropError{}
+		return droppedPeer, relay.RateLimitDropError{}
 	}
 
 	opts := testutils.NewOpts().
@@ -573,7 +577,9 @@ func TestRelayRateLimitDrop(t *testing.T) {
 		assert.False(t, gotCall, "Server should not receive a call")
 
 		calls := relaytest.NewMockStats()
-		calls.Add(client.PeerInfo().ServiceName, ts.ServiceName(), "echo").Failed("relay-dropped").End()
+		calls.Add(client.PeerInfo().ServiceName, ts.ServiceName(), "echo").
+			SetPeer(droppedPeer).
+			Failed("relay-dropped").End()
 		ts.AssertRelayStats(calls)
 	})
 }


### PR DESCRIPTION
This adds a new error that can be used to force the relay to drop packets. This should cause the client to timeout.