### PR TITLE
Improve connection logging

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -616,8 +616,7 @@ func (ch *Channel) connectionActive(c *Connection, direction connectionDirection
 
 	if added := ch.addConnection(c, direction); !added {
 		// The channel isn't in a valid state to accept this connection, close the connection.
-		c.log.Debugf("Closing connection due to closing channel state")
-		c.Close()
+		c.close(LogField{"reason", "new active connection on closing channel"})
 		return
 	}
 
@@ -763,7 +762,7 @@ func (ch *Channel) Close() {
 	ch.mutable.Unlock()
 
 	for _, c := range connections {
-		c.Close()
+		c.close(LogField{"reason", "channel closing"})
 	}
 
 	if channelClosed {

--- a/connection.go
+++ b/connection.go
@@ -244,15 +244,23 @@ func (ch *Channel) newConnection(conn net.Conn, initialID uint32, outboundHP str
 	log := ch.log.WithFields(LogFields{
 		{"connID", connID},
 		{"localAddr", conn.LocalAddr()},
-		{"outboundHP", outboundHP},
 		{"remoteAddr", conn.RemoteAddr()},
 		{"remoteHostPort", remotePeer.HostPort},
 		{"remoteIsEphemeral", remotePeer.IsEphemeral},
 		{"remoteProcess", remotePeer.ProcessName},
 	}...)
+	if outboundHP != "" {
+		log = log.WithFields(LogFields{
+			{"outboundHP", outboundHP},
+			{"connectionDirection", outbound},
+		}...)
+	} else {
+		log = log.WithFields(LogFields{
+			{"connectionDirection", inbound},
+		}...)
+	}
 	peerInfo := ch.PeerInfo()
-	log.Debugf("Connection created for %v (%v) local: %v remote: %v",
-		peerInfo.ServiceName, peerInfo.ProcessName, conn.LocalAddr(), conn.RemoteAddr())
+
 	c := &Connection{
 		channelConnectionCommon: ch.channelConnectionCommon,
 
@@ -302,11 +310,16 @@ func (c *Connection) IsActive() bool {
 }
 
 func (c *Connection) callOnActive() {
-	msg := "Inbound connection is active."
-	if c.outboundHP != "" {
-		msg = "Outbound connection is active."
+	log := c.log
+	if remoteVersion := c.remotePeerInfo.Version; remoteVersion != (PeerVersion{}) {
+		log = log.WithFields(LogFields{
+			{"remotePeerLanguage", remoteVersion.Language},
+			{"remotePeerLanguageVersion", remoteVersion.LanguageVersion},
+			{"remotePeerTChannelVersion", remoteVersion.TChannelVersion},
+		}...)
 	}
-	c.log.Info(msg)
+	log.Info("Created new active connection.")
+
 	if f := c.events.OnActive; f != nil {
 		f(c)
 	}
@@ -496,8 +509,17 @@ func (c *Connection) connectionError(site string, err error) error {
 		return nil
 	})
 
+	var closeLogFields LogFields
+	if err == io.EOF {
+		closeLogFields = LogFields{{"reason", "network connection EOF"}}
+	} else {
+		closeLogFields = LogFields{
+			{"reason", "connection error"},
+			ErrField(err),
+		}
+	}
 	err = c.logConnectionError(site, err)
-	c.Close()
+	c.close(closeLogFields...)
 
 	// On any connection error, notify the exchanges of this error.
 	if c.stoppedExchanges.CAS(0, 1) {
@@ -512,7 +534,10 @@ func (c *Connection) protocolError(id uint32, err error) error {
 	sysErr := NewWrappedSystemError(ErrCodeProtocol, err)
 	c.SendSystemError(id, Span{}, sysErr)
 	// Don't close the connection until the error has been sent.
-	c.Close()
+	c.close(LogFields{
+		{"reason", "protocol error"},
+		ErrField(err),
+	}...)
 
 	// On any connection error, notify the exchanges of this error.
 	if c.stoppedExchanges.CAS(0, 1) {
@@ -728,15 +753,13 @@ func (c *Connection) checkExchanges() {
 
 		c.log.WithFields(
 			LogField{"newState", updated},
-		).Info("Connection state updated during shutdown.")
+		).Debug("Connection state updated during shutdown.")
 		c.callOnCloseStateChange()
 	}
 }
 
-// Close starts a graceful Close which will first reject incoming calls, reject outgoing calls
-// before finally marking the connection state as closed.
-func (c *Connection) Close() error {
-	c.log.Info("Connection.Close called.")
+func (c *Connection) close(fields ...LogField) error {
+	c.log.WithFields(fields...).Info("Connection closing.")
 
 	// Update the state which will start blocking incoming calls.
 	if err := c.withStateLock(func() error {
@@ -753,13 +776,19 @@ func (c *Connection) Close() error {
 
 	c.log.WithFields(
 		LogField{"newState", c.readState()},
-	).Info("Connection state updated in Close.")
+	).Debug("Connection state updated in Close.")
 	c.callOnCloseStateChange()
 
 	// Check all in-flight requests to see whether we can transition the Close state.
 	c.checkExchanges()
 
 	return nil
+}
+
+// Close starts a graceful Close which will first reject incoming calls, reject outgoing calls
+// before finally marking the connection state as closed.
+func (c *Connection) Close() error {
+	return c.close(LogField{"reason", "user initiated"})
 }
 
 // closeNetwork closes the network connection and all network-related channels.

--- a/connection.go
+++ b/connection.go
@@ -255,9 +255,7 @@ func (ch *Channel) newConnection(conn net.Conn, initialID uint32, outboundHP str
 			{"connectionDirection", outbound},
 		}...)
 	} else {
-		log = log.WithFields(LogFields{
-			{"connectionDirection", inbound},
-		}...)
+		log = log.WithFields(LogField{"connectionDirection", inbound})
 	}
 	peerInfo := ch.PeerInfo()
 
@@ -534,10 +532,10 @@ func (c *Connection) protocolError(id uint32, err error) error {
 	sysErr := NewWrappedSystemError(ErrCodeProtocol, err)
 	c.SendSystemError(id, Span{}, sysErr)
 	// Don't close the connection until the error has been sent.
-	c.close(LogFields{
-		{"reason", "protocol error"},
+	c.close(
+		LogField{"reason", "protocol error"},
 		ErrField(err),
-	}...)
+	)
 
 	// On any connection error, notify the exchanges of this error.
 	if c.stoppedExchanges.CAS(0, 1) {

--- a/root_peer_list.go
+++ b/root_peer_list.go
@@ -103,7 +103,7 @@ func (l *RootPeerList) onClosedConnRemoved(peer *Peer) {
 		l.Unlock()
 		l.channel.Logger().WithFields(
 			LogField{"remoteHostPort", hostPort},
-		).Info("Removed peer from root peer list.")
+		).Debug("Removed peer from root peer list.")
 	}
 }
 


### PR DESCRIPTION
Our health checks currently use a new TCP connection and we have a large
number of info logs for each health check (which is a very short lived
connection).

Improve the info logs to contain more information, and reduce the level
of less relevant logs to Debug.

Fixes #599