### PR TITLE
Make frame parsing more resilient to bad inputs

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -136,7 +136,10 @@ func (f *Frame) ReadIn(r io.Reader) error {
 	if err := f.Header.read(&rbuf); err != nil {
 		return err
 	}
-	if f.Header.PayloadSize() > 0 {
+	switch payloadSize := f.Header.PayloadSize(); {
+	case payloadSize > MaxFramePayloadSize:
+		return fmt.Errorf("invalid frame size %v", f.Header.size)
+	case payloadSize > 0:
 		if _, err := io.ReadFull(r, f.SizedPayload()); err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, if we recieve a frame that is invalid (E.g., the size is
smaller than the header size which is the minimum), then we end up with
a huge payload size which causes an out-of-bounds panic trying to read
the payload.

Add full unit tests for parsing of the frame, as well as a quick test to
ensure TChannel will not panic on bad frames.