### PR TITLE
Wrap(ctx) should not drop existing headers

### DIFF
--- a/context_header.go
+++ b/context_header.go
@@ -78,6 +78,18 @@ func (c headerCtx) SetResponseHeaders(headers map[string]string) {
 	panic("SetResponseHeaders called on ContextWithHeaders not created via WrapWithHeaders")
 }
 
+// Wrap wraps an existing context.Context into a ContextWithHeaders.
+// If the underlying context has headers, they are preserved.
+func Wrap(ctx context.Context) ContextWithHeaders {
+	hctx := headerCtx{Context: ctx}
+	if h := hctx.headers(); h != nil {
+		return hctx
+	}
+
+	// If there is no header container, we should create an empty one.
+	return WrapWithHeaders(ctx, nil)
+}
+
 // WrapWithHeaders returns a Context that can be used to make a call with request headers.
 // If the parent `ctx` is already an instance of ContextWithHeaders, its existing headers
 // will be ignored. In order to merge new headers with parent headers, use ContextBuilder.

--- a/context_test.go
+++ b/context_test.go
@@ -226,3 +226,19 @@ func TestContextBuilderParentContextSpan(t *testing.T) {
 
 	goroutines.VerifyNoLeaks(t, nil)
 }
+
+func TestContextWrap(t *testing.T) {
+	ctxNoHeaders, cancel := NewContextBuilder(time.Second).Build()
+	defer cancel()
+
+	ctxWithHeaders, cancel := NewContextBuilder(time.Second).AddHeader("h1", "v1").Build()
+	defer cancel()
+
+	ctxNoHeaders = Wrap(context.WithValue(ctxNoHeaders, "1", "2"))
+	assert.Equal(t, "2", ctxNoHeaders.Value("1"), "Missing value in context")
+	assert.Nil(t, ctxNoHeaders.Headers(), "Context should have no headers")
+
+	ctxWithHeaders = Wrap(context.WithValue(ctxWithHeaders, "1", "2"))
+	assert.Equal(t, "2", ctxNoHeaders.Value("1"), "Missing value in context")
+	assert.Equal(t, map[string]string{"h1": "v1"}, ctxWithHeaders.Headers(), "Headers lost after Wrap")
+}

--- a/thrift/context.go
+++ b/thrift/context.go
@@ -33,12 +33,12 @@ type Context tchannel.ContextWithHeaders
 // NewContext returns a Context that can be used to make Thrift calls.
 func NewContext(timeout time.Duration) (Context, context.CancelFunc) {
 	ctx, cancel := tchannel.NewContext(timeout)
-	return tchannel.WrapWithHeaders(ctx, nil), cancel
+	return Wrap(ctx), cancel
 }
 
 // Wrap returns a Thrift Context that wraps around a Context.
 func Wrap(ctx context.Context) Context {
-	return tchannel.WrapWithHeaders(ctx, nil)
+	return tchannel.Wrap(ctx)
 }
 
 // WithHeaders returns a Context that can be used to make a call with request headers.

--- a/thrift/context_test.go
+++ b/thrift/context_test.go
@@ -37,10 +37,16 @@ import (
 )
 
 func TestWrapContext(t *testing.T) {
-	ctx, cancel := NewContext(time.Second)
+	tctx, cancel := NewContext(time.Second)
 	defer cancel()
-	actual := Wrap(ctx)
-	assert.NotNil(t, actual, "Should not return nil.")
+
+	headers := map[string]string{"h1": "v1"}
+	ctx := context.WithValue(WithHeaders(tctx, headers), "1", "2")
+	wrapped := Wrap(ctx)
+	assert.NotNil(t, wrapped, "Should not return nil.")
+
+	assert.Equal(t, headers, wrapped.Headers(), "Unexpected headers")
+	assert.Equal(t, "2", wrapped.Value("1"), "Unexpected value")
 }
 
 func TestContextBuilder(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/uber/tchannel-go/issues/546