### PR TITLE
relay: Fail calls if the dest connection's sendCh is full

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -40,6 +40,7 @@ const _relayTombTTL = 3 * time.Second
 
 var (
 	errRelayMethodFragmented = NewSystemError(ErrCodeBadRequest, "relay handler cannot receive fragmented calls")
+	errFrameNotSent          = NewSystemError(ErrCodeNetwork, "frame was not sent to remote side")
 	errUnknownID             = errors.New("non-callReq for inactive ID")
 )
 
@@ -219,7 +220,8 @@ func (r *Relayer) Relay(f *Frame) error {
 }
 
 // Receive receives frames intended for this connection.
-func (r *Relayer) Receive(f *Frame, fType frameType) {
+// It returns whether the frame was sent and a reason for failure if it failed.
+func (r *Relayer) Receive(f *Frame, fType frameType) (sent bool, failureReason string) {
 	id := f.Header.ID
 
 	// If we receive a response frame, we expect to find that ID in our outbound.
@@ -231,7 +233,7 @@ func (r *Relayer) Receive(f *Frame, fType frameType) {
 		r.logger.WithFields(
 			LogField{"id", id},
 		).Warn("Received a frame without a RelayItem.")
-		return
+		return false, "relay-not-found"
 	}
 
 	// call res frames don't include the OK bit, so we can't wait until the last
@@ -250,14 +252,25 @@ func (r *Relayer) Receive(f *Frame, fType frameType) {
 	// may be released to the frame pool at any point.
 	finished := finishesCall(f)
 
-	// TODO: Add some sort of timeout here to avoid blocking forever on a
-	// stalled connection.
-	r.conn.sendCh <- f
+	select {
+	case r.conn.sendCh <- f:
+	default:
+		// Buffer is full, so drop this frame and cancel the call.
+		r.logger.WithFields(
+			LogField{"id", id},
+		).Warn("Dropping call due to slow connection to destination.")
+
+		items := r.receiverItems(fType)
+		r.failRelayItem(items, id, "relay-dest-conn-slow")
+		return false, "relay-dest-conn-slow"
+	}
 
 	if finished {
 		items := r.receiverItems(fType)
 		r.finishRelayItem(items, id)
 	}
+
+	return true, ""
 }
 
 func (r *Relayer) canHandleNewCall() (bool, connectionState) {
@@ -363,6 +376,7 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 		return err
 	}
 
+	origID := f.Header.ID
 	destinationID := remoteConn.NextMessageID()
 	ttl := f.TTL()
 	span := f.Span()
@@ -371,7 +385,12 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 	relayToDest := r.addRelayItem(true /* isOriginator */, f.Header.ID, destinationID, remoteConn.relay, ttl, span, callStats)
 
 	f.Header.ID = destinationID
-	relayToDest.destination.Receive(f.Frame, requestFrame)
+	sent, failure := relayToDest.destination.Receive(f.Frame, requestFrame)
+	if !sent {
+		r.failRelayItem(r.outbound, origID, failure)
+		return nil
+	}
+
 	return nil
 }
 
@@ -401,7 +420,11 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	// Once we call Receive on the frame, we lose ownership of the frame.
 	finished := finishesCall(f)
 
-	item.destination.Receive(f, frameType)
+	sent, failure := item.destination.Receive(f, frameType)
+	if !sent {
+		r.failRelayItem(items, originalID, failure)
+		return nil
+	}
 
 	if finished {
 		r.finishRelayItem(items, originalID)
@@ -435,6 +458,22 @@ func (r *Relayer) timeoutRelayItem(isOriginator bool, items *relayItems, id uint
 	if isOriginator {
 		r.conn.SendSystemError(id, item.span, ErrTimeout)
 		item.stats.Failed("timeout")
+		item.stats.End()
+	}
+
+	r.decrementPending()
+}
+
+func (r *Relayer) failRelayItem(items *relayItems, id uint32, failure string) {
+	// Entomb it so that we don't get unknown exchange errors for further calls
+	// to this relay item.
+	item, ok := items.Entomb(id, _relayTombTTL)
+	if !ok {
+		return
+	}
+	if item.stats != nil {
+		r.conn.SendSystemError(id, item.span, errFrameNotSent)
+		item.stats.Failed(failure)
 		item.stats.End()
 	}
 

--- a/relay.go
+++ b/relay.go
@@ -465,8 +465,8 @@ func (r *Relayer) timeoutRelayItem(isOriginator bool, items *relayItems, id uint
 }
 
 func (r *Relayer) failRelayItem(items *relayItems, id uint32, failure string) {
-	// Entomb it so that we don't get unknown exchange errors for further calls
-	// to this relay item.
+	// Entomb it so that we don't get unknown exchange errors on further frames
+	// for this call.
 	item, ok := items.Entomb(id, _relayTombTTL)
 	if !ok {
 		return

--- a/relay_test.go
+++ b/relay_test.go
@@ -607,7 +607,7 @@ func TestRelayStalledConnection(t *testing.T) {
 		}
 		ts.Register(HandlerFunc(stallHandler), "echo")
 
-		ctx, cancel := NewContext(time.Second)
+		ctx, cancel := NewContext(testutils.Timeout(300 * time.Millisecond))
 		defer cancel()
 
 		client := ts.NewClient(nil)
@@ -645,7 +645,7 @@ func TestRelayStalledConnection(t *testing.T) {
 		// trying to read arguments till the timeout.
 		select {
 		case <-stallComplete:
-		case <-time.After(time.Second):
+		case <-time.After(testutils.Timeout(300 * time.Millisecond)):
 			t.Fatalf("Stall handler did not complete")
 		}
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -22,6 +22,7 @@ package tchannel_test
 
 import (
 	"errors"
+	"io"
 	"runtime"
 	"strings"
 	"sync"
@@ -35,6 +36,7 @@ import (
 	"github.com/uber/tchannel-go/relay"
 	"github.com/uber/tchannel-go/relay/relaytest"
 	"github.com/uber/tchannel-go/testutils"
+	"github.com/uber/tchannel-go/testutils/testreader"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -580,6 +582,78 @@ func TestRelayRateLimitDrop(t *testing.T) {
 		calls.Add(client.PeerInfo().ServiceName, ts.ServiceName(), "echo").
 			SetPeer(droppedPeer).
 			Failed("relay-dropped").End()
+		ts.AssertRelayStats(calls)
+	})
+}
+
+// Test that a stalled connection to a single server does not block all calls
+// from that server, and we have stats to capture that this is happening.
+func TestRelayStalledConnection(t *testing.T) {
+	opts := testutils.NewOpts().
+		DisableLogVerification(). // we expect warnings due to removed relay item.
+		SetSendBufferSize(10).    // We want to hit the buffer size earlier.
+		SetServiceName("s1").
+		SetRelayOnly()
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		s2 := ts.NewServer(testutils.NewOpts().SetServiceName("s2"))
+		testutils.RegisterEcho(s2, nil)
+
+		stall := make(chan struct{})
+		stallComplete := make(chan struct{})
+		stallHandler := func(ctx context.Context, call *InboundCall) {
+			<-stall
+			raw.ReadArgs(call)
+			close(stallComplete)
+		}
+		ts.Register(HandlerFunc(stallHandler), "echo")
+
+		ctx, cancel := NewContext(time.Second)
+		defer cancel()
+
+		client := ts.NewClient(nil)
+		call, err := client.BeginCall(ctx, ts.HostPort(), ts.ServiceName(), "echo", nil)
+		require.NoError(t, err, "BeginCall failed")
+		writer, err := call.Arg2Writer()
+		require.NoError(t, err, "Arg2Writer failed")
+		go io.Copy(writer, testreader.Looper([]byte("test")))
+
+		// Try to read the response which might get an error.
+		readDone := make(chan struct{})
+		go func() {
+			defer close(readDone)
+
+			_, err := call.Response().Arg2Reader()
+			if assert.Error(t, err, "Expected error while reading") {
+				assert.Contains(t, err.Error(), "frame was not sent to remote side")
+			}
+		}()
+
+		// Wait for the reader to error out.
+		select {
+		case <-time.After(testutils.Timeout(10 * time.Second)):
+			t.Fatalf("Test timed out waiting for reader to fail")
+		case <-readDone:
+			cancel()
+			close(stall)
+		}
+
+		// We should be able to make calls to s2 even if s1 is stalled.
+		testutils.AssertEcho(t, client, ts.HostPort(), "s2")
+
+		// The server channel will not close until the stall handler receives
+		// an error. Since we don't propagate cancels, the handler will keep
+		// trying to read arguments till the timeout.
+		select {
+		case <-stallComplete:
+		case <-time.After(time.Second):
+			t.Fatalf("Stall handler did not complete")
+		}
+
+		calls := relaytest.NewMockStats()
+		calls.Add(client.PeerInfo().ServiceName, ts.ServiceName(), "echo").
+			Failed("relay-dest-conn-slow").End()
+		calls.Add(client.PeerInfo().ServiceName, "s2", "echo").
+			Succeeded().End()
 		ts.AssertRelayStats(calls)
 	})
 }

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -125,6 +125,12 @@ func (o *ChannelOpts) SetProcessPrefixes(prefixes ...string) *ChannelOpts {
 	return o
 }
 
+// SetSendBufferSize sets the SendBufferSize in DefaultConnectionOptions.
+func (o *ChannelOpts) SetSendBufferSize(bufSize int) *ChannelOpts {
+	o.DefaultConnectionOptions.SendBufferSize = bufSize
+	return o
+}
+
 // SetTimeNow sets TimeNow in ChannelOptions.
 func (o *ChannelOpts) SetTimeNow(timeNow func() time.Time) *ChannelOpts {
 	o.TimeNow = timeNow


### PR DESCRIPTION
The current behaviour tries to write the frame to sendCh forever, which
can cause issues if the connection is stalled. The current behaviour
with a stalled connection would be:
- S1 calls S2, S2's connection gets stalled (bug in S2, or TCP issue)
- Relay reads from S1's connection, and in the same goroutine tries to
  write it to S2's sendCh
- If the connection is stalled, the write would not make any progress.
- All calls from S1 on that connection are now "stuck" behind the
  stalled connection. The relay would not even see frames (hence no
  stats would be incremented), and no progress would be made till the
  connection was killed.

Instead of trying to write to sendCh forever, we should fail the call
immediately if sendCh is at capacity. Instead of the server timing out,
they will instead see an error from the relay and we'll have stats on
the relay side to detect this.