### PR TITLE
Relax timeout for TestWriteAfterArg3Timeout

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -563,15 +563,15 @@ func TestWriteArg3AfterTimeout(t *testing.T) {
 		}
 		ts.Register(HandlerFunc(handler), "call")
 
-		ctx, cancel := NewContext(testutils.Timeout(50 * time.Millisecond))
+		ctx, cancel := NewContext(testutils.Timeout(100 * time.Millisecond))
 		defer cancel()
 
 		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), ts.ServiceName(), "call", nil, nil)
 		assert.Equal(t, err, ErrTimeout, "Call should timeout")
 
-		// Wait for the write to complete, make sure there's no errors.
+		// Wait for the write to complete, make sure there are no errors.
 		select {
-		case <-time.After(testutils.Timeout(30 * time.Millisecond)):
+		case <-time.After(testutils.Timeout(60 * time.Millisecond)):
 			t.Errorf("Handler should have failed due to timeout")
 		case <-timedOut:
 		}


### PR DESCRIPTION
This test routinely flaps on my developer workstation.