### PR TITLE
Publicize channel root peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+# v1.3.0 (unreleased)
+
+* Exposes the channel's RootPeerList with `channel.RootPeers()`.
+
 # v1.2.3
 
 * Improve error messages when an argument reader is closed without
@@ -9,7 +13,7 @@ Changelog
   but none was found (e.g., exception is from the future). (#566)
 * Fix ListenIP selecting docker interfaces over physical networks. (#565)
 * Fix for error when a Thrift payload has completed decoding and attempts
-  to close the argument reader without waiting till EOF.  (#564)
+  to close the argument reader without waiting until EOF.  (#564)
 * thrift-gen: Fix "namespace go" being ignored even though the Apache thrift
   generated code was respecting it. (#559)
 

--- a/introspection.go
+++ b/introspection.go
@@ -216,7 +216,7 @@ func (ch *Channel) IntrospectState(opts *IntrospectionOptions) *RuntimeState {
 		CreatedStack:   ch.createdStack,
 		LocalPeer:      ch.PeerInfo(),
 		SubChannels:    ch.subChannels.IntrospectState(opts),
-		RootPeers:      ch.rootPeers().IntrospectState(opts),
+		RootPeers:      ch.RootPeers().IntrospectState(opts),
 		Peers:          ch.Peers().IntrospectList(opts),
 		NumConnections: numConns,
 		Connections:    connIDs,

--- a/relay.go
+++ b/relay.go
@@ -196,7 +196,7 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 		localHandler: ch.relayLocal,
 		outbound:     newRelayItems(ch.Logger().WithFields(LogField{"relay", "outbound"})),
 		inbound:      newRelayItems(ch.Logger().WithFields(LogField{"relay", "inbound"})),
-		peers:        ch.rootPeers(),
+		peers:        ch.RootPeers(),
 		conn:         conn,
 		logger:       conn.log,
 	}

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -33,11 +33,6 @@ import (
 // MexChannelBufferSize is the size of the message exchange channel buffer.
 const MexChannelBufferSize = mexChannelBufferSize
 
-// RootPeers returns the root peer list from the Channel.
-func (ch *Channel) RootPeers() *RootPeerList {
-	return ch.rootPeers()
-}
-
 // SetOnUpdate sets onUpdate for a peer, which is called when the peer's score is
 // updated in all peer lists.
 func (p *Peer) SetOnUpdate(f func(*Peer)) {


### PR DESCRIPTION
This change reveals the root peer list on the channel’s public interface. This allows a library, say YARPC, to provide alternate peer list implementations and manage the lifecycle of retained peers without affecting unrelated TChannel proper peer lists.

Test coverage existed for RootPeers as the method was previously exposed as public but only for the purpose of tests. Clever!