### PR TITLE
Override inbound request handler

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -313,7 +313,7 @@ func (ch *Channel) newConnection(conn net.Conn, outboundHP string, initialState 
 		outboundHP:      outboundHP,
 		inbound:         newMessageExchangeSet(log, messageExchangeSetInbound),
 		outbound:        newMessageExchangeSet(log, messageExchangeSetOutbound),
-		handler:         channelHandler{ch},
+		handler:         ch.handler,
 		events:          events,
 		commonStatsTags: ch.commonStatsTags,
 	}

--- a/subchannel_test.go
+++ b/subchannel_test.go
@@ -252,3 +252,19 @@ func TestGetSubchannelOptionsOnNew(t *testing.T) {
 	require.NoError(t, err, "Should get peer")
 	assert.Equal(t, want, peer, "Unexpected peer")
 }
+
+func TestHandlerWithoutSubChannel(t *testing.T) {
+	opts := testutils.NewOpts().NoRelay()
+	opts.Handler = raw.Wrap(newTestHandler(t))
+	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+		client := ts.NewClient(nil)
+		testutils.AssertEcho(t, client, ts.HostPort(), ts.ServiceName())
+		testutils.AssertEcho(t, client, ts.HostPort(), "larry")
+		testutils.AssertEcho(t, client, ts.HostPort(), "curly")
+		testutils.AssertEcho(t, client, ts.HostPort(), "moe")
+
+		assert.Panics(t, func() {
+			ts.Server().Register(raw.Wrap(newTestHandler(t)), "nyuck")
+		})
+	})
+}


### PR DESCRIPTION
The default inbound request handler delegates to the subchannel for a service name. YARPC needs the ability to dispatch or forward requests with arbitrary service names. To do so, it needs to bypass the subchannel router. This introduces an option to the Channel constructor to thread an alternate root handler.