### PR TITLE
thrift: Return error if we didn't decode a known exception

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ thrift_gen:
 	$(BUILD)/thrift-gen --generateThrift --inputFile examples/keyvalue/keyvalue.thrift --outputDir examples/keyvalue/gen-go
 	$(BUILD)/thrift-gen --generateThrift --inputFile examples/thrift/example.thrift --outputDir examples/thrift/gen-go
 	$(BUILD)/thrift-gen --generateThrift --inputFile hyperbahn/hyperbahn.thrift --outputDir hyperbahn/gen-go
-	rm -rf trace/thrift/gen-go/tcollector && $(BUILD)/thrift-gen --generateThrift --inputFile trace/tcollector.thrift --outputDir trace/thrift/gen-go/
 
 release_thrift_gen: clean setup
 	GOOS=linux GOARCH=amd64 go build -o $(THRIFT_GEN_RELEASE_LINUX)/thrift-gen ./thrift/thrift-gen

--- a/crossdock/behavior/trace/thrift.go
+++ b/crossdock/behavior/trace/thrift.go
@@ -39,6 +39,8 @@ func (b *Behavior) registerThrift(ch *tchannel.Channel) {
 }
 
 type thriftHandler struct {
+	gen.TChanSimpleService // leave nil so calls to unimplemented methods panic.
+
 	ch *tchannel.Channel
 	b  *Behavior
 }
@@ -53,10 +55,6 @@ func (h *thriftHandler) Call(ctx thrift.Context, arg *gen.Data) (*gen.Data, erro
 		return nil, err
 	}
 	return responseToThrift(res)
-}
-
-func (h *thriftHandler) Simple(ctx thrift.Context) error {
-	panic("Simple not implemented")
 }
 
 func (h *thriftHandler) callDownstream(ctx context.Context, target *Downstream) (*Response, error) {

--- a/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
+++ b/examples/keyvalue/gen-go/keyvalue/tchan-keyvalue.go
@@ -59,8 +59,11 @@ func (c *tchanAdminClient) ClearAll(ctx thrift.Context) error {
 	args := AdminClearAllArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "clearAll", &args, &resp)
 	if err == nil && !success {
-		if e := resp.NotAuthorized; e != nil {
-			err = e
+		switch {
+		case resp.NotAuthorized != nil:
+			err = resp.NotAuthorized
+		default:
+			err = fmt.Errorf("received no result or unknown exception for clearAll")
 		}
 	}
 
@@ -160,11 +163,13 @@ func (c *tchanKeyValueClient) Get(ctx thrift.Context, key string) (string, error
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Get", &args, &resp)
 	if err == nil && !success {
-		if e := resp.NotFound; e != nil {
-			err = e
-		}
-		if e := resp.InvalidKey; e != nil {
-			err = e
+		switch {
+		case resp.NotFound != nil:
+			err = resp.NotFound
+		case resp.InvalidKey != nil:
+			err = resp.InvalidKey
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Get")
 		}
 	}
 
@@ -179,8 +184,11 @@ func (c *tchanKeyValueClient) Set(ctx thrift.Context, key string, value string) 
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Set", &args, &resp)
 	if err == nil && !success {
-		if e := resp.InvalidKey; e != nil {
-			err = e
+		switch {
+		case resp.InvalidKey != nil:
+			err = resp.InvalidKey
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Set")
 		}
 	}
 
@@ -311,6 +319,10 @@ func (c *tchanBaseServiceClient) HealthCheck(ctx thrift.Context) (string, error)
 	args := BaseServiceHealthCheckArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "HealthCheck", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for HealthCheck")
+		}
 	}
 
 	return resp.GetSuccess(), err

--- a/examples/thrift/gen-go/example/tchan-example.go
+++ b/examples/thrift/gen-go/example/tchan-example.go
@@ -55,6 +55,10 @@ func (c *tchanBaseClient) BaseCall(ctx thrift.Context) error {
 	args := BaseBaseCallArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "BaseCall", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for BaseCall")
+		}
 	}
 
 	return err
@@ -136,6 +140,10 @@ func (c *tchanFirstClient) AppError(ctx thrift.Context) error {
 	args := FirstAppErrorArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "AppError", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for AppError")
+		}
 	}
 
 	return err
@@ -148,6 +156,10 @@ func (c *tchanFirstClient) Echo(ctx thrift.Context, msg string) (string, error) 
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Echo", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Echo")
+		}
 	}
 
 	return resp.GetSuccess(), err
@@ -158,6 +170,10 @@ func (c *tchanFirstClient) Healthcheck(ctx thrift.Context) (*HealthCheckRes, err
 	args := FirstHealthcheckArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "Healthcheck", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Healthcheck")
+		}
 	}
 
 	return resp.GetSuccess(), err
@@ -289,6 +305,10 @@ func (c *tchanSecondClient) Test(ctx thrift.Context) error {
 	args := SecondTestArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "Test", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Test")
+		}
 	}
 
 	return err

--- a/hyperbahn/gen-go/hyperbahn/tchan-hyperbahn.go
+++ b/hyperbahn/gen-go/hyperbahn/tchan-hyperbahn.go
@@ -43,11 +43,13 @@ func (c *tchanHyperbahnClient) Discover(ctx thrift.Context, query *DiscoveryQuer
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "discover", &args, &resp)
 	if err == nil && !success {
-		if e := resp.NoPeersAvailable; e != nil {
-			err = e
-		}
-		if e := resp.InvalidServiceName; e != nil {
-			err = e
+		switch {
+		case resp.NoPeersAvailable != nil:
+			err = resp.NoPeersAvailable
+		case resp.InvalidServiceName != nil:
+			err = resp.InvalidServiceName
+		default:
+			err = fmt.Errorf("received no result or unknown exception for discover")
 		}
 	}
 

--- a/thrift/gen-go/test/secondservice.go
+++ b/thrift/gen-go/test/secondservice.go
@@ -96,16 +96,16 @@ func (p *SecondServiceClient) recvEcho() (value string, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error12 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error13 error
-		error13, err = error12.Read(iprot)
+		error14 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error15 error
+		error15, err = error14.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error13
+		err = error15
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -143,9 +143,9 @@ func (p *SecondServiceProcessor) ProcessorMap() map[string]thrift.TProcessorFunc
 
 func NewSecondServiceProcessor(handler SecondService) *SecondServiceProcessor {
 
-	self14 := &SecondServiceProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self14.processorMap["Echo"] = &secondServiceProcessorEcho{handler: handler}
-	return self14
+	self16 := &SecondServiceProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
+	self16.processorMap["Echo"] = &secondServiceProcessorEcho{handler: handler}
+	return self16
 }
 
 func (p *SecondServiceProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
@@ -158,12 +158,12 @@ func (p *SecondServiceProcessor) Process(iprot, oprot thrift.TProtocol) (success
 	}
 	iprot.Skip(thrift.STRUCT)
 	iprot.ReadMessageEnd()
-	x15 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
+	x17 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
 	oprot.WriteMessageBegin(name, thrift.EXCEPTION, seqId)
-	x15.Write(oprot)
+	x17.Write(oprot)
 	oprot.WriteMessageEnd()
 	oprot.Flush()
-	return false, x15
+	return false, x17
 
 }
 

--- a/thrift/gen-go/test/tchan-test.go
+++ b/thrift/gen-go/test/tchan-test.go
@@ -21,6 +21,7 @@ type TChanSecondService interface {
 type TChanSimpleService interface {
 	Call(ctx thrift.Context, arg *Data) (*Data, error)
 	Simple(ctx thrift.Context) error
+	SimpleFuture(ctx thrift.Context) error
 }
 
 // Implementation of a client and service handler.
@@ -49,6 +50,10 @@ func (c *tchanSecondServiceClient) Echo(ctx thrift.Context, arg string) (string,
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Echo", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Echo")
+		}
 	}
 
 	return resp.GetSuccess(), err
@@ -130,6 +135,10 @@ func (c *tchanSimpleServiceClient) Call(ctx thrift.Context, arg *Data) (*Data, e
 	}
 	success, err := c.client.Call(ctx, c.thriftService, "Call", &args, &resp)
 	if err == nil && !success {
+		switch {
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Call")
+		}
 	}
 
 	return resp.GetSuccess(), err
@@ -140,8 +149,29 @@ func (c *tchanSimpleServiceClient) Simple(ctx thrift.Context) error {
 	args := SimpleServiceSimpleArgs{}
 	success, err := c.client.Call(ctx, c.thriftService, "Simple", &args, &resp)
 	if err == nil && !success {
-		if e := resp.SimpleErr; e != nil {
-			err = e
+		switch {
+		case resp.SimpleErr != nil:
+			err = resp.SimpleErr
+		default:
+			err = fmt.Errorf("received no result or unknown exception for Simple")
+		}
+	}
+
+	return err
+}
+
+func (c *tchanSimpleServiceClient) SimpleFuture(ctx thrift.Context) error {
+	var resp SimpleServiceSimpleFutureResult
+	args := SimpleServiceSimpleFutureArgs{}
+	success, err := c.client.Call(ctx, c.thriftService, "SimpleFuture", &args, &resp)
+	if err == nil && !success {
+		switch {
+		case resp.SimpleErr != nil:
+			err = resp.SimpleErr
+		case resp.NewErr_ != nil:
+			err = resp.NewErr_
+		default:
+			err = fmt.Errorf("received no result or unknown exception for SimpleFuture")
 		}
 	}
 
@@ -168,6 +198,7 @@ func (s *tchanSimpleServiceServer) Methods() []string {
 	return []string{
 		"Call",
 		"Simple",
+		"SimpleFuture",
 	}
 }
 
@@ -177,6 +208,8 @@ func (s *tchanSimpleServiceServer) Handle(ctx thrift.Context, methodName string,
 		return s.handleCall(ctx, protocol)
 	case "Simple":
 		return s.handleSimple(ctx, protocol)
+	case "SimpleFuture":
+		return s.handleSimpleFuture(ctx, protocol)
 
 	default:
 		return false, nil, fmt.Errorf("method %v not found in service %v", methodName, s.Service())
@@ -221,6 +254,38 @@ func (s *tchanSimpleServiceServer) handleSimple(ctx thrift.Context, protocol ath
 				return false, nil, fmt.Errorf("Handler for simpleErr returned non-nil error type *SimpleErr but nil value")
 			}
 			res.SimpleErr = v
+		default:
+			return false, nil, err
+		}
+	} else {
+	}
+
+	return err == nil, &res, nil
+}
+
+func (s *tchanSimpleServiceServer) handleSimpleFuture(ctx thrift.Context, protocol athrift.TProtocol) (bool, athrift.TStruct, error) {
+	var req SimpleServiceSimpleFutureArgs
+	var res SimpleServiceSimpleFutureResult
+
+	if err := req.Read(protocol); err != nil {
+		return false, nil, err
+	}
+
+	err :=
+		s.handler.SimpleFuture(ctx)
+
+	if err != nil {
+		switch v := err.(type) {
+		case *SimpleErr:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for simpleErr returned non-nil error type *SimpleErr but nil value")
+			}
+			res.SimpleErr = v
+		case *NewErr_:
+			if v == nil {
+				return false, nil, fmt.Errorf("Handler for newErr returned non-nil error type *NewErr_ but nil value")
+			}
+			res.NewErr_ = v
 		default:
 			return false, nil, err
 		}

--- a/thrift/gen-go/test/ttypes.go
+++ b/thrift/gen-go/test/ttypes.go
@@ -21,9 +21,9 @@ var GoUnusedProtection__ int
 //  - S2
 //  - I3
 type Data struct {
-	B1 bool   `thrift:"b1,1" db:"b1" json:"b1"`
-	S2 string `thrift:"s2,2" db:"s2" json:"s2"`
-	I3 int32  `thrift:"i3,3" db:"i3" json:"i3"`
+	B1 bool   `thrift:"b1,1,required" db:"b1" json:"b1"`
+	S2 string `thrift:"s2,2,required" db:"s2" json:"s2"`
+	I3 int32  `thrift:"i3,3,required" db:"i3" json:"i3"`
 }
 
 func NewData() *Data {
@@ -46,6 +46,10 @@ func (p *Data) Read(iprot thrift.TProtocol) error {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
 	}
 
+	var issetB1 bool = false
+	var issetS2 bool = false
+	var issetI3 bool = false
+
 	for {
 		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
 		if err != nil {
@@ -59,14 +63,17 @@ func (p *Data) Read(iprot thrift.TProtocol) error {
 			if err := p.ReadField1(iprot); err != nil {
 				return err
 			}
+			issetB1 = true
 		case 2:
 			if err := p.ReadField2(iprot); err != nil {
 				return err
 			}
+			issetS2 = true
 		case 3:
 			if err := p.ReadField3(iprot); err != nil {
 				return err
 			}
+			issetI3 = true
 		default:
 			if err := iprot.Skip(fieldTypeId); err != nil {
 				return err
@@ -78,6 +85,15 @@ func (p *Data) Read(iprot thrift.TProtocol) error {
 	}
 	if err := iprot.ReadStructEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	if !issetB1 {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field B1 is not set"))
+	}
+	if !issetS2 {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field S2 is not set"))
+	}
+	if !issetI3 {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field I3 is not set"))
 	}
 	return nil
 }
@@ -269,5 +285,100 @@ func (p *SimpleErr) String() string {
 }
 
 func (p *SimpleErr) Error() string {
+	return p.String()
+}
+
+// Attributes:
+//  - Message
+type NewErr_ struct {
+	Message string `thrift:"message,1" db:"message" json:"message"`
+}
+
+func NewNewErr_() *NewErr_ {
+	return &NewErr_{}
+}
+
+func (p *NewErr_) GetMessage() string {
+	return p.Message
+}
+func (p *NewErr_) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *NewErr_) ReadField1(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		p.Message = v
+	}
+	return nil
+}
+
+func (p *NewErr_) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("NewErr"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if err := p.writeField1(oprot); err != nil {
+		return err
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *NewErr_) writeField1(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("message", thrift.STRING, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:message: ", p), err)
+	}
+	if err := oprot.WriteString(string(p.Message)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.message (1) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:message: ", p), err)
+	}
+	return err
+}
+
+func (p *NewErr_) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("NewErr_(%+v)", *p)
+}
+
+func (p *NewErr_) Error() string {
 	return p.String()
 }

--- a/thrift/mocks/TChanSecondService.go
+++ b/thrift/mocks/TChanSecondService.go
@@ -28,11 +28,22 @@ type TChanSecondService struct {
 	mock.Mock
 }
 
-func (m *TChanSecondService) Echo(ctx thrift.Context, arg string) (string, error) {
-	ret := m.Called(ctx, arg)
+func (_m *TChanSecondService) Echo(_ctx thrift.Context, _arg string) (string, error) {
+	ret := _m.Called(_ctx, _arg)
 
-	r0 := ret.Get(0).(string)
-	r1 := ret.Error(1)
+	var r0 string
+	if rf, ok := ret.Get(0).(func(thrift.Context, string) string); ok {
+		r0 = rf(_ctx, _arg)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, string) error); ok {
+		r1 = rf(_ctx, _arg)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }

--- a/thrift/mocks/TChanSimpleService.go
+++ b/thrift/mocks/TChanSimpleService.go
@@ -29,21 +29,48 @@ type TChanSimpleService struct {
 	mock.Mock
 }
 
-func (m *TChanSimpleService) Call(ctx thrift.Context, arg *test.Data) (*test.Data, error) {
-	ret := m.Called(ctx, arg)
+func (_m *TChanSimpleService) Call(_ctx thrift.Context, _arg *test.Data) (*test.Data, error) {
+	ret := _m.Called(_ctx, _arg)
 
 	var r0 *test.Data
-	if ret.Get(0) != nil {
-		r0 = ret.Get(0).(*test.Data)
+	if rf, ok := ret.Get(0).(func(thrift.Context, *test.Data) *test.Data); ok {
+		r0 = rf(_ctx, _arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*test.Data)
+		}
 	}
-	r1 := ret.Error(1)
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(thrift.Context, *test.Data) error); ok {
+		r1 = rf(_ctx, _arg)
+	} else {
+		r1 = ret.Error(1)
+	}
 
 	return r0, r1
 }
-func (m *TChanSimpleService) Simple(ctx thrift.Context) error {
-	ret := m.Called(ctx)
+func (_m *TChanSimpleService) Simple(_ctx thrift.Context) error {
+	ret := _m.Called(_ctx)
 
-	r0 := ret.Error(0)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context) error); ok {
+		r0 = rf(_ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+func (_m *TChanSimpleService) SimpleFuture(_ctx thrift.Context) error {
+	ret := _m.Called(_ctx)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(thrift.Context) error); ok {
+		r0 = rf(_ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
 
 	return r0
 }

--- a/thrift/test.thrift
+++ b/thrift/test.thrift
@@ -8,9 +8,14 @@ exception SimpleErr {
   1: string message
 }
 
+exception NewErr {
+  1: string message
+}
+
 service SimpleService {
   Data Call(1: Data arg)
   void Simple() throws (1: SimpleErr simpleErr)
+  void SimpleFuture() throws (1: SimpleErr simpleErr, 2: NewErr newErr)
 }
 
 service SecondService {

--- a/thrift/thrift-gen/tchannel-template.go
+++ b/thrift/thrift-gen/tchannel-template.go
@@ -77,11 +77,14 @@ func {{ .ClientConstructor }}(client thrift.TChanClient) {{ .Interface }} {
 		}
 		success, err := c.client.Call(ctx, c.thriftService, "{{ .ThriftName }}", &args, &resp)
 		if err == nil && !success {
+			switch {
 			{{ range .Exceptions }}
-				if e := resp.{{ .ArgStructName }}; e != nil {
-					err = e
-				}
+			case resp.{{ .ArgStructName }} != nil:
+				err = resp.{{ .ArgStructName }}
 			{{ end }}
+			default:
+				err = fmt.Errorf("received no result or unknown exception for {{ .ThriftName }}")
+			}
 		}
 
 		{{ if .HasReturn }}

--- a/thrift/tracing_test.go
+++ b/thrift/tracing_test.go
@@ -14,7 +14,9 @@ import (
 
 // ThriftHandler tests tracing over Thrift encoding
 type ThriftHandler struct {
+	gen.TChanSimpleService // leave nil so calls to unimplemented methods panic.
 	TraceHandler
+
 	thriftClient gen.TChanSimpleService
 	t            *testing.T
 }
@@ -60,10 +62,6 @@ func (h *ThriftHandler) Call(ctx thrift.Context, arg *gen.Data) (*gen.Data, erro
 		return nil, err
 	}
 	return responseToThrift(h.t, res)
-}
-
-func (h *ThriftHandler) Simple(ctx thrift.Context) error {
-	return nil
 }
 
 func (h *ThriftHandler) firstCall(ctx context.Context, req *TracingRequest) (*TracingResponse, error) {


### PR DESCRIPTION
This can happen if if the service sends an exception from the future
that the client side does not know about and cannot decode.

Previously, the user would just get a `nil` response object and a `nil`
error which is harder to debug.

Fixes #561