### PR TITLE
Small test cleanups

### DIFF
--- a/hyperbahn/advertise_test.go
+++ b/hyperbahn/advertise_test.go
@@ -369,7 +369,7 @@ func withSetup(t *testing.T, f func(ch *tchannel.Channel, hostPort string)) {
 	serverCh, err := tchannel.NewChannel(hyperbahnServiceName, nil)
 	require.NoError(t, err)
 	defer serverCh.Close()
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	serverCh.Serve(listener)
 

--- a/init_test.go
+++ b/init_test.go
@@ -89,7 +89,7 @@ func TestUnexpectedInitReq(t *testing.T) {
 		ch, err := NewChannel("test", nil)
 		require.NoError(t, err)
 		defer ch.Close()
-		require.NoError(t, ch.ListenAndServe(":0"))
+		require.NoError(t, ch.ListenAndServe("127.0.0.1:0"))
 		hostPort := ch.PeerInfo().HostPort
 
 		conn, err := net.Dial("tcp", hostPort)
@@ -202,7 +202,7 @@ func TestHandleInitReqNewVersion(t *testing.T) {
 	ch, err := NewChannel("test", nil)
 	require.NoError(t, err)
 	defer ch.Close()
-	require.NoError(t, ch.ListenAndServe(":0"))
+	require.NoError(t, ch.ListenAndServe("127.0.0.1:0"))
 	hostPort := ch.PeerInfo().HostPort
 
 	conn, err := net.Dial("tcp", hostPort)
@@ -330,7 +330,7 @@ func TestInitReqGetsError(t *testing.T) {
 }
 
 func newListener(t *testing.T) net.Listener {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "Listen failed")
 	return l
 }

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -187,7 +187,7 @@ func TestHeadersForwarded(t *testing.T) {
 		"forward": handler.forward,
 		"leaf":    handler.leaf,
 	}, handler.onError))
-	assert.NoError(t, ch.ListenAndServe(":0"))
+	assert.NoError(t, ch.ListenAndServe("127.0.0.1:0"))
 
 	rootArg := &ForwardArgs{
 		Service:   "svc",

--- a/relay_test.go
+++ b/relay_test.go
@@ -562,6 +562,7 @@ func TestRelayRejectsDuringClose(t *testing.T) {
 		require.Error(t, err, "Expect call to fail after relay is shutdown")
 		assert.Contains(t, err.Error(), "incoming connection is not active")
 		close(block)
+		wg.Wait()
 
 		// We have a successful call that ran in the goroutine
 		// and a failed call that we just checked the error on.

--- a/retry_test.go
+++ b/retry_test.go
@@ -218,7 +218,7 @@ func TestRetryNetConnect(t *testing.T) {
 	defer cancel()
 
 	closedAddr := testutils.GetClosedHostPort(t)
-	listenC, err := net.Listen("tcp", ":0")
+	listenC, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "Listen failed")
 	defer listenC.Close()
 

--- a/testutils/relay.go
+++ b/testutils/relay.go
@@ -45,7 +45,7 @@ type frameRelay struct {
 }
 
 func (r *frameRelay) listen() (listenHostPort string, cancel func()) {
-	conn, err := net.Listen("tcp", ":0")
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(r.t, err, "net.Listen failed")
 
 	go func() {


### PR DESCRIPTION
This PR:

- Explicitly listens on `127.0.0.1:0` in tests, which allows the test suite to pass in Travis's old-skool VM infrastructure (v. the container-based builds we usually use)
- Adds a missing `waitgroup.Wait` to a relay test.