### PR TITLE
relay: Avoid allocations on errors from relay

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -125,6 +125,31 @@ func (c SystemErrCode) MetricsKey() string {
 	}
 }
 
+func (c SystemErrCode) relayMetricsKey() string {
+	switch c {
+	case ErrCodeInvalid:
+		return "relay-invalid"
+	case ErrCodeTimeout:
+		return "relay-timeout"
+	case ErrCodeCancelled:
+		return "relay-cancelled"
+	case ErrCodeBusy:
+		return "relay-busy"
+	case ErrCodeDeclined:
+		return "relay-declined"
+	case ErrCodeUnexpected:
+		return "relay-unexpected-error"
+	case ErrCodeBadRequest:
+		return "relay-bad-request"
+	case ErrCodeNetwork:
+		return "relay-network-error"
+	case ErrCodeProtocol:
+		return "relay-protocol-error"
+	default:
+		return "relay-" + c.String()
+	}
+}
+
 // A SystemError is a system-level error, containing an error code and message
 // TODO(mmihic): Probably we want to hide this interface, and let application code
 // just deal with standard raw errors.

--- a/errors_test.go
+++ b/errors_test.go
@@ -66,3 +66,10 @@ func TestSystemError(t *testing.T) {
 	code := GetSystemErrorCode(ErrTimeout)
 	assert.Equal(t, ErrCodeTimeout, code, "tchannel timeout error produces ErrCodeTimeout")
 }
+
+func TestRelayMetricsKey(t *testing.T) {
+	for i := 0; i <= 256; i++ {
+		code := SystemErrCode(i)
+		assert.Equal(t, "relay-"+code.MetricsKey(), code.relayMetricsKey(), "Unexpected relay metrics key for %v", code)
+	}
+}

--- a/relay.go
+++ b/relay.go
@@ -304,7 +304,7 @@ func (r *Relayer) getDestination(f lazyCallReq, cs relay.CallStats) (*Connection
 			LogField{"dest", string(f.Service())},
 			LogField{"method", string(f.Method())},
 		).Warn("Received duplicate callReq.")
-		cs.Failed("relay-" + ErrCodeProtocol.MetricsKey())
+		cs.Failed(ErrCodeProtocol.relayMetricsKey())
 		// TODO: this is a protocol error, kill the connection.
 		return nil, false, errors.New("callReq with already active ID")
 	}
@@ -325,7 +325,7 @@ func (r *Relayer) getDestination(f lazyCallReq, cs relay.CallStats) (*Connection
 		if _, ok := err.(SystemError); !ok {
 			err = NewSystemError(ErrCodeDeclined, err.Error())
 		}
-		cs.Failed("relay-" + GetSystemErrorCode(err).MetricsKey())
+		cs.Failed(GetSystemErrorCode(err).relayMetricsKey())
 		r.conn.SendSystemError(f.Header.ID, f.Span(), err)
 		return nil, false, nil
 	}


### PR DESCRIPTION
We currently allocate a string for the relay error reason since we are
concatenating strings in the request path. Instead we can hardcode the
strings and verify in tests that there are no mismatches.