### PR TITLE
Add hook for peer connection status changes

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -57,7 +57,9 @@ type ChannelOptions struct {
 	// The name of the process, for logging and reporting to peers
 	ProcessName string
 
-	// OnPeerStatusChanged
+	// OnPeerStatusChanged is an optional callback that receives a notification
+	// whenever the channel establishes a usable connection to a peer, or loses
+	// a connection to a peer.
 	OnPeerStatusChanged func(*Peer)
 
 	// The logger to use for this channel
@@ -123,14 +125,15 @@ const (
 type Channel struct {
 	channelConnectionCommon
 
-	chID              uint32
-	createdStack      string
-	commonStatsTags   map[string]string
-	connectionOptions ConnectionOptions
-	peers             *PeerList
-	relayHost         RelayHost
-	relayMaxTimeout   time.Duration
-	handler           Handler
+	chID                uint32
+	createdStack        string
+	commonStatsTags     map[string]string
+	connectionOptions   ConnectionOptions
+	peers               *PeerList
+	relayHost           RelayHost
+	relayMaxTimeout     time.Duration
+	handler             Handler
+	onPeerStatusChanged func(*Peer)
 
 	// mutable contains all the members of Channel which are mutable.
 	mutable struct {
@@ -220,7 +223,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		relayHost:         opts.RelayHost,
 		relayMaxTimeout:   validateRelayMaxTimeout(opts.RelayMaxTimeout, logger),
 	}
-	ch.peers = newRootPeerList(ch).newChild()
+	ch.peers = newRootPeerList(ch, opts.OnPeerStatusChanged).newChild()
 
 	if opts.Handler != nil {
 		ch.handler = opts.Handler
@@ -740,7 +743,7 @@ func (ch *Channel) State() ChannelState {
 // Close starts a graceful Close for the channel. This does not happen immediately:
 // 1. This call closes the Listener and starts closing connections.
 // 2. When all incoming connections are drained, the connection blocks new outgoing calls.
-// 3. When all connections are drainged, the channel's state is updated to Closed.
+// 3. When all connections are drained, the channel's state is updated to Closed.
 func (ch *Channel) Close() {
 	ch.Logger().Info("Channel.Close called.")
 	var connections []*Connection

--- a/connection_test.go
+++ b/connection_test.go
@@ -885,7 +885,7 @@ func TestPeerStatusChangeClient(t *testing.T) {
 		// Induce the creation of a connection from client to server.
 		client := ts.NewClient(copts)
 		testutils.AssertEcho(t, client, ts.HostPort(), ts.ServiceName())
-		assert.Equal(t, 1, <-changes, "first connection")
+		assert.Equal(t, 1, <-changes, "event for first connection")
 
 		// Re-use
 		testutils.AssertEcho(t, client, ts.HostPort(), ts.ServiceName())
@@ -897,15 +897,15 @@ func TestPeerStatusChangeClient(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 		defer cancel()
 		p.Connect(ctx)
-		assert.Equal(t, 2, <-changes, "second connection")
+		assert.Equal(t, 2, <-changes, "event for second connection")
 
 		// Induce the destruction of a connection from the server to the client.
 		server.Close()
-		assert.Equal(t, 1, <-changes, "first disconnection")
-		assert.Equal(t, 0, <-changes, "second disconnection")
+		assert.Equal(t, 1, <-changes, "event for first disconnection")
+		assert.Equal(t, 0, <-changes, "event for second disconnection")
 
 		client.Close()
-		assert.Equal(t, 0, len(changes), "unexpected peer status changes")
+		assert.Len(t, changes, 0, "unexpected peer status changes")
 	})
 }
 
@@ -926,16 +926,16 @@ func TestPeerStatusChangeServer(t *testing.T) {
 
 			// Open
 			testutils.AssertEcho(t, client, ts.HostPort(), ts.ServiceName())
-			assert.Equal(t, 1, <-changes, "opened")
+			assert.Equal(t, 1, <-changes, "one event on new connection")
 
 			// Re-use
 			testutils.AssertEcho(t, client, ts.HostPort(), ts.ServiceName())
-			assert.Equal(t, 0, len(changes), "re-used")
+			assert.Len(t, changes, 0, "no new events on re-used connection")
 
 			// Close
 			client.Close()
-			assert.Equal(t, 0, <-changes, "closed")
+			assert.Equal(t, 0, <-changes, "one event on lost connection")
 		}
 	})
-	assert.Equal(t, 0, len(changes), "unexpected peer status changes")
+	assert.Len(t, changes, 0, "unexpected peer status changes")
 }

--- a/root_peer_list.go
+++ b/root_peer_list.go
@@ -27,14 +27,16 @@ import "sync"
 type RootPeerList struct {
 	sync.RWMutex
 
-	channel         Connectable
-	peersByHostPort map[string]*Peer
+	channel             Connectable
+	onPeerStatusChanged func(*Peer)
+	peersByHostPort     map[string]*Peer
 }
 
-func newRootPeerList(ch Connectable) *RootPeerList {
+func newRootPeerList(ch Connectable, onPeerStatusChanged func(*Peer)) *RootPeerList {
 	return &RootPeerList{
-		channel:         ch,
-		peersByHostPort: make(map[string]*Peer),
+		channel:             ch,
+		onPeerStatusChanged: onPeerStatusChanged,
+		peersByHostPort:     make(map[string]*Peer),
 	}
 }
 
@@ -65,7 +67,7 @@ func (l *RootPeerList) Add(hostPort string) *Peer {
 	var p *Peer
 	// To avoid duplicate connections, only the root list should create new
 	// peers. All other lists should keep refs to the root list's peers.
-	p = newPeer(l.channel, hostPort, l.onClosedConnRemoved)
+	p = newPeer(l.channel, hostPort, l.onPeerStatusChanged, l.onClosedConnRemoved)
 	l.peersByHostPort[hostPort] = p
 	return p
 }

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -200,6 +200,13 @@ func (o *ChannelOpts) SetRelayMaxTimeout(d time.Duration) *ChannelOpts {
 	return o
 }
 
+// SetOnPeerStatusChanged sets the callback for channel status change
+// noficiations.
+func (o *ChannelOpts) SetOnPeerStatusChanged(f func(*tchannel.Peer)) *ChannelOpts {
+	o.ChannelOptions.OnPeerStatusChanged = f
+	return o
+}
+
 func defaultString(v string, defaultValue string) string {
 	if v == "" {
 		return defaultValue


### PR DESCRIPTION
This change adds a channel option OnPeerStatusChanged.  This is a callback that will receive a notification for peer connection status change events: whenever any connection opens or closes.