### PR TITLE
Don't reuse id 1 on first call when used for init req.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -237,13 +237,14 @@ func (co ConnectionOptions) withDefaults() ConnectionOptions {
 	return co
 }
 
-func (ch *Channel) newConnection(conn net.Conn, outboundHP string, remotePeer PeerInfo, remotePeerAddress peerAddressComponents, events connectionEvents) *Connection {
+func (ch *Channel) newConnection(conn net.Conn, initialID uint32, outboundHP string, remotePeer PeerInfo, remotePeerAddress peerAddressComponents, events connectionEvents) *Connection {
 	opts := ch.connectionOptions.withDefaults()
 
 	connID := _nextConnID.Inc()
 	log := ch.log.WithFields(LogFields{
 		{"connID", connID},
 		{"localAddr", conn.LocalAddr()},
+		{"outboundHP", outboundHP},
 		{"remoteAddr", conn.RemoteAddr()},
 		{"remoteHostPort", remotePeer.HostPort},
 		{"remoteIsEphemeral", remotePeer.IsEphemeral},
@@ -271,6 +272,8 @@ func (ch *Channel) newConnection(conn net.Conn, outboundHP string, remotePeer Pe
 		events:            events,
 		commonStatsTags:   ch.commonStatsTags,
 	}
+
+	c.nextMessageID.Store(initialID)
 	c.log = log
 	c.inbound.onRemoved = c.checkExchanges
 	c.outbound.onRemoved = c.checkExchanges

--- a/preinit_connection.go
+++ b/preinit_connection.go
@@ -63,7 +63,7 @@ func (ch *Channel) outboundHandshake(ctx context.Context, c net.Conn, outboundHP
 		return nil, NewWrappedSystemError(ErrCodeProtocol, err)
 	}
 
-	return ch.newConnection(c, outboundHP, remotePeer, remotePeerAddress, events), nil
+	return ch.newConnection(c, 1 /* initialID */, outboundHP, remotePeer, remotePeerAddress, events), nil
 }
 
 func (ch *Channel) inboundHandshake(ctx context.Context, c net.Conn, events connectionEvents) (_ *Connection, err error) {
@@ -94,7 +94,7 @@ func (ch *Channel) inboundHandshake(ctx context.Context, c net.Conn, events conn
 		return nil, err
 	}
 
-	return ch.newConnection(c, "" /* outboundHP */, remotePeer, remotePeerAddress, events), nil
+	return ch.newConnection(c, 0 /* initialID */, "" /* outboundHP */, remotePeer, remotePeerAddress, events), nil
 }
 
 func (ch *Channel) getInitParams() initParams {


### PR DESCRIPTION
As part of #587, we no longer use the connection's `nextMessageID` field
for init req messages, and so a new outbound connection would reuse id 1
for the first ping/call.