### PR TITLE
Fix flaky TestIntrospectNumConnections

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -281,10 +281,11 @@ func (ch *Channel) newConnection(conn net.Conn, outboundHP string, remotePeer Pe
 		c.relay = NewRelayer(ch, c)
 	}
 
-	go c.readFrames(connID)
-	go c.writeFrames(connID)
 	// Connections are activated as soon as they are created.
 	c.callOnActive()
+
+	go c.readFrames(connID)
+	go c.writeFrames(connID)
 	return c
 }
 


### PR DESCRIPTION
See failure:
https://travis-ci.org/uber/tchannel-go/jobs/205167194

Test pings from new clients to a server, and verifies the number of
connections the server should have. The test is flaky since we don't add
connections to the internal connection list before we start the
read/write goroutines on the connection, so we can end up processing
pings/calls on a connection before we've added the connection to the
list.