### PR TITLE
Refactor connection options propagation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -132,7 +132,7 @@ type ConnectionOptions struct {
 	// The frame pool, allowing better management of frame buffers. Defaults to using raw heap.
 	FramePool FramePool
 
-	// The size of receive channel buffers. Defaults to 512.
+	// NOTE: This is deprecated and not used for anything.
 	RecvBufferSize int
 
 	// The size of send channel buffers. Defaults to 512.
@@ -253,9 +253,6 @@ func (co ConnectionOptions) withDefaults() ConnectionOptions {
 	if co.SendBufferSize <= 0 {
 		co.SendBufferSize = defaultConnectionBufferSize
 	}
-	if co.RecvBufferSize <= 0 {
-		co.RecvBufferSize = defaultConnectionBufferSize
-	}
 	return co
 }
 
@@ -312,7 +309,7 @@ func (ch *Channel) newConnection(conn net.Conn, outboundHP string, initialState 
 		conn:            conn,
 		opts:            opts,
 		state:           initialState,
-		sendCh:          make(chan *Frame, opts.RecvBufferSize),
+		sendCh:          make(chan *Frame, opts.SendBufferSize),
 		stopCh:          make(chan struct{}),
 		localPeerInfo:   peerInfo,
 		outboundHP:      outboundHP,

--- a/inbound.go
+++ b/inbound.go
@@ -53,7 +53,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 
 	callReq := new(callReq)
 	callReq.id = frame.Header.ID
-	initialFragment, err := parseInboundFragment(c.framePool, frame, callReq)
+	initialFragment, err := parseInboundFragment(c.opts.FramePool, frame, callReq)
 	if err != nil {
 		// TODO(mmihic): Probably want to treat this as a protocol error
 		c.log.WithFields(
@@ -73,7 +73,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	}
 	defer c.pendingExchangeMethodDone()
 
-	mex, err := c.inbound.newExchange(ctx, c.framePool, callReq.messageType(), frame.Header.ID, mexChannelBufferSize)
+	mex, err := c.inbound.newExchange(ctx, c.opts.FramePool, callReq.messageType(), frame.Header.ID, mexChannelBufferSize)
 	if err != nil {
 		if err == errDuplicateMex {
 			err = errInboundRequestAlreadyActive
@@ -168,7 +168,7 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 			LogField{"remotePeer", c.remotePeerInfo},
 			ErrField(err),
 		).Error("Couldn't read method.")
-		c.framePool.Release(frame)
+		c.opts.FramePool.Release(frame)
 		return
 	}
 

--- a/outbound.go
+++ b/outbound.go
@@ -74,7 +74,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 	defer c.pendingExchangeMethodDone()
 
 	requestID := c.NextMessageID()
-	mex, err := c.outbound.newExchange(ctx, c.framePool, messageTypeCallReq, requestID, mexChannelBufferSize)
+	mex, err := c.outbound.newExchange(ctx, c.opts.FramePool, messageTypeCallReq, requestID, mexChannelBufferSize)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 		return new(callReqContinue)
 	}
 
-	call.contents = newFragmentingWriter(call.log, call, c.checksumType.New())
+	call.contents = newFragmentingWriter(call.log, call, c.opts.ChecksumType.New())
 
 	response := new(OutboundCallResponse)
 	response.startedAt = now

--- a/relay.go
+++ b/relay.go
@@ -547,7 +547,7 @@ func (r *Relayer) handleLocalCallReq(cr lazyCallReq) bool {
 	}
 
 	if release := r.conn.handleFrameNoRelay(f); release {
-		r.conn.framePool.Release(f)
+		r.conn.opts.FramePool.Release(f)
 	}
 	return true
 }

--- a/reqres.go
+++ b/reqres.go
@@ -116,7 +116,7 @@ func (w *reqResWriter) newFragment(initial bool, checksum Checksum) (*writableFr
 	message := w.messageForFragment(initial)
 
 	// Create the frame
-	frame := w.conn.framePool.Get()
+	frame := w.conn.opts.FramePool.Get()
 	frame.Header.ID = w.mex.msgID
 	frame.Header.messageType = message.messageType()
 


### PR DESCRIPTION
As we add more connection options, we keep duplicating them in
the connection struct. Instead, we can store the connection options
struct as a field in the connection.

This is some prefactoring for the active health checking work.