### PR TITLE
Coalesce timers to improve relay performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: go
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 PATH := $(GOPATH)/bin:$(PATH)
 EXAMPLES=./examples/bench/server ./examples/bench/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server
 ALL_PKGS := $(shell glide nv)
-PROD_PKGS := . ./http ./hyperbahn ./json ./pprof ./raw ./relay ./stats ./thrift $(EXAMPLES)
+PROD_PKGS := . ./http ./hyperbahn ./json ./pprof ./raw ./relay ./stats ./thrift ./timers $(EXAMPLES)
 TEST_ARG ?= -race -v -timeout 5m
 BUILD := ./build
 THRIFT_GEN_RELEASE := ./thrift-gen-release

--- a/all_channels_test.go
+++ b/all_channels_test.go
@@ -18,13 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tchannel
+package tchannel_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	. "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/testutils"
 )
 
 func TestAllChannelsRegistered(t *testing.T) {
@@ -42,6 +46,8 @@ func TestAllChannelsRegistered(t *testing.T) {
 	assert.Equal(t, 1, len(state.OtherChannels["ch2"]))
 
 	ch1_2.Close()
+	// TODO: replace this sleep with a callback hook.
+	time.Sleep(testutils.Timeout(10 * time.Millisecond))
 
 	state = ch1_1.IntrospectState(introspectOpts)
 	assert.Equal(t, 0, len(state.OtherChannels["ch1"]))
@@ -57,6 +63,8 @@ func TestAllChannelsRegistered(t *testing.T) {
 	ch1_1.Close()
 	ch2_1.Close()
 	ch2_2.Close()
+	// TODO: replace this sleep with a callback hook.
+	time.Sleep(testutils.Timeout(10 * time.Millisecond))
 
 	state = ch1_1.IntrospectState(introspectOpts)
 	assert.Equal(t, 0, len(state.OtherChannels["ch1"]))

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 111bdf9797d23d4b9f8833a9780e382dd53153af70ad286f99815cea4c2fdf4b
-updated: 2016-08-05T18:02:17.171302481-04:00
+hash: 0b26263b5124a201a903d6f8e280d96322c6ee8cc7ec7c8ce04eb1da70593120
+updated: 2016-12-08T08:54:17.949295355-08:00
 imports:
+- name: github.com/andres-erbsen/clock
+  version: 9e14626cd129ba01ccb6806bcca9d523e570aaf0
 - name: github.com/apache/thrift
-  version: 0e9fed1e12ed066865e46c6903782b2ef95f4650
+  version: 59cb6661bcee265d39ad524154472ebe27760f1e
   subpackages:
   - lib/go/thrift
 - name: github.com/bmizerany/perks
@@ -10,24 +12,25 @@ imports:
   subpackages:
   - quantile
 - name: github.com/cactus/go-statsd-client
-  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
+  version: 1c27c506c7a0584d017ca479f91b88d6a6538332
   subpackages:
   - statsd
 - name: github.com/crossdock/crossdock-go
-  version: 228792ab861c86f8900b2db0439577feef9ec9d8
+  version: 049aabb0122b03bc9bd30cab8f3f91fb60166361
   subpackages:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/jessevdk/go-flags
-  version: f2785f5820ec967043de79c8be97edfc464ca745
+  version: 8bc97d602c3bfeb5fc6fc9b5a9c898f245495637
 - name: github.com/opentracing/opentracing-go
-  version: 855519783f479520497c6b3445611b05fc42f009
+  version: ac5446f53f2c0fc68dc16dc5f426eae1cd288b34
   subpackages:
   - ext
+  - log
   - mocktracer
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
@@ -44,26 +47,27 @@ imports:
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert
   - mock
   - require
 - name: github.com/uber-go/atomic
-  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/jaeger-client-go
-  version: 9342cec8070f1d9bbf56f8df1d7a885ed8cb015d
+  version: aecd4675e3cd24416b145364a9262e505d592f59
   subpackages:
+  - internal/spanlog
+  - thrift-gen/agent
   - thrift-gen/sampling
   - thrift-gen/zipkincore
   - transport
   - utils
-  - thrift-gen/agent
 - name: golang.org/x/net
-  version: b400c2eff1badec7022a8c8f5bea058b6315eed7
+  version: 944c58e9d57bcecf171fd4bea155269aa8a96805
   subpackages:
   - context
   - context/ctxhttp
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
-devImports: []
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -47,3 +47,4 @@ import:
 - package: github.com/opentracing/opentracing-go
 - package: github.com/uber/jaeger-client-go
 - package: github.com/crossdock/crossdock-go
+- package: github.com/andres-erbsen/clock

--- a/introspection.go
+++ b/introspection.go
@@ -156,6 +156,7 @@ type RelayerRuntimeState struct {
 	InboundItems  RelayItemSetState `json:"inboundItems"`
 	OutboundItems RelayItemSetState `json:"outboundItems"`
 	MaxTimeout    time.Duration     `json:"maxTimeout"`
+	TimeoutTick   time.Duration     `json:"timeoutTick"`
 }
 
 // ExchangeSetRuntimeState is the runtime state for a message exchange set.
@@ -360,6 +361,7 @@ func (r *Relayer) IntrospectState(opts *IntrospectionOptions) RelayerRuntimeStat
 		InboundItems:  r.inbound.IntrospectState(opts, "inbound"),
 		OutboundItems: r.outbound.IntrospectState(opts, "outbound"),
 		MaxTimeout:    r.maxTimeout,
+		TimeoutTick:   r.timeoutTick,
 	}
 }
 

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -193,6 +193,12 @@ func (o *ChannelOpts) SetRelayMaxTimeout(d time.Duration) *ChannelOpts {
 	return o
 }
 
+// SetRelayTimeoutTick sets the coarseness of relay timeouts.
+func (o *ChannelOpts) SetRelayTimeoutTick(d time.Duration) *ChannelOpts {
+	o.ChannelOptions.RelayTimeoutTick = d
+	return o
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue

--- a/timers/timers.go
+++ b/timers/timers.go
@@ -1,0 +1,242 @@
+// Package timers provides a timer facility similar to the standard library's.
+// It's designed to be faster, but less accurate.
+package timers
+
+import (
+	"math"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/andres-erbsen/clock"
+	"github.com/uber-go/atomic"
+)
+
+const cacheline = 64
+
+const (
+	// State machine for timers.
+	stateScheduled = iota
+	stateExpired
+	stateCanceled
+)
+
+// A Timer is a handle to a deferred operation.
+type Timer struct {
+	f        func()
+	deadline uint64 // in ticks
+	state    atomic.Int32
+	next     *Timer
+	tail     *Timer // only set on head (TODO: move to bucket)
+}
+
+func newTimer(deadline uint64, f func()) *Timer {
+	t := &Timer{
+		f:        f,
+		deadline: deadline,
+	}
+	t.tail = t
+	return t
+}
+
+// Stop cancels the deferred operation. It returns whether or not the
+// cancellation succeeded.
+func (t *Timer) Stop() bool {
+	return t.state.CAS(stateScheduled, stateCanceled)
+}
+
+func (t *Timer) expire() bool {
+	return t.state.CAS(stateScheduled, stateExpired)
+}
+
+func (t *Timer) pushOne(head *Timer) *Timer {
+	head.next = t
+	if t == nil {
+		head.tail = head
+	} else {
+		head.tail = t.tail
+		t.tail = nil
+	}
+	return head
+}
+
+func (t *Timer) push(head *Timer) *Timer {
+	if head == nil {
+		return t
+	}
+	if t == nil {
+		return head
+	}
+	head.tail.next = t
+	head.tail = t.tail
+	t.tail = nil
+	return head
+}
+
+type bucket struct {
+	sync.Mutex
+	timers *Timer
+	// Avoid false sharing:
+	// http://mechanical-sympathy.blogspot.com/2011/07/false-sharing.html
+	_ [cacheline - unsafe.Sizeof(sync.Mutex{}) - unsafe.Sizeof(&Timer{})]byte
+}
+
+type bucketList struct {
+	mask    uint64
+	buckets []bucket
+}
+
+func (bs *bucketList) Schedule(deadline uint64, f func()) *Timer {
+	t := newTimer(deadline, f)
+	b := &bs.buckets[deadline&bs.mask]
+	b.Lock()
+	b.timers = b.timers.pushOne(t)
+	b.Unlock()
+	return t
+}
+
+func (bs *bucketList) Clear() {
+	for i := range bs.buckets {
+		b := &bs.buckets[i]
+		b.Lock()
+		b.timers = nil
+		b.Unlock()
+	}
+}
+
+func (bs *bucketList) GatherExpired(start, end, now uint64) *Timer {
+	// If we're more than a full rotation behind, only inspect each bucket
+	// once.
+	if (end-start == math.MaxUint64) || (int(end-start+1) > len(bs.buckets)) {
+		start, end = 0, uint64(len(bs.buckets))
+	}
+
+	var todo *Timer
+	for tick := start; tick < end; tick++ {
+		todo = bs.gatherBucket(tick, now, todo)
+	}
+	return todo
+}
+
+func (bs *bucketList) gatherBucket(tick, now uint64, todo *Timer) *Timer {
+	b := &bs.buckets[tick&bs.mask]
+
+	b.Lock()
+	batch := b.timers
+	b.timers = nil
+	b.Unlock()
+
+	var unexpired *Timer
+	for batch != nil {
+		next := batch.next
+		if batch.deadline > now {
+			unexpired = unexpired.pushOne(batch)
+		} else if batch.expire() {
+			todo = todo.pushOne(batch)
+		}
+		batch = next
+	}
+	if unexpired != nil {
+		// We should only hit this case if we're a full wheel rotation
+		// behind.
+		b.Lock()
+		b.timers = b.timers.push(unexpired)
+		b.Unlock()
+	}
+	return todo
+}
+
+// A Wheel schedules and executes deferred operations.
+type Wheel struct {
+	clock     clock.Clock
+	periodExp uint64
+	ticker    *clock.Ticker
+	buckets   bucketList
+	stopOnce  sync.Once
+	stop      chan struct{}
+	stopped   chan struct{}
+}
+
+// NewWheel creates and starts a new Wheel.
+func NewWheel(period, maxTimeout time.Duration) *Wheel {
+	w := newWheel(period, maxTimeout, clock.New())
+	w.start()
+	return w
+}
+
+func newWheel(period, maxTimeout time.Duration, clock clock.Clock) *Wheel {
+	tickNanos, power := nextPowerOfTwo(int64(period)/2 + 1)
+	numBuckets, _ := nextPowerOfTwo(int64(maxTimeout) / tickNanos)
+	w := &Wheel{
+		clock:     clock,
+		periodExp: power,
+		ticker:    clock.Ticker(time.Duration(tickNanos)),
+		buckets: bucketList{
+			mask:    uint64(numBuckets - 1),
+			buckets: make([]bucket, numBuckets),
+		},
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	return w
+}
+
+// Stop shuts down the wheel, blocking until all the background goroutines
+// complete. It then clears all remaining timers, without firing any of their
+// associated callbacks.
+//
+// Stop is safe to call multiple times; calls after the first are no-ops.
+func (w *Wheel) Stop() {
+	// TChannel Channels are safe to close more than once, so wheels should be
+	// too.
+	w.stopOnce.Do(func() {
+		w.ticker.Stop()
+		close(w.stop)
+		<-w.stopped
+		w.buckets.Clear()
+	})
+}
+
+// AfterFunc schedules a deferred operation and returns a Timer.
+func (w *Wheel) AfterFunc(d time.Duration, f func()) *Timer {
+	deadline := w.asTick(w.clock.Now().Add(d))
+	return w.buckets.Schedule(deadline, f)
+}
+
+func (w *Wheel) start() {
+	go w.tick(w.clock.Now(), w.ticker.C)
+}
+
+func (w *Wheel) tick(now time.Time, nowCh <-chan time.Time) {
+	watermark := w.asTick(now)
+	for {
+		select {
+		case now := <-nowCh:
+			nowTick := w.asTick(now)
+			todo := w.buckets.GatherExpired(watermark, nowTick, nowTick)
+			w.fire(todo)
+			watermark = nowTick
+		case <-w.stop:
+			close(w.stopped)
+			return
+		}
+	}
+}
+
+func (w *Wheel) fire(batch *Timer) {
+	for t := batch; t != nil; t = t.next {
+		t.f()
+	}
+}
+
+func (w *Wheel) asTick(t time.Time) uint64 {
+	return uint64(t.UnixNano() >> w.periodExp)
+}
+
+func nextPowerOfTwo(n int64) (num int64, exponent uint64) {
+	pow := uint64(0)
+	for (1 << pow) < n {
+		pow++
+	}
+	return 1 << pow, pow
+}

--- a/timers/timers_test.go
+++ b/timers/timers_test.go
@@ -1,0 +1,443 @@
+package timers
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/andres-erbsen/clock"
+	"github.com/stretchr/testify/assert"
+)
+
+// O(n), only for use in tests.
+func (t *Timer) len() int {
+	n := 0
+	for el := t; el != nil; el = el.next {
+		n++
+	}
+	return n
+}
+
+func assertListWellFormed(t testing.TB, list *Timer, expectedLen int) {
+	if expectedLen == 0 {
+		assert.Nil(t, list, "Expected zero-length list to be nil.")
+		return
+	}
+	var (
+		last   *Timer
+		length int
+	)
+	head := list
+	seen := make(map[*Timer]struct{})
+	for el := list; el != nil; el = el.next {
+		if _, ok := seen[el]; ok {
+			t.Fatalf("Detected cycle in linked list with repeated element: %+v", *el)
+		}
+		seen[el] = struct{}{}
+		if el != head {
+			assert.Nil(t, el.tail, "Only head should have a tail set.")
+		}
+		last = el
+		length++
+	}
+	assert.Equal(t, head.tail, last, "Expected list tail to point to last element.")
+	assert.Equal(t, expectedLen, length, "Unexpected list length.")
+}
+
+func fakeWheel(tick time.Duration) (*Wheel, *clock.Mock) {
+	clock := clock.NewMock()
+	w := newWheel(tick, 2*time.Minute, clock)
+	w.start()
+	return w, clock
+}
+
+func newBucketList() *bucketList {
+	return &bucketList{
+		mask:    uint64(1<<3 - 1),
+		buckets: make([]bucket, 1<<3),
+	}
+}
+
+func assertQueuedTimers(t testing.TB, bs *bucketList, bucketIdx, expected int) {
+	b := &bs.buckets[bucketIdx]
+	b.Lock()
+	defer b.Unlock()
+	assert.Equal(
+		t,
+		expected,
+		b.timers.len(),
+		"Unexpected number of counters in bucket %v.", bucketIdx,
+	)
+}
+
+func fakeWork() {} // non-nil func to schedule
+
+func randomTimeouts(n int, max time.Duration) []time.Duration {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	ds := make([]time.Duration, n)
+	for i := 0; i < n; i++ {
+		ds[i] = time.Duration(r.Int63n(int64(max)))
+	}
+	return ds
+}
+
+func TestTimersLinkedListPushOneNils(t *testing.T) {
+	var root *Timer
+	head := newTimer(0, nil)
+	root = root.pushOne(head)
+	assertListWellFormed(t, root, 1)
+	assert.Equal(t, head, root, "Expected pushOne with nil receiver to return head.")
+	assert.Panics(t, func() { root.pushOne(nil) }, "Expected pushOne'ing a nil to panic.")
+}
+
+func TestTimersLinkedListPushNils(t *testing.T) {
+	// nil receiver & head
+	var root *Timer
+	assertListWellFormed(t, root.push(nil), 0)
+
+	// nil receiver
+	head := newTimer(0, nil)
+	root = root.push(head)
+	assertListWellFormed(t, root, 1)
+	assert.Equal(t, head, root, "Expected push with nil receiver to return head list.")
+
+	// nil head
+	originalRoot := newTimer(0, nil)
+	root = originalRoot
+	root = root.push(nil)
+	assertListWellFormed(t, root, 1)
+	assert.Equal(t, originalRoot, root, "Expected pushing nil onto a list to return original list.")
+}
+
+func TestTimersLinkedList(t *testing.T) {
+	els := []*Timer{
+		newTimer(0, nil),
+		newTimer(1, nil),
+		newTimer(2, nil),
+		newTimer(3, nil),
+		newTimer(4, nil),
+		newTimer(5, nil),
+	}
+	// Build a single-node list.
+	var root *Timer
+	root = root.pushOne(els[0])
+	assert.Equal(t, root, els[0], "Unexpected first node.")
+	assertListWellFormed(t, root, 1)
+
+	// Add a second element.
+	root = root.pushOne(els[1])
+	assertListWellFormed(t, root, 2)
+
+	// Push a list.
+	root = root.push((*Timer)(nil).
+		pushOne(els[2]).
+		pushOne(els[3]).
+		pushOne(els[4]).
+		pushOne(els[5]))
+	assertListWellFormed(t, root, 6)
+
+	var deadlines []uint64
+	for el := root; el != nil; el = el.next {
+		deadlines = append(deadlines, el.deadline)
+	}
+	assert.Equal(t, []uint64{5, 4, 3, 2, 1, 0}, deadlines, "Unexpected list ordering.")
+}
+
+func TestBucketsAvoidFalseSharing(t *testing.T) {
+	assert.Equal(t,
+		int(cacheline),
+		int(unsafe.Sizeof(bucket{})),
+		"Expected buckets to exactly fill a CPU cache line.",
+	)
+}
+
+func TestBucketListSchedule(t *testing.T) {
+	bs := newBucketList()
+	assertQueuedTimers(t, bs, 0, 0)
+
+	bs.Schedule(uint64(0), fakeWork)
+	assertQueuedTimers(t, bs, 0, 1)
+
+	bs.Schedule(uint64(1), fakeWork)
+	assertQueuedTimers(t, bs, 1, 1)
+
+	bs.Schedule(uint64(7), fakeWork)
+	assertQueuedTimers(t, bs, 7, 1)
+
+	bs.Schedule(uint64(8), fakeWork)
+	assertQueuedTimers(t, bs, 0, 2)
+}
+
+func TestBucketListGatherExpired(t *testing.T) {
+	bs := newBucketList()
+	for i := range bs.buckets {
+		bs.Schedule(uint64(i), fakeWork)
+	}
+	assert.Equal(t, 0, bs.GatherExpired(0, 0, 0).len(), "Unexpected no. expired timers in range [0,0).")
+	assert.Equal(t, 3, bs.GatherExpired(0, 3, 3).len(), "Unexpected no. expired timers in range [0,3).")
+	assert.Equal(t, 0, bs.GatherExpired(0, 3, 3).len(), "Unexpected no. expired timers in range [0,3) on re-gather.")
+	assert.Equal(t, 5, bs.GatherExpired(3, 100, 100).len(), "Unexpected no. expired timers in range [3,100).")
+
+	// We should be leaving unexpired timers in place.
+	bs.Schedule(8, fakeWork)
+	bs.Schedule(8, fakeWork)
+	assert.Equal(t, 0, bs.GatherExpired(0, 1, 1).len(), "Unexpected no. expired timers in range [0,1).")
+	assertQueuedTimers(t, bs, 0, 2)
+}
+
+func TestBucketListClear(t *testing.T) {
+	bs := newBucketList()
+	for i := range bs.buckets {
+		bs.Schedule(uint64(i), fakeWork)
+	}
+	bs.Schedule(uint64(1<<20), fakeWork)
+	bs.Clear()
+	all := bs.GatherExpired(0, math.MaxUint64, math.MaxUint64)
+	assert.Equal(t, 0, all.len(), "Unexpected number of timers after clearing bucketList.")
+}
+
+func TestTimerBucketCalculations(t *testing.T) {
+	tests := []struct {
+		tick, max time.Duration
+		buckets   int
+	}{
+		// If everything is a power of two, buckets = max / tick.
+		{2, 8, 4},
+		// Tick gets dropped to 1<<2, so we need 5 buckets to support 20ns
+		// max without overlap. We then bump that to 1<<3.
+		{6, 20, 8},
+	}
+
+	for _, tt := range tests {
+		w := NewWheel(tt.tick, tt.max)
+		defer w.Stop()
+		assert.Equal(t, tt.buckets, len(w.buckets.buckets), "Unexpected number of buckets.")
+	}
+}
+
+func TestTimersScheduleAndCancel(t *testing.T) {
+	const (
+		numTimers    = 20
+		tickDuration = 1 << 22
+		maxDelay     = tickDuration * numTimers
+	)
+	w, c := fakeWheel(tickDuration)
+	defer w.Stop()
+
+	var wg sync.WaitGroup
+	scheduled := make([]*Timer, 0, numTimers)
+	for i := time.Duration(0); i < numTimers; i++ {
+		scheduled = append(scheduled, w.AfterFunc(i*tickDuration, wg.Done))
+		// wg.Done() panics if the counter is less than zero, but these extra
+		// calls should never fire.
+		canceled := w.AfterFunc(i*tickDuration, wg.Done)
+		assert.True(t, canceled.Stop())
+	}
+
+	for i := 0; i < numTimers; i++ {
+		wg.Add(1)
+		c.Add(tickDuration)
+		wg.Wait()
+	}
+
+	for _, timer := range scheduled {
+		assert.False(t, timer.Stop(), "Shouldn't be able to cancel after expiry.")
+	}
+}
+
+func TestTimerDroppingTicks(t *testing.T) {
+	const (
+		numTimers    = 100
+		tickDuration = 1 << 22
+		maxDelay     = numTimers * tickDuration
+	)
+	now := make(chan time.Time)
+	defer close(now)
+
+	c := clock.NewMock()
+	w := newWheel(5*time.Millisecond, 2*time.Minute, c)
+	go w.tick(time.Unix(0, 0), now)
+	defer w.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(numTimers)
+	timeouts := randomTimeouts(numTimers, maxDelay)
+	for _, d := range timeouts {
+		w.AfterFunc(d, func() { wg.Done() })
+	}
+	now <- time.Unix(0, int64(2*maxDelay))
+	wg.Wait()
+}
+
+func TestTimerStopClearsWheel(t *testing.T) {
+	const numTimers = 100
+	w, _ := fakeWheel(1 * time.Millisecond)
+
+	timeouts := randomTimeouts(numTimers, 100*time.Millisecond)
+	for _, d := range timeouts {
+		w.AfterFunc(d, fakeWork)
+	}
+
+	w.Stop()
+	all := w.buckets.GatherExpired(0, math.MaxUint64, math.MaxUint64)
+	assert.Equal(t, 0, all.len(), "Expected wheel.Stop to clear all timers.")
+}
+
+func TestPowersOfTwo(t *testing.T) {
+	tests := []struct {
+		in       int
+		out      int
+		exponent int
+	}{
+		{-42, 1, 0},
+		{0, 1, 0},
+		{1, 1, 0},
+		{5, 8, 3},
+		{1000, 1024, 10},
+		{1 << 22, 1 << 22, 22},
+	}
+	for _, tt := range tests {
+		n, exp := nextPowerOfTwo(int64(tt.in))
+		assert.Equal(t, tt.out, int(n), "Unexpected next power of two for input %v", tt.in)
+		assert.Equal(t, tt.exponent, int(exp), "Unexpected exponent for input %v", tt.in)
+	}
+}
+
+func TestWheelsDontConsumeInsaneAmountsOfMemory(t *testing.T) {
+	w := NewWheel(5*time.Millisecond, 2*time.Minute)
+	defer w.Stop()
+
+	assert.Equal(
+		t,
+		32768,
+		len(w.buckets.buckets),
+		"Agh, too much memory",
+	)
+}
+
+func scheduleAndCancel(b *testing.B, w *Wheel) {
+	ds := randomTimeouts(1024, time.Minute)
+	for i := range ds {
+		ds[i] = ds[i] + 24*time.Hour
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			w.AfterFunc(ds[i&10], fakeWork).Stop()
+			i++
+		}
+	})
+}
+
+func scheduleAndCancelStd(b *testing.B) {
+	ds := randomTimeouts(1024, time.Minute)
+	for i := range ds {
+		ds[i] = ds[i] + 24*time.Hour
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			time.AfterFunc(ds[i&10], fakeWork).Stop()
+			i++
+		}
+	})
+}
+
+func BenchmarkScheduleAndCancelWheelNoHeap(b *testing.B) {
+	w := NewWheel(5*time.Millisecond, 2*time.Minute)
+	defer w.Stop()
+
+	scheduleAndCancel(b, w)
+	b.StopTimer()
+}
+
+func BenchmarkScheduleAndCancelWheelWithHeap(b *testing.B) {
+	w := NewWheel(5*time.Millisecond, 2*time.Minute)
+	defer w.Stop()
+
+	ds := randomTimeouts(10000, time.Minute)
+	for i := range ds {
+		ds[i] = ds[i] + 24*time.Hour
+	}
+	for i := range ds {
+		w.AfterFunc(ds[i], fakeWork)
+	}
+
+	scheduleAndCancel(b, w)
+	b.StopTimer()
+}
+
+func BenchmarkScheduleAndCancelStandardLibraryNoHeap(b *testing.B) {
+	scheduleAndCancelStd(b)
+}
+
+func BenchmarkScheduleAndCancelStandardLibraryWithHeap(b *testing.B) {
+	ds := randomTimeouts(10000, time.Minute)
+	timers := make([]*time.Timer, 10000)
+	for i := range ds {
+		timers[i] = time.AfterFunc(ds[i]+24*time.Hour, fakeWork)
+	}
+
+	scheduleAndCancelStd(b)
+	b.StopTimer()
+	for _, t := range timers {
+		t.Stop()
+	}
+}
+
+func BenchmarkWheelWorkThread(b *testing.B) {
+	// Note that this benchmark includes 1ms of wait time; attempting to reduce
+	// this by ticking faster is counterproductive, since we start missing
+	// ticks and then need to lock more buckets to catch up.
+	w := NewWheel(time.Millisecond, time.Second)
+	defer w.Stop()
+	var wg sync.WaitGroup
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		wg.Add(1)
+		w.AfterFunc(0, func() { wg.Done() })
+		wg.Wait()
+	}
+}
+
+func BenchmarkWheelTimerExpiry(b *testing.B) {
+	w, c := fakeWheel(time.Millisecond)
+	defer w.Stop()
+	var wg sync.WaitGroup
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		wg.Add(1)
+		w.AfterFunc(time.Millisecond, func() { wg.Done() })
+		c.Add(10 * time.Millisecond)
+		wg.Wait()
+	}
+}
+
+func BenchmarkStandardLibraryTimerExpiry(b *testing.B) {
+	// To compare accurately against our timer wheel, we need to create a mock
+	// clock, listen on it, and advance it. (This actually accounts for the
+	// vast majority of time spent and memory allocated in this benchmark.)
+	clock := clock.NewMock()
+	go func() {
+		<-clock.Ticker(time.Millisecond).C
+	}()
+
+	var wg sync.WaitGroup
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		wg.Add(1)
+		time.AfterFunc(0, func() { wg.Done() })
+		clock.Add(10 * time.Millisecond)
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
This diff replaces the relayer's use of the standard lib's `time.Timer` with a custom timer wheel. The wheel reduces the overhead of maintaining timers in four ways:

- First, it stores timers in multiple buckets, which reduces lock contention.
- Within buckets, it uses a linked list instead of a heap, which allows for O(1) insertion.
- Second, it executes callback functions in the ticker thread (instead of spawning a goroutine per ticker).
- Lastly, it reduces timer cancellation to an atomic CAS.

The tradeoffs are, of course, that we coarsen timers to fire only every ~5ms, and we run a greater risk of blocking the tick thread when callbacks block.

With 10k relayed calls in flight, benchmarks suggest that this implementation is 50% faster than the standard lib:

```
# Schedule and immediately cancel a single timer.
BenchmarkScheduleAndCancelWheelNoHeap-4                 10000000               144 ns/op              48 B/op          1 allocs/op
BenchmarkScheduleAndCancelStandardLibraryNoHeap-4       10000000               239 ns/op              64 B/op          1 allocs/op

# Schedule 10k timers for tomorrow, then benchmark scheduling and canceling an additional timer.
BenchmarkScheduleAndCancelWheelWithHeap-4               10000000               156 ns/op              48 B/op          1 allocs/op
BenchmarkScheduleAndCancelStandardLibraryWithHeap-4      5000000               317 ns/op         
```

/cc @prashantv @billf @monicato @witriew 