### PR TITLE
relay: Remove "remote process match" checks

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -552,10 +552,6 @@ func (r *Relayer) handleLocalCallReq(cr lazyCallReq) bool {
 	return true
 }
 
-func (r *relayConn) RemoteProcessPrefixMatches() []bool {
-	return (*Connection)(r).remoteProcessPrefixMatches
-}
-
 func (r *relayConn) RemoteHostPort() string {
 	return (*Connection)(r).RemotePeerInfo().HostPort
 }

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -27,12 +27,6 @@ package relay
 // Conn is an interface that exposes a bit of information about the underlying
 // connection.
 type Conn interface {
-	// RemoteProcessPrefixMatches checks whether the remote peer's process name
-	// matches a preconfigured list of prefixes specified in the connection
-	// options. It's the caller's responsibility to match indices between the two
-	// slices. Callers shouldn't mutate the returned slice.
-	RemoteProcessPrefixMatches() []bool
-
 	// RemoteHostPort returns the host:port of the remote peer.
 	RemoteHostPort() string
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -503,16 +503,13 @@ func TestRelayConnection(t *testing.T) {
 	var errTest = errors.New("test")
 	var wantHostPort string
 	getHost := func(call relay.CallFrame, conn relay.Conn) (string, error) {
-		matches := conn.RemoteProcessPrefixMatches()
-		assert.Equal(t, []bool{true, true, true, false}, matches, "Unexpected prefix matches.")
 		assert.Equal(t, wantHostPort, conn.RemoteHostPort(), "Unexpected RemoteHostPort")
 		return "", errTest
 	}
 
 	opts := testutils.NewOpts().
 		SetRelayOnly().
-		SetRelayHost(relaytest.HostFunc(getHost)).
-		SetProcessPrefixes("nod", "nodejs-hyperbahn", "", "hyperbahn")
+		SetRelayHost(relaytest.HostFunc(getHost))
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		// Create a client that is listening so we can set the expected host:port.
 		clientOpts := testutils.NewOpts().SetProcessName("nodejs-hyperbahn")

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -118,12 +118,6 @@ func (o *ChannelOpts) SetFramePool(framePool tchannel.FramePool) *ChannelOpts {
 	return o
 }
 
-// SetProcessPrefixes sets CheckProcessPrefixes in DefaultConnectionOptions.
-func (o *ChannelOpts) SetProcessPrefixes(prefixes ...string) *ChannelOpts {
-	o.DefaultConnectionOptions.CheckedProcessPrefixes = prefixes
-	return o
-}
-
 // SetSendBufferSize sets the SendBufferSize in DefaultConnectionOptions.
 func (o *ChannelOpts) SetSendBufferSize(bufSize int) *ChannelOpts {
 	o.DefaultConnectionOptions.SendBufferSize = bufSize


### PR DESCRIPTION
Our internal relays have been refactored to no longer require the remote
process checking, so we can remove this very specific functionality.