### PR TITLE
testutils: Use tchannel.Registrar instead of *Channel

### DIFF
--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -75,7 +75,7 @@ func NewClientChannel(opts *ChannelOpts) (*tchannel.Channel, error) {
 }
 
 type rawFuncHandler struct {
-	ch *tchannel.Channel
+	ch tchannel.Registrar
 	f  func(context.Context, *raw.Args) (*raw.Res, error)
 }
 
@@ -91,7 +91,7 @@ func (h rawFuncHandler) Handle(ctx context.Context, args *raw.Args) (*raw.Res, e
 }
 
 // RegisterFunc registers a function as a handler for the given method name.
-func RegisterFunc(ch *tchannel.Channel, name string,
+func RegisterFunc(ch tchannel.Registrar, name string,
 	f func(ctx context.Context, args *raw.Args) (*raw.Res, error)) {
 
 	ch.Register(raw.Wrap(rawFuncHandler{ch, f}), name)

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -66,7 +66,7 @@ func AssertEcho(tb testing.TB, src *tchannel.Channel, targetHostPort, targetServ
 
 // RegisterEcho registers an echo endpoint on the given channel. The optional provided
 // function is run before the handler returns.
-func RegisterEcho(src *tchannel.Channel, f func()) {
+func RegisterEcho(src tchannel.Registrar, f func()) {
 	RegisterFunc(src, "echo", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 		if f != nil {
 			f()


### PR DESCRIPTION
This allows a subchannel to be passed to the Register* functions.