### PR TITLE
relay: Remove relay.Conn and use Connection directly

### DIFF
--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -36,7 +36,7 @@ type fixedHosts struct {
 	pickI atomic.Int32
 }
 
-func (fh *fixedHosts) Get(cf relay.CallFrame, _ relay.Conn) (string, error) {
+func (fh *fixedHosts) Get(cf relay.CallFrame, _ *tchannel.Connection) (string, error) {
 	peers := fh.hosts[string(cf.Service())]
 	if len(peers) == 0 {
 		return "", errors.New("no peers")

--- a/relay.go
+++ b/relay.go
@@ -49,9 +49,6 @@ var (
 	errUnknownID             = errors.New("non-callReq for inactive ID")
 )
 
-// relayConn implements the relay.Connection interface.
-type relayConn Connection
-
 type relayItem struct {
 	*time.Timer
 
@@ -334,7 +331,7 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 		return nil
 	}
 
-	call, err := r.relayHost.Start(f, (*relayConn)(r.conn))
+	call, err := r.relayHost.Start(f, r.conn)
 	if err != nil {
 		// If we have a RateLimitDropError we record the statistic, but
 		// we *don't* send an error frame back to the client.
@@ -550,10 +547,6 @@ func (r *Relayer) handleLocalCallReq(cr lazyCallReq) bool {
 		r.conn.opts.FramePool.Release(f)
 	}
 	return true
-}
-
-func (r *relayConn) RemoteHostPort() string {
-	return (*Connection)(r).RemotePeerInfo().HostPort
 }
 
 func frameTypeFor(f *Frame) frameType {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -24,13 +24,6 @@
 // backwards-compatibility guarantee.
 package relay
 
-// Conn is an interface that exposes a bit of information about the underlying
-// connection.
-type Conn interface {
-	// RemoteHostPort returns the host:port of the remote peer.
-	RemoteHostPort() string
-}
-
 // CallFrame is an interface that abstracts access to the call req frame.
 type CallFrame interface {
 	// Caller is the name of the originating service.

--- a/relay/relaytest/func_host.go
+++ b/relay/relaytest/func_host.go
@@ -1,14 +1,14 @@
 package relaytest
 
 import (
-	tchannel "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/relay"
 )
 
 type hostFunc struct {
 	ch    *tchannel.Channel
 	stats *MockStats
-	fn    func(cf relay.CallFrame, conn relay.Conn) (string, error)
+	fn    func(relay.CallFrame, *tchannel.Connection) (string, error)
 }
 
 type hostFuncPeer struct {
@@ -18,7 +18,7 @@ type hostFuncPeer struct {
 }
 
 // HostFunc wraps a given function to implement tchannel.RelayHost.
-func HostFunc(fn func(cf relay.CallFrame, conn relay.Conn) (string, error)) tchannel.RelayHost {
+func HostFunc(fn func(cf relay.CallFrame, _ *tchannel.Connection) (string, error)) tchannel.RelayHost {
 	return &hostFunc{nil, NewMockStats(), fn}
 }
 
@@ -26,7 +26,7 @@ func (hf *hostFunc) SetChannel(ch *tchannel.Channel) {
 	hf.ch = ch
 }
 
-func (hf *hostFunc) Start(cf relay.CallFrame, conn relay.Conn) (tchannel.RelayCall, error) {
+func (hf *hostFunc) Start(cf relay.CallFrame, conn *tchannel.Connection) (tchannel.RelayCall, error) {
 	var peer *tchannel.Peer
 
 	peerHP, err := hf.fn(cf, conn)

--- a/relay/relaytest/func_host.go
+++ b/relay/relaytest/func_host.go
@@ -18,7 +18,7 @@ type hostFuncPeer struct {
 }
 
 // HostFunc wraps a given function to implement tchannel.RelayHost.
-func HostFunc(fn func(cf relay.CallFrame, _ *tchannel.Connection) (string, error)) tchannel.RelayHost {
+func HostFunc(fn func(relay.CallFrame, *tchannel.Connection) (string, error)) tchannel.RelayHost {
 	return &hostFunc{nil, NewMockStats(), fn}
 }
 

--- a/relay/relaytest/stub_host.go
+++ b/relay/relaytest/stub_host.go
@@ -57,7 +57,7 @@ func (rh *StubRelayHost) SetChannel(ch *tchannel.Channel) {
 }
 
 // Start starts a new RelayCall for the given call on a specific connection.
-func (rh *StubRelayHost) Start(cf relay.CallFrame, conn relay.Conn) (tchannel.RelayCall, error) {
+func (rh *StubRelayHost) Start(cf relay.CallFrame, _ *tchannel.Connection) (tchannel.RelayCall, error) {
 	// Get a peer from the subchannel.
 	peer, err := rh.ch.GetSubChannel(string(cf.Service())).Peers().Get(nil)
 	return &stubCall{rh.stats.Begin(cf), peer}, err

--- a/relay_api.go
+++ b/relay_api.go
@@ -32,7 +32,7 @@ type RelayHost interface {
 	// Start starts a new RelayCall given the call frame and connection.
 	// It may return a call and an error, in which case the caller will
 	// call Failed/End on the RelayCall.
-	Start(relay.CallFrame, relay.Conn) (RelayCall, error)
+	Start(relay.CallFrame, *Connection) (RelayCall, error)
 }
 
 // RelayCall abstracts away peer selection, stats, and any other business

--- a/relay_test.go
+++ b/relay_test.go
@@ -199,7 +199,7 @@ func TestRelayErrorsOnGetPeer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		f := func(relay.CallFrame, relay.Conn) (string, error) {
+		f := func(relay.CallFrame, *Connection) (string, error) {
 			return tt.returnPeer, tt.returnErr
 		}
 
@@ -502,8 +502,8 @@ func TestRelayMakeOutgoingCall(t *testing.T) {
 func TestRelayConnection(t *testing.T) {
 	var errTest = errors.New("test")
 	var wantHostPort string
-	getHost := func(call relay.CallFrame, conn relay.Conn) (string, error) {
-		assert.Equal(t, wantHostPort, conn.RemoteHostPort(), "Unexpected RemoteHostPort")
+	getHost := func(call relay.CallFrame, conn *Connection) (string, error) {
+		assert.Equal(t, wantHostPort, conn.RemotePeerInfo().HostPort, "Unexpected RemoteHostPort")
 		return "", errTest
 	}
 
@@ -577,7 +577,7 @@ func TestRelayRejectsDuringClose(t *testing.T) {
 }
 
 func TestRelayRateLimitDrop(t *testing.T) {
-	getHost := func(call relay.CallFrame, conn relay.Conn) (string, error) {
+	getHost := func(call relay.CallFrame, _ *Connection) (string, error) {
 		return "", relay.RateLimitDropError{}
 	}
 
@@ -691,7 +691,7 @@ func TestRelayThroughSeparateRelay(t *testing.T) {
 		SetRelayOnly()
 	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
 		serverHP := ts.Server().PeerInfo().HostPort
-		dummyFactory := func(relay.CallFrame, relay.Conn) (string, error) {
+		dummyFactory := func(relay.CallFrame, *Connection) (string, error) {
 			panic("should not get invoked")
 		}
 		relay2Opts := testutils.NewOpts().SetRelayHost(relaytest.HostFunc(dummyFactory))


### PR DESCRIPTION
relay.Conn was used to expose relay-specific methods that we did not
want on the Connection (see #482). We were able to refactor some code
to remove this logic (#550).

We'd like to access more information about the connection a call started
on, so let's instead expose the Connection object.