### PR TITLE
Update the peer scores when SetStrategy is called

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -544,7 +544,7 @@ func (ch *Channel) exchangeUpdated(c *Connection) {
 
 // updatePeer updates the score of the peer and update it's position in heap as well.
 func (ch *Channel) updatePeer(p *Peer) {
-	ch.peers.updatePeer(p)
+	ch.peers.onPeerChange(p)
 	ch.subChannels.updatePeer(p)
 	p.callOnUpdateComplete()
 }

--- a/peer.go
+++ b/peer.go
@@ -83,7 +83,7 @@ func (l *PeerList) SetStrategy(sc ScoreCalculator) {
 
 	l.scoreCalculator = sc
 	for _, ps := range l.peersByHostPort {
-		l.updatePeerScore(ps, ps.score)
+		l.updatePeer(ps, ps.score)
 	}
 }
 
@@ -227,22 +227,22 @@ func (l *PeerList) exists(hostPort string) (*peerScore, uint64, bool) {
 	return ps, score, ok
 }
 
-// updatePeer is called when there is a change that may cause the peer's score to change.
+// onPeerChange is called when there is a change that may cause the peer's score to change.
 // The new score is calculated, and the peer heap is updated with the new score if the score changes.
-func (l *PeerList) updatePeer(p *Peer) {
+func (l *PeerList) onPeerChange(p *Peer) {
 	ps, psScore, ok := l.exists(p.hostPort)
 	if !ok {
 		return
 	}
 
 	l.Lock()
-	l.updatePeerScore(ps, psScore)
+	l.updatePeer(ps, psScore)
 	l.Unlock()
 }
 
-// Try to update the score of the peer given the existing score.
+// updatePeer is called to update the score of the peer given the existing score.
 // Note that a Write lock must be held to call this function.
-func (l *PeerList) updatePeerScore(ps *peerScore, psScore uint64) {
+func (l *PeerList) updatePeer(ps *peerScore, psScore uint64) {
 	newScore := l.scoreCalculator.GetScore(ps.Peer)
 	if newScore == psScore {
 		return

--- a/peer_test.go
+++ b/peer_test.go
@@ -1148,3 +1148,27 @@ func BenchmarkAddPeers(b *testing.B) {
 		}
 	}
 }
+
+func TestPeerSelectionStrategyChange(t *testing.T) {
+	const numPeers = 2
+
+	ch := testutils.NewClient(t, nil)
+	defer ch.Close()
+
+	for i := 0; i < numPeers; i++ {
+		ch.Peers().Add(fmt.Sprintf("127.0.0.1:60%v", i))
+	}
+
+	for _, score := range []uint64{1000, 2000} {
+		ch.Peers().SetStrategy(createConstScoreStrategy(score))
+		for _, v := range ch.Peers().IntrospectList(nil) {
+			assert.Equal(t, v.Score, score)
+		}
+	}
+}
+
+func createConstScoreStrategy(score uint64) (calc ScoreCalculator) {
+	return ScoreCalculatorFunc(func(p *Peer) uint64 {
+		return score
+	})
+}

--- a/subchannel.go
+++ b/subchannel.go
@@ -212,7 +212,7 @@ func (subChMap *subChannelMap) updatePeer(p *Peer) {
 	for _, subCh := range subChMap.subchannels {
 		if subCh.Isolated() {
 			subCh.RLock()
-			subCh.Peers().updatePeer(p)
+			subCh.Peers().onPeerChange(p)
 			subCh.RUnlock()
 		}
 	}


### PR DESCRIPTION
Fixes #580.

I took a heavy locking approach to this change, as I think that it's not safe to allow any access to any peer while the change is occurring, i.e. until all peers have been updated, the data is in an inconsistent state, and peers should not be compared to each other.

It's also worth noting that `.scoreCalculator` was not being protected, so there could have been a race with setting that, vs using it.