### PR TITLE
Log Info level logs on channel creation

### DIFF
--- a/all_channels.go
+++ b/all_channels.go
@@ -20,7 +20,10 @@
 
 package tchannel
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // channelMap is used to ensure that applications don't create multiple channels with
 // the same service name in a single process.
@@ -34,7 +37,10 @@ var channelMap = struct {
 func registerNewChannel(ch *Channel) {
 	serviceName := ch.ServiceName()
 	ch.createdStack = string(getStacks(false /* all */))
-	ch.log.Debugf("NewChannel created at %s", ch.createdStack)
+	ch.log.WithFields(
+		LogField{"channelPtr", fmt.Sprintf("%p", ch)},
+		LogField{"createdStack", ch.createdStack},
+	).Info("Created new channel.")
 
 	channelMap.Lock()
 	defer channelMap.Unlock()

--- a/channel.go
+++ b/channel.go
@@ -287,7 +287,9 @@ func (ch *Channel) Serve(l net.Listener) error {
 	ch.log = ch.log.WithFields(LogField{"hostPort", mutable.peerInfo.HostPort})
 
 	peerInfo := mutable.peerInfo
-	ch.log.Debugf("%v (%v) listening on %v", peerInfo.ProcessName, peerInfo.ServiceName, peerInfo.HostPort)
+	ch.log.WithFields(
+		LogField{"hostPort", peerInfo.HostPort},
+	).Info("Channel is listening.")
 	go ch.serve()
 	return nil
 }


### PR DESCRIPTION
Channels are not created frequently (especially compared to connections,
which we log using Info), so let's log them using Info levels.

This will help us diagnose any panics which contain channel pointers
since we can compare them to the channelPtr log field.