### PR TITLE
Always call the Thrift post response callback if the ctx fn is called

### DIFF
--- a/thrift/server.go
+++ b/thrift/server.go
@@ -134,9 +134,7 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 	thriftProtocolPool.Put(wp)
 
 	if handler.postResponseCB != nil {
-		defer func() {
-			handler.postResponseCB(ctx, method, resp)
-		}()
+		defer handler.postResponseCB(ctx, method, resp)
 	}
 
 	if err != nil {

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -133,6 +133,12 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 	success, resp, err := handler.server.Handle(ctx, method, wp.protocol)
 	thriftProtocolPool.Put(wp)
 
+	if handler.postResponseCB != nil {
+		defer func() {
+			handler.postResponseCB(ctx, method, resp)
+		}()
+	}
+
 	if err != nil {
 		if _, ok := err.(thrift.TProtocolException); ok {
 			// We failed to parse the Thrift generated code, so convert the error to bad request.
@@ -168,10 +174,6 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 	resp.Write(wp.protocol)
 	thriftProtocolPool.Put(wp)
 	err = writer.Close()
-
-	if handler.postResponseCB != nil {
-		handler.postResponseCB(ctx, method, resp)
-	}
 
 	return err
 }


### PR DESCRIPTION
cc @prashantv @xichen2020 @martin-mao @cw9

This fixes several small memory leaks for M3DB where the post response callback was not getting called and hence we weren't marking resources as able to be closed and flushed.