### PR TITLE
Use net.DialContext on go1.7 when creating outbound connections

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -456,15 +456,6 @@ func (ch *Channel) ServiceName() string {
 	return ch.PeerInfo().ServiceName
 }
 
-func getTimeout(ctx context.Context) time.Duration {
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		return DefaultConnectTimeout
-	}
-
-	return deadline.Sub(time.Now())
-}
-
 // Connect creates a new outbound connection to hostPort.
 func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, error) {
 	switch state := ch.State(); state {
@@ -493,7 +484,7 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, e
 		return nil, GetContextError(err)
 	}
 
-	c, err := ch.newOutboundConnection(getTimeout(ctx), hostPort, events)
+	c, err := ch.newOutboundConnection(ctx, hostPort, events)
 	if err != nil {
 		return nil, err
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -727,6 +727,10 @@ func TestNetDialTimeout(t *testing.T) {
 }
 
 func TestNetDialCancelContext(t *testing.T) {
+	if runtime.Version() < "go1.7" {
+		t.Skipf("go version is < 1.7")
+	}
+
 	// timeoutHostPort uses a blackholed address (RFC 6890) with a port
 	// reserved for documentation. This address should always cause a timeout.
 	const timeoutHostPort = "192.18.0.254:44444"

--- a/connection_test.go
+++ b/connection_test.go
@@ -726,10 +726,6 @@ func TestNetDialTimeout(t *testing.T) {
 	assert.True(t, d >= timeoutPeriod, "Timeout should take more than %v, took %v", timeoutPeriod, d)
 }
 
-func TestNetDialCancelContext(t *testing.T) {
-	testNetDialCancelContext(t)
-}
-
 func TestConnectTimeout(t *testing.T) {
 	opts := testutils.NewOpts().DisableLogVerification()
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -727,38 +727,7 @@ func TestNetDialTimeout(t *testing.T) {
 }
 
 func TestNetDialCancelContext(t *testing.T) {
-	if runtime.Version() < "go1.7" {
-		t.Skipf("go version is < 1.7")
-	}
-
-	// timeoutHostPort uses a blackholed address (RFC 6890) with a port
-	// reserved for documentation. This address should always cause a timeout.
-	const timeoutHostPort = "192.18.0.254:44444"
-	timeoutPeriod := testutils.Timeout(50 * time.Millisecond)
-
-	client := testutils.NewClient(t, nil)
-	defer client.Close()
-
-	started := time.Now()
-	ctx, cancel := NewContext(time.Minute)
-
-	go func() {
-		time.Sleep(timeoutPeriod)
-		cancel()
-	}()
-
-	err := client.Ping(ctx, timeoutHostPort)
-	if !assert.Error(t, err, "Ping to blackhole address should fail") {
-		return
-	}
-
-	if strings.Contains(err.Error(), "network is unreachable") {
-		t.Skipf("Skipping test, as network interface may not be available")
-	}
-
-	d := time.Since(started)
-	assert.Equal(t, ErrCodeCancelled, GetSystemErrorCode(err), "Ping expected to fail with timeout")
-	assert.True(t, d <= 2*timeoutPeriod, "Timeout should take less than %v, took %v", timeoutPeriod, d)
+	testNetDialCancelContext(t)
 }
 
 func TestConnectTimeout(t *testing.T) {

--- a/dial_16.go
+++ b/dial_16.go
@@ -23,8 +23,9 @@
 package tchannel
 
 import (
-	"context"
 	"net"
+
+	"golang.org/x/net/context"
 )
 
 func dialContext(ctx context.Context, hostPort string) (net.Conn, error) {

--- a/dial_16.go
+++ b/dial_16.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build !go1.7
+
+package tchannel
+
+import (
+	"context"
+	"net"
+)
+
+func dialContext(ctx context.Context, hostPort string) (net.Conn, error) {
+	timeout := getTimeout(ctx)
+	return net.DialTimeout("tcp", hostPort, timeout)
+}

--- a/dial_17.go
+++ b/dial_17.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build go1.7
+
+package tchannel
+
+import (
+	"context"
+	"net"
+)
+
+func dialContext(ctx context.Context, hostPort string) (net.Conn, error) {
+	d := net.Dialer{}
+	return d.DialContext(ctx, "tcp", hostPort)
+}

--- a/dial_17_test.go
+++ b/dial_17_test.go
@@ -60,6 +60,6 @@ func TestNetDialCancelContext(t *testing.T) {
 	}
 
 	d := time.Since(started)
-	assert.Equal(t, ErrCodeCancelled, GetSystemErrorCode(err), "Ping expected to fail with timeout")
-	assert.True(t, d <= 2*timeoutPeriod, "Timeout should take less than %v, took %v", timeoutPeriod, d)
+	assert.Equal(t, ErrCodeCancelled, GetSystemErrorCode(err), "Ping expected to fail with context cancelled")
+	assert.True(t, d < 2*timeoutPeriod, "Timeout should take less than %v, took %v", 2*timeoutPeriod, d)
 }

--- a/dial_17_test.go
+++ b/dial_17_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build go1.7
+
+package tchannel_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/uber/tchannel-go"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+func testNetDialCancelContext(t *testing.T) {
+	// timeoutHostPort uses a blackholed address (RFC 6890) with a port
+	// reserved for documentation. This address should always cause a timeout.
+	const timeoutHostPort = "192.18.0.254:44444"
+	timeoutPeriod := testutils.Timeout(50 * time.Millisecond)
+
+	client := testutils.NewClient(t, nil)
+	defer client.Close()
+
+	started := time.Now()
+	ctx, cancel := NewContext(time.Minute)
+
+	go func() {
+		time.Sleep(timeoutPeriod)
+		cancel()
+	}()
+
+	err := client.Ping(ctx, timeoutHostPort)
+	if !assert.Error(t, err, "Ping to blackhole address should fail") {
+		return
+	}
+
+	if strings.Contains(err.Error(), "network is unreachable") {
+		t.Skipf("Skipping test, as network interface may not be available")
+	}
+
+	d := time.Since(started)
+	assert.Equal(t, ErrCodeCancelled, GetSystemErrorCode(err), "Ping expected to fail with timeout")
+	assert.True(t, d <= 2*timeoutPeriod, "Timeout should take less than %v, took %v", timeoutPeriod, d)
+}

--- a/dial_17_test.go
+++ b/dial_17_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/uber/tchannel-go/testutils"
 )
 
-func testNetDialCancelContext(t *testing.T) {
+func TestNetDialCancelContext(t *testing.T) {
 	// timeoutHostPort uses a blackholed address (RFC 6890) with a port
 	// reserved for documentation. This address should always cause a timeout.
 	const timeoutHostPort = "192.18.0.254:44444"

--- a/errors.go
+++ b/errors.go
@@ -95,6 +95,8 @@ var (
 
 	// ErrMethodTooLarge is a SystemError indicating that the method is too large.
 	ErrMethodTooLarge = NewSystemError(ErrCodeProtocol, "method too large")
+
+	errDialCancelled = NewSystemError(ErrCodeCancelled, "dial cancelled")
 )
 
 // MetricsKey is a string representation of the error code that's suitable for


### PR DESCRIPTION
Fixes #540 