### PR TITLE
Add ctx.Child method for easier parallel sub-request calls

### DIFF
--- a/context_header.go
+++ b/context_header.go
@@ -35,9 +35,9 @@ type ContextWithHeaders interface {
 	// SetResponseHeaders sets the given response headers on the context.
 	SetResponseHeaders(map[string]string)
 
-	// Clone creates a copy of the context which stores headers separately from
+	// Child creates a child context which stores headers separately from
 	// the parent context.
-	Clone() ContextWithHeaders
+	Child() ContextWithHeaders
 }
 
 type headerCtx struct {
@@ -82,8 +82,8 @@ func (c headerCtx) SetResponseHeaders(headers map[string]string) {
 	panic("SetResponseHeaders called on ContextWithHeaders not created via WrapWithHeaders")
 }
 
-// Clone creates a copy of the context with a separate container for headers.
-func (c headerCtx) Clone() ContextWithHeaders {
+// Child creates a child context with a separate container for headers.
+func (c headerCtx) Child() ContextWithHeaders {
 	var headersCopy headersContainer
 	if h := c.headers(); h != nil {
 		headersCopy = *h

--- a/context_header.go
+++ b/context_header.go
@@ -34,6 +34,10 @@ type ContextWithHeaders interface {
 
 	// SetResponseHeaders sets the given response headers on the context.
 	SetResponseHeaders(map[string]string)
+
+	// Clone creates a copy of the context which stores headers separately from
+	// the parent context.
+	Clone() ContextWithHeaders
 }
 
 type headerCtx struct {
@@ -76,6 +80,16 @@ func (c headerCtx) SetResponseHeaders(headers map[string]string) {
 		return
 	}
 	panic("SetResponseHeaders called on ContextWithHeaders not created via WrapWithHeaders")
+}
+
+// Clone creates a copy of the context with a separate container for headers.
+func (c headerCtx) Clone() ContextWithHeaders {
+	var headersCopy headersContainer
+	if h := c.headers(); h != nil {
+		headersCopy = *h
+	}
+
+	return Wrap(context.WithValue(c.Context, contextKeyHeaders, &headersCopy))
 }
 
 // Wrap wraps an existing context.Context into a ContextWithHeaders.

--- a/context_test.go
+++ b/context_test.go
@@ -227,7 +227,7 @@ func TestContextBuilderParentContextSpan(t *testing.T) {
 	goroutines.VerifyNoLeaks(t, nil)
 }
 
-func TestContextWrapClone(t *testing.T) {
+func TestContextWrapChild(t *testing.T) {
 	tests := []struct {
 		msg         string
 		ctxFn       func() ContextWithHeaders
@@ -264,11 +264,11 @@ func TestContextWrapClone(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		for _, clone := range []bool{false, true} {
+		for _, child := range []bool{false, true} {
 			origCtx := tt.ctxFn()
 			ctx := origCtx
-			if clone {
-				ctx = origCtx.Clone()
+			if child {
+				ctx = origCtx.Child()
 			}
 
 			assert.Equal(t, tt.wantValue, ctx.Value("1"), "%v: Unexpected value", tt.msg)
@@ -278,10 +278,10 @@ func TestContextWrapClone(t *testing.T) {
 			ctx.SetResponseHeaders(respHeaders)
 			assert.Equal(t, respHeaders, ctx.ResponseHeaders(), "%v: Unexpected response headers", tt.msg)
 
-			if clone {
-				// If we're working with a clone, changes to response headers should not
-				// affect the original context.
-				assert.Nil(t, origCtx.ResponseHeaders(), "%v: Clone modified original context's headers", tt.msg)
+			if child {
+				// If we're working with a child context, changes to response headers
+				// should not affect the original context.
+				assert.Nil(t, origCtx.ResponseHeaders(), "%v: Child modified original context's headers", tt.msg)
 			}
 		}
 	}


### PR DESCRIPTION
Since our context is not goroutine safe (SetResponesHeaders mutates the
headers container), users need to create a copy when making sub-requests
in parallel. Child makes this much easier for users.

Fixes https://github.com/uber/tchannel-go/issues/519