### PR TITLE
Ensure reader is empty before calling Close

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -25,6 +25,8 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+
+	"github.com/uber/tchannel-go/internal/argreader"
 )
 
 // ArgReader is the interface for the arg2 and arg3 streams on an
@@ -72,6 +74,9 @@ func (r ArgReadHelper) read(f func() error) error {
 		return r.err
 	}
 	if err := f(); err != nil {
+		return err
+	}
+	if err := argreader.EnsureEmpty(r.reader, "read arg"); err != nil {
 		return err
 	}
 	return r.reader.Close()

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -23,7 +23,10 @@ package tchannel
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
+
+	"io/ioutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,6 +73,15 @@ func TestJSONInputOutput(t *testing.T) {
 	assert.True(t, reader.closed)
 	assert.Equal(t, "Foo", outObj.Name)
 	assert.Equal(t, 20756, outObj.Value)
+}
+
+func TestReadNotEmpty(t *testing.T) {
+	// Note: The contents need to be larger than the default buffer size of bufio.NewReader.
+	r := bytes.NewReader([]byte("{}" + strings.Repeat("{}\n", 10000)))
+
+	var data map[string]interface{}
+	reader := NewArgReader(ioutil.NopCloser(r), nil)
+	require.Error(t, reader.ReadJSON(&data), "Read should fail due to extra bytes")
 }
 
 func BenchmarkArgReaderWriter(b *testing.B) {

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -23,10 +23,9 @@ package tchannel
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"strings"
 	"testing"
-
-	"io/ioutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/argreader/empty.go
+++ b/internal/argreader/empty.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package argreader
+
+import (
+	"fmt"
+	"io"
+)
+
+// EnsureEmpty ensures that the specified reader is empty. If the reader is
+// not empty, it returns an error with the specified stage in the message.
+func EnsureEmpty(r io.Reader, stage string) error {
+	buf := make([]byte, 128)
+	n, err := r.Read(buf)
+	if n > 0 {
+		return fmt.Errorf("found unexpected bytes after %s, found (upto 128 bytes): %x", stage, buf)
+	}
+	if err == io.EOF {
+		return nil
+	}
+	return err
+}

--- a/internal/argreader/empty_test.go
+++ b/internal/argreader/empty_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package argreader
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/testutils/testreader"
+)
+
+func TestEnsureEmptySuccess(t *testing.T) {
+	reader := bytes.NewReader(nil)
+	err := EnsureEmpty(reader, "success")
+	require.NoError(t, err, "ensureEmpty should succeed with empty reader")
+}
+
+func TestEnsureEmptyHasBytes(t *testing.T) {
+	reader := bytes.NewReader([]byte{1, 2, 3})
+	err := EnsureEmpty(reader, "has bytes")
+	require.Error(t, err, "ensureEmpty should fail when there's bytes")
+	assert.Contains(t, err.Error(), "found unexpected bytes")
+}
+
+func TestEnsureEmptyError(t *testing.T) {
+	control, reader := testreader.ChunkReader()
+	control <- nil
+	close(control)
+
+	err := EnsureEmpty(reader, "has bytes")
+	require.Error(t, err, "ensureEmpty should fail when there's an error")
+	assert.Equal(t, testreader.ErrUser, err, "Unexpected error")
+}

--- a/internal/argreader/empty_test.go
+++ b/internal/argreader/empty_test.go
@@ -24,9 +24,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/uber/tchannel-go/testutils/testreader"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/testutils/testreader"
 )
 
 func TestEnsureEmptySuccess(t *testing.T) {
@@ -37,9 +38,9 @@ func TestEnsureEmptySuccess(t *testing.T) {
 
 func TestEnsureEmptyHasBytes(t *testing.T) {
 	reader := bytes.NewReader([]byte{1, 2, 3})
-	err := EnsureEmpty(reader, "has bytes")
+	err := EnsureEmpty(reader, "T")
 	require.Error(t, err, "ensureEmpty should fail when there's bytes")
-	assert.Contains(t, err.Error(), "found unexpected bytes")
+	assert.Equal(t, err.Error(), "found unexpected bytes after T, found (upto 128 bytes): 010203")
 }
 
 func TestEnsureEmptyError(t *testing.T) {

--- a/thrift/client.go
+++ b/thrift/client.go
@@ -22,6 +22,7 @@ package thrift
 
 import (
 	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/internal/argreader"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"golang.org/x/net/context"
@@ -99,6 +100,10 @@ func readResponse(response *tchannel.OutboundCallResponse, resp thrift.TStruct) 
 		return nil, false, err
 	}
 
+	if err := argreader.EnsureEmpty(reader, "reading response headers"); err != nil {
+		return nil, false, err
+	}
+
 	if err := reader.Close(); err != nil {
 		return nil, false, err
 	}
@@ -111,6 +116,10 @@ func readResponse(response *tchannel.OutboundCallResponse, resp thrift.TStruct) 
 
 	if err := ReadStruct(reader, resp); err != nil {
 		return headers, success, err
+	}
+
+	if err := argreader.EnsureEmpty(reader, "reading response body"); err != nil {
+		return nil, false, err
 	}
 
 	return headers, success, reader.Close()

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	tchannel "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/internal/argreader"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"golang.org/x/net/context"
@@ -116,6 +117,11 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 	if err != nil {
 		return err
 	}
+
+	if err := argreader.EnsureEmpty(reader, "reading request headers"); err != nil {
+		return err
+	}
+
 	if err := reader.Close(); err != nil {
 		return err
 	}
@@ -146,6 +152,10 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 		reader.Close()
 		call.Response().SendSystemError(err)
 		return nil
+	}
+
+	if err := argreader.EnsureEmpty(reader, "reading request body"); err != nil {
+		return err
 	}
 	if err := reader.Close(); err != nil {
 		return err


### PR DESCRIPTION
This triggers an extra Read which will avoid
https://github.com/uber/tchannel-go/issues/563

This is only an issue if the remote side is sending empty TChannel
frames, which should only happen during streaming.

Fixes #563 

cc @willhug @akshayjshah 