### PR TITLE
Add version information to LocalPeerInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+# v1.4.0 (unreleased)
+
+* Add version information to the channel's LocalPeerInfo.
+
 # v1.3.0
 
 * Exposes the channel's RootPeerList with `channel.RootPeers()`.

--- a/channel.go
+++ b/channel.go
@@ -26,6 +26,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -220,6 +222,11 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 			ProcessName: processName,
 			HostPort:    ephemeralHostPort,
 			IsEphemeral: true,
+			Version: PeerVersion{
+				Language:        "go",
+				LanguageVersion: strings.TrimPrefix(runtime.Version(), "go"),
+				TChannelVersion: VersionInfo,
+			},
 		},
 		ServiceName: serviceName,
 	}

--- a/channel_test.go
+++ b/channel_test.go
@@ -24,6 +24,8 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +41,27 @@ func toMap(fields LogFields) map[string]interface{} {
 		m[f.Key] = f.Value
 	}
 	return m
+}
+
+func TestNewChannel(t *testing.T) {
+	ch, err := NewChannel("svc", &ChannelOptions{
+		ProcessName: "pname",
+	})
+	require.NoError(t, err, "NewChannel failed")
+
+	assert.Equal(t, LocalPeerInfo{
+		ServiceName: "svc",
+		PeerInfo: PeerInfo{
+			ProcessName: "pname",
+			HostPort:    ephemeralHostPort,
+			IsEphemeral: true,
+			Version: PeerVersion{
+				Language:        "go",
+				LanguageVersion: strings.TrimPrefix(runtime.Version(), "go"),
+				TChannelVersion: VersionInfo,
+			},
+		},
+	}, ch.PeerInfo(), "Wrong local peer info")
 }
 
 func TestLoggers(t *testing.T) {

--- a/connection.go
+++ b/connection.go
@@ -27,9 +27,7 @@ import (
 	"io"
 	"math"
 	"net"
-	"runtime"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -364,9 +362,9 @@ func (c *Connection) getInitParams() initParams {
 	return initParams{
 		InitParamHostPort:                c.localPeerInfo.HostPort,
 		InitParamProcessName:             c.localPeerInfo.ProcessName,
-		InitParamTChannelLanguage:        "go",
-		InitParamTChannelLanguageVersion: strings.TrimPrefix(runtime.Version(), "go"),
-		InitParamTChannelVersion:         VersionInfo,
+		InitParamTChannelLanguage:        c.localPeerInfo.Version.Language,
+		InitParamTChannelLanguageVersion: c.localPeerInfo.Version.LanguageVersion,
+		InitParamTChannelVersion:         c.localPeerInfo.Version.TChannelVersion,
 	}
 }
 


### PR DESCRIPTION
Currently, version information is set for remote peers, but not for local peers.