### PR TITLE
thrift-gen: Add "namespace go" support.

### DIFF
--- a/thrift/thrift-gen/include.go
+++ b/thrift/thrift-gen/include.go
@@ -20,16 +20,13 @@
 
 package main
 
-import (
-	"strings"
-
-	"github.com/samuel/go-thrift/parser"
-)
+import "github.com/samuel/go-thrift/parser"
 
 // Include represents a single include statement in the Thrift file.
 type Include struct {
 	key  string
 	file string
+	pkg  string
 }
 
 // Import returns the go import to use for this package.
@@ -42,15 +39,17 @@ func (i *Include) Import() string {
 
 // Package returns the package selector for this package.
 func (i *Include) Package() string {
-	return strings.ToLower(i.key)
+	return i.pkg
 }
 
-func createIncludes(parsed *parser.Thrift) map[string]*Include {
+func createIncludes(parsed *parser.Thrift, all map[string]parseState) map[string]*Include {
 	includes := make(map[string]*Include)
 	for k, v := range parsed.Includes {
+		included := all[v]
 		includes[k] = &Include{
 			key:  k,
 			file: v,
+			pkg:  included.namespace,
 		}
 	}
 	return includes

--- a/thrift/thrift-gen/test_files/include_test/namespace/a/shared.thrift
+++ b/thrift/thrift-gen/test_files/include_test/namespace/a/shared.thrift
@@ -1,0 +1,5 @@
+namespace go a_shared
+
+include "../b/shared.thrift"
+
+typedef shared.b_string a_string

--- a/thrift/thrift-gen/test_files/include_test/namespace/b/shared.thrift
+++ b/thrift/thrift-gen/test_files/include_test/namespace/b/shared.thrift
@@ -1,0 +1,3 @@
+namespace go b_shared
+
+typedef string b_string

--- a/thrift/thrift-gen/test_files/include_test/namespace/namespace.thrift
+++ b/thrift/thrift-gen/test_files/include_test/namespace/namespace.thrift
@@ -1,0 +1,5 @@
+include "a/shared.thrift"
+
+service Foo {
+ void Foo(1: shared.a_string str)
+}

--- a/thrift/thrift-gen/typestate.go
+++ b/thrift/thrift-gen/typestate.go
@@ -51,7 +51,13 @@ func newState(v *parser.Thrift, all map[string]parseState) *State {
 		typedefs[k] = i64Type
 	}
 
-	return &State{typedefs, createIncludes(v), all}
+	return &State{typedefs, nil, all}
+}
+
+func setIncludes(all map[string]parseState) {
+	for _, v := range all {
+		v.global.includes = createIncludes(v.ast, all)
+	}
 }
 
 func (s *State) isBasicType(thriftType string) bool {


### PR DESCRIPTION
Currently, if "a.thrift" includes "b.thrift" but "b.thrift" has a
"namespace go" declaration, then the Apache Thrift generated code
uses the "namespace go" value as the package name. thrift-gen was
not respecting the "namespace go" and so the generated code would
not compile.

This will also help work around the following scenario. If we had:
- b/b.thrift which includes:
    b/shared.thrift
- c/c.thrift which includes
    c/shared.thrift

If a.thrift includes "b/b.thrift", everything is OK. As soon as it tries
to include "c/c.thrift", everything breaks since the "shared" package is
overwritten by the last compiled "shared.thrift". We can work around
this by adding a "namespace go" declaration to one of the shared.thrift
file to use a unique package for each of the shared.thrift files,
without having to rename the file (Which may break a lot of existing
code).

Fixes #101