### PR TITLE
ListenIP: Reduce preference for locally administered MAC addresses.

### DIFF
--- a/localip_test.go
+++ b/localip_test.go
@@ -63,6 +63,16 @@ func TestScoreAddr(t *testing.T) {
 			wantIP: ipv4,
 		},
 		{
+			msg: "non-local up ipv4 address, local MAC address",
+			iface: net.Interface{
+				Flags:        net.FlagUp,
+				HardwareAddr: mustParseMAC("02:42:9c:52:fc:86"),
+			},
+			addr:   &net.IPNet{IP: ipv4},
+			want:   450,
+			wantIP: ipv4,
+		},
+		{
 			msg:    "non-local down ipv4 address",
 			iface:  net.Interface{},
 			addr:   &net.IPNet{IP: ipv4},


### PR DESCRIPTION
Instead of checking for a Docker-specific prefix, reduce preference for
any locally administered MAC address. This includes the Docker address
space.

Related to #554. Our internal docker interface was using `02:42:9c:...` and so only checking for the Docker prefix of `02:42:ac:...` didn't work.