### PR TITLE
Fix flaky TestWriteArg3AfterTimeout

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -535,7 +535,7 @@ func TestWriteArg3AfterTimeout(t *testing.T) {
 			assert.NoError(t, err, "Arg3Writer failed")
 
 			for {
-				if _, err := writer.Write(testutils.RandBytes(4096)); err != nil {
+				if _, err := writer.Write(testutils.RandBytes(4)); err != nil {
 					assert.Equal(t, err, ErrTimeout, "Handler should timeout")
 					close(timedOut)
 					return


### PR DESCRIPTION
TestWriteArg3AfterTimeout is failing when the relay stops forwarding
calls after the TCP buffer fills up:
```

r:          Not equal: []string{"timeout"} (expected)
                                != []string{"relay-dest-conn-slow"} (actual)

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -1,3 +1,3 @@
                         ([]string) (len=1 cap=1) {
                        - (string) (len=7) "timeout"
                        + (string) (len=20) "relay-dest-conn-slow"
                         }
        Messages:       Unexpected reasons for RPC failure.
```

Reducing the size of the writes we make will avoid filling up the TCP buffer, and stop the
relay-dest-conn-slow failures.