### PR TITLE
relay: Don't attempt concurrent connections to the same peer

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -729,11 +729,11 @@ func TestRelayConcurrentNewConnectionAttempts(t *testing.T) {
 		defer slowServer.Close()
 		testutils.RegisterEcho(slowServer, nil)
 
-		var delayed bool
+		var delayed atomic.Bool
 		relayFunc := func(outgoing bool, f *Frame) *Frame {
-			if !delayed {
+			if !delayed.Load() {
 				time.Sleep(testutils.Timeout(50 * time.Millisecond))
-				delayed = true
+				delayed.Store(true)
 			}
 			return f
 		}


### PR DESCRIPTION
We avoid concurrent connections on peer.GetConnection, but the relay
path was missing the same checks.

Related PR: https://github.com/uber/tchannel-go/pull/500