### PR TITLE
Added a peer.GetNew() to only return previously unselected peers.

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -144,13 +144,15 @@ func (l *PeerList) GetNew(prevSelected map[string]struct{}) (*Peer, error) {
 // will avoid previously selected peers if possible.
 func (l *PeerList) Get(prevSelected map[string]struct{}) (*Peer, error) {
 	peer, err := l.GetNew(prevSelected)
-	if err != nil && err != ErrNoNewPeers {
-		return nil, err
-	}
-	if peer == nil {
+	if err == ErrNoNewPeers {
 		l.Lock()
 		peer = l.choosePeer(nil, false /* avoidHost */)
 		l.Unlock()
+	} else if err != nil {
+		return nil, err
+	}
+	if peer == nil {
+		return nil, ErrNoPeers
 	}
 	return peer, nil
 }

--- a/peer_test.go
+++ b/peer_test.go
@@ -169,19 +169,14 @@ func TestGetPeerAvoidPrevSelected(t *testing.T) {
 		}
 
 		newPeer, err := peers.GetNew(rs.PrevSelectedPeers())
-		if err != nil {
-			t.Errorf("Got unexpected error selecting new peer: %v", err)
-			continue
-		}
-
 		if len(tt.peers) == len(tt.prevSelected) {
-			if newPeer != nil {
-				t.Errorf("%s: newPeer should not have been found %v\n", tt.msg, newPeer)
+			if newPeer != nil || err != ErrNoNewPeers {
+				t.Errorf("%s: newPeer should not have been found %v: %v\n", tt.msg, newPeer, err)
 			}
 		} else {
-			if gotPeer != newPeer {
-				t.Errorf("%s: expected equal peers, got %v new %v\n",
-					tt.msg, gotPeer, newPeer)
+			if gotPeer != newPeer || err != nil {
+				t.Errorf("%s: expected equal peers, got %v new %v: %v\n",
+					tt.msg, gotPeer, newPeer, err)
 			}
 		}
 

--- a/peer_test.go
+++ b/peer_test.go
@@ -168,6 +168,23 @@ func TestGetPeerAvoidPrevSelected(t *testing.T) {
 			continue
 		}
 
+		newPeer, err := peers.GetNew(rs.PrevSelectedPeers())
+		if err != nil {
+			t.Errorf("Got unexpected error selecting new peer: %v", err)
+			continue
+		}
+
+		if len(tt.peers) == len(tt.prevSelected) {
+			if newPeer != nil {
+				t.Errorf("%s: newPeer should not have been found %v\n", tt.msg, newPeer)
+			}
+		} else {
+			if gotPeer != newPeer {
+				t.Errorf("%s: expected equal peers, got %v new %v\n",
+					tt.msg, gotPeer, newPeer)
+			}
+		}
+
 		got := gotPeer.HostPort()
 		if _, ok := tt.expected[got]; !ok {
 			t.Errorf("%s: got unexpected peer, expected one of %v got %v\n  Peers = %v PrevSelected = %v",


### PR DESCRIPTION
We pass in a `prevSelected` map, so this API will enforce that we honor it.