### PR TITLE
Reduce flakiness in TestRelayConcurrentCalls

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -375,7 +375,7 @@ func TestLargeTimeoutsAreClamped(t *testing.T) {
 	})
 }
 
-// TestRelayStress makes many concurrent calls and ensures that
+// TestRelayConcurrentCalls makes many concurrent calls and ensures that
 // we don't try to reuse any frames once they've been released.
 func TestRelayConcurrentCalls(t *testing.T) {
 	pool := NewProtectMemFramePool()
@@ -390,7 +390,8 @@ func TestRelayConcurrentCalls(t *testing.T) {
 
 		client := benchmark.NewClient([]string{ts.HostPort()},
 			benchmark.WithNoDurations(),
-			benchmark.WithNoLibrary(),
+			// TODO(prashant): Enable once we have control over concurrency with NoLibrary.
+			// benchmark.WithNoLibrary(),
 			benchmark.WithNumClients(20),
 			benchmark.WithServiceName("s1"),
 			benchmark.WithTimeout(time.Minute),


### PR DESCRIPTION
TestRelayConcurrentCalls used the no-library benchmark client which
does not limit concurrency and makes all calls at once. Since we have
numClients = 20, combined with 1000 calls, we essentially make 20,000
calls at once to a single server. The server isn't able to keep up which
could lead to stalling the connection, causing the following log:
"Dropping call due to slow connection to destination."

We should provide a way to control the concurrency limits on the client
side. For now, use the normal client which limits to a single concurrent
call per client.

This will lead to ~20 concurrent calls at any time which should avoid
the test flaking out.

See related issue: https://github.com/uber/tchannel-go/issues/531

cc @akshayjshah 