### PR TITLE
Clamp relay timeouts to a configurable max

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -90,10 +90,11 @@ func TestRelayMaxTTL(t *testing.T) {
 		expected time.Duration
 	}{
 		{time.Second, time.Second},
-		{-time.Second, defaultRelayMaxTimeout},
-		{0, defaultRelayMaxTimeout},
+		{-time.Second, _defaultRelayMaxTimeout},
+		{0, _defaultRelayMaxTimeout},
+		{time.Microsecond, _defaultRelayMaxTimeout},
 		{math.MaxUint32 * time.Millisecond, math.MaxUint32 * time.Millisecond},
-		{(math.MaxUint32 + 1) * time.Millisecond, defaultRelayMaxTimeout},
+		{(math.MaxUint32 + 1) * time.Millisecond, _defaultRelayMaxTimeout},
 	}
 
 	for _, tt := range tests {

--- a/relay.go
+++ b/relay.go
@@ -592,7 +592,7 @@ func determinesCallSuccess(f *Frame) (succeeded bool, failMsg string) {
 
 func validateRelayMaxTimeout(d time.Duration, logger Logger) time.Duration {
 	maxMillis := d / time.Millisecond
-	if maxMillis >= 1 && maxMillis <= math.MaxUint32 {
+	if maxMillis > 0 && maxMillis <= math.MaxUint32 {
 		return d
 	}
 	if d == 0 {

--- a/relay.go
+++ b/relay.go
@@ -384,16 +384,7 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 	ttl := f.TTL()
 	if ttl > r.maxTimeout {
 		ttl = r.maxTimeout
-		if err := f.SetTTL(r.maxTimeout); err != nil {
-			originalTTL := f.TTL()
-			r.logger.WithFields(
-				ErrField(err),
-				LogField{"maxTTL", r.maxTimeout},
-				LogField{"originalTTL", originalTTL},
-			).Warn("Failed to clamp callreq TTL to max.")
-			// The max TTL is misconfigured, don't use it.
-			ttl = originalTTL
-		}
+		f.SetTTL(r.maxTimeout)
 	}
 	span := f.Span()
 	// The remote side of the relay doesn't need to track stats.

--- a/relay.go
+++ b/relay.go
@@ -384,6 +384,16 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 	ttl := f.TTL()
 	if ttl > r.maxTimeout {
 		ttl = r.maxTimeout
+		if err := f.SetTTL(r.maxTimeout); err != nil {
+			originalTTL := f.TTL()
+			r.logger.WithFields(
+				ErrField(err),
+				LogField{"maxTTL", r.maxTimeout},
+				LogField{"originalTTL", originalTTL},
+			).Warn("Failed to clamp callreq TTL to max.")
+			// The max TTL is misconfigured, don't use it.
+			ttl = originalTTL
+		}
 	}
 	span := f.Span()
 	// The remote side of the relay doesn't need to track stats.

--- a/relay.go
+++ b/relay.go
@@ -31,12 +31,13 @@ import (
 	"github.com/uber-go/atomic"
 )
 
-// _maxRelayTombs is the maximum number of tombs we'll accumulate in a single
-// relayItems.
-const _maxRelayTombs = 3e4
-
-// _relayTombTTL is the length of time we'll keep a tomb before GC'ing it.
-const _relayTombTTL = 3 * time.Second
+const (
+	// _maxRelayTombs is the maximum number of tombs we'll accumulate in a
+	// single relayItems.
+	_maxRelayTombs = 3e4
+	// _relayTombTTL is the length of time we'll keep a tomb before GC'ing it.
+	_relayTombTTL = 3 * time.Second
+)
 
 var (
 	errRelayMethodFragmented = NewSystemError(ErrCodeBadRequest, "relay handler cannot receive fragmented calls")

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -23,9 +23,7 @@ package tchannel
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
-	"math"
 	"time"
 )
 
@@ -33,9 +31,6 @@ var (
 	_callerNameKeyBytes      = []byte(CallerName)
 	_routingDelegateKeyBytes = []byte(RoutingDelegate)
 	_routingKeyKeyBytes      = []byte(RoutingKey)
-
-	errTTLNegative = errors.New("can't set a negative TTL")
-	errTTLOverflow = errors.New("TTL overflows uint32")
 )
 
 const (
@@ -172,17 +167,10 @@ func (f lazyCallReq) TTL() time.Duration {
 	return time.Duration(ttl) * time.Millisecond
 }
 
-func (f lazyCallReq) SetTTL(d time.Duration) error {
-	if d < 0 {
-		return errTTLNegative
-	}
-	millis := d / time.Millisecond
-	if millis > math.MaxUint32 {
-		return errTTLOverflow
-	}
-	ttl := uint32(millis)
+// SetTTL overwrites the frame's TTL.
+func (f lazyCallReq) SetTTL(d time.Duration) {
+	ttl := uint32(d / time.Millisecond)
 	binary.BigEndian.PutUint32(f.Payload[_ttlIndex:_ttlIndex+_ttlLen], ttl)
-	return nil
 }
 
 // Span returns the Span

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -21,14 +21,12 @@
 package tchannel
 
 import (
-	"math"
 	"testing"
 	"time"
 
 	"github.com/uber/tchannel-go/typed"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type testCallReq int
@@ -269,18 +267,8 @@ func TestLazyCallReqTTL(t *testing.T) {
 func TestLazyCallReqSetTTL(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
 		cr := crt.req()
-		require.NoError(t, cr.SetTTL(time.Second), "Unexpected error setting TTL.")
+		cr.SetTTL(time.Second)
 		assert.Equal(t, time.Second, cr.TTL(), "Failed to write TTL to frame.")
-	})
-}
-
-func TestLazyCallReqSetInvalidTTL(t *testing.T) {
-	tooBig := time.Duration(math.MaxUint32+1) * time.Millisecond
-	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
-		require.Error(t, cr.SetTTL(-1*time.Second), "Expected setting a negative TTL to be an error.")
-		require.Error(t, cr.SetTTL(tooBig), "Expected error when setting a TTL that overflows uint32.")
-		assert.Equal(t, 42*time.Millisecond, cr.TTL(), "Expected erroneous SetTTL calls to leave TTL unchanged.")
 	})
 }
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -375,8 +375,8 @@ func TestLargeTimeoutsAreClamped(t *testing.T) {
 		}()
 
 		select {
-		case <-time.After(testutils.Timeout(100 * time.Millisecond)):
-			t.Fatal("Failed to clamp timeout to 1ms.")
+		case <-time.After(testutils.Timeout(10 * clampTTL)):
+			t.Fatal("Failed to clamp timeout.")
 		case <-ctx.Done():
 		}
 	})

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -194,6 +194,12 @@ func (o *ChannelOpts) SetRelayLocal(relayLocal ...string) *ChannelOpts {
 	return o
 }
 
+// SetRelayMaxTimeout sets the maximum allowable timeout for relayed calls.
+func (o *ChannelOpts) SetRelayMaxTimeout(d time.Duration) *ChannelOpts {
+	o.ChannelOptions.RelayMaxTimeout = d
+	return o
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue


### PR DESCRIPTION
To prevent accumulating an unbounded number of relay items, clamp timeouts to a configurable max. Default to a max of 2 minutes, which matches Hyperbahn's current behavior.

Addresses #529.