### PR TITLE
relay: Close connections if the RelayHost returns a ProtocolError

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -350,6 +350,11 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 			call.End()
 		}
 		r.conn.SendSystemError(f.Header.ID, f.Span(), err)
+
+		// If the RelayHost returns a protocol error, close the connection.
+		if GetSystemErrorCode(err) == ErrCodeProtocol {
+			return r.conn.close(LogField{"reason", "RelayHost returned protocol error"})
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Some old library versions do not follow the protocol correctly and cause
relay failures. We should allow the RelayHost to detect these bad
libraries, and close connections to them by returning a protocol error.