### PR TITLE
Clean up Channel lifecycle, add ID per channel

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -191,8 +191,8 @@ type Connection struct {
 	}
 }
 
-// nextConnID gives an ID for each connection for debugging purposes.
-var nextConnID atomic.Uint32
+// _nextConnID is used to allocate unique IDs to every connection for debugging purposes.
+var _nextConnID atomic.Uint32
 
 type connectionState int
 
@@ -290,7 +290,7 @@ func (ch *Channel) newConnection(conn net.Conn, outboundHP string, initialState 
 		framePool = DefaultFramePool
 	}
 
-	connID := nextConnID.Inc()
+	connID := _nextConnID.Inc()
 	log := ch.log.WithFields(LogFields{
 		{"connID", connID},
 		{"localAddr", conn.LocalAddr()},

--- a/introspection.go
+++ b/introspection.go
@@ -55,6 +55,8 @@ type RuntimeVersion struct {
 
 // RuntimeState is a snapshot of the runtime state for a channel.
 type RuntimeState struct {
+	ID uint32 `json:"id"`
+
 	// CreatedStack is the stack for how this channel was created.
 	CreatedStack string `json:"createdStack"`
 
@@ -91,6 +93,7 @@ type GoRuntimeStateOptions struct {
 
 // ChannelInfo is the state of other channels in the same process.
 type ChannelInfo struct {
+	ID           uint32        `json:"id"`
 	CreatedStack string        `json:"createdStack"`
 	LocalPeer    LocalPeerInfo `json:"localPeer"`
 }
@@ -209,6 +212,7 @@ func (ch *Channel) IntrospectState(opts *IntrospectionOptions) *RuntimeState {
 	ch.mutable.RUnlock()
 
 	return &RuntimeState{
+		ID:             ch.chID,
 		CreatedStack:   ch.createdStack,
 		LocalPeer:      ch.PeerInfo(),
 		SubChannels:    ch.subChannels.IntrospectState(opts),
@@ -248,6 +252,7 @@ func (ch *Channel) IntrospectOthers(opts *IntrospectionOptions) map[string][]Cha
 // ReportInfo returns ChannelInfo for a channel.
 func (ch *Channel) ReportInfo(opts *IntrospectionOptions) ChannelInfo {
 	return ChannelInfo{
+		ID:           ch.chID,
 		CreatedStack: ch.createdStack,
 		LocalPeer:    ch.PeerInfo(),
 	}


### PR DESCRIPTION
Add a unique channel ID, and have an onClosed method for when a channel
is actually closed. This is useful for:
 - Stopping related objects that are no longer needed on shutdown
 - Raising an event when a channel is closed