### PR TITLE
Consistent error logging on init handshake errors

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -454,8 +454,6 @@ func (ch *Channel) serve() {
 				OnExchangeUpdated:  ch.exchangeUpdated,
 			}
 			if _, err := ch.inboundHandshake(context.Background(), netConn, events); err != nil {
-				// Server is getting overloaded - begin rejecting new connections
-				ch.log.WithFields(ErrField(err)).Error("Couldn't create new TChannelConnection for incoming conn.")
 				netConn.Close()
 			}
 		}()

--- a/connection_test.go
+++ b/connection_test.go
@@ -777,7 +777,7 @@ func TestConnectTimeout(t *testing.T) {
 }
 
 func TestParallelConnectionAccepts(t *testing.T) {
-	opts := testutils.NewOpts().AddLogFilter("Couldn't create new TChannelConnection", 1)
+	opts := testutils.NewOpts().AddLogFilter("Failed during connection handshake", 1)
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 

--- a/init_test.go
+++ b/init_test.go
@@ -83,6 +83,16 @@ func TestUnexpectedInitReq(t *testing.T) {
 				errCode: ErrCodeProtocol,
 			},
 		},
+		{
+			name: "unexpected message type",
+			initMsg: &pingReq{
+				id: 1,
+			},
+			expectedError: errorMessage{
+				id:      1,
+				errCode: ErrCodeProtocol,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently, the inbound side logging may log different messages in
different cases. We may log "Couldn't create new TChannelConnection",
"Failed during connection handshake", or both depending on where the
error occurred in the handshake.

Instead, make this consistent with the outbound side to always only
log "Failed during connection handshake". This also ensures that we send
back an error when we get the wrong message type as the first frame on
an init req.

Also include `localAddr` and `remoteAddr` (consistent with connection logging) when logging init handshake errors.