### PR TITLE
Add option to random load balance to >1 server nodes

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -21,7 +21,6 @@
 package tchannel
 
 import (
-	"container/heap"
 	"errors"
 	"strings"
 	"sync"
@@ -63,19 +62,21 @@ type Connectable interface {
 type PeerList struct {
 	sync.RWMutex
 
-	parent          *RootPeerList
-	peersByHostPort map[string]*peerScore
-	peerHeap        *peerHeap
-	scoreCalculator ScoreCalculator
-	lastSelected    uint64
+	parent              *RootPeerList
+	peersByHostPort     map[string]*peerScore
+	peerHeap            *peerHeap
+	scoreCalculator     ScoreCalculator
+	peerConnectionCount uint32
+	lastSelected        uint64
 }
 
 func newPeerList(root *RootPeerList) *PeerList {
 	return &PeerList{
-		parent:          root,
-		peersByHostPort: make(map[string]*peerScore),
-		scoreCalculator: newPreferIncomingCalculator(),
-		peerHeap:        newPeerHeap(),
+		parent:              root,
+		peersByHostPort:     make(map[string]*peerScore),
+		scoreCalculator:     newPreferIncomingCalculator(),
+		peerHeap:            newPeerHeap(),
+		peerConnectionCount: 1,
 	}
 }
 
@@ -89,6 +90,16 @@ func (l *PeerList) SetStrategy(sc ScoreCalculator) {
 		newScore := l.scoreCalculator.GetScore(ps.Peer)
 		l.updatePeer(ps, newScore)
 	}
+}
+
+// SetPeerConnectionCount sets the number of peer connections to be used in
+// combination with the ScoreCalculator to achieve a random load balancing
+// of a single client node to `peerConnectionCount` number of server nodes
+func (l *PeerList) SetPeerConnectionCount(peerConnectionCount uint32) {
+	l.Lock()
+	defer l.Unlock()
+
+	l.peerConnectionCount = peerConnectionCount
 }
 
 // Siblings don't share peer lists (though they take care not to double-connect
@@ -175,8 +186,8 @@ func (l *PeerList) Remove(hostPort string) error {
 	return nil
 }
 func (l *PeerList) choosePeer(prevSelected map[string]struct{}, avoidHost bool) *Peer {
-	var psPopList []*peerScore
-	var ps *peerScore
+	var chosenPSList []*peerScore
+	var poppedList []*peerScore
 
 	canChoosePeer := func(hostPort string) bool {
 		if _, ok := prevSelected[hostPort]; ok {
@@ -191,27 +202,41 @@ func (l *PeerList) choosePeer(prevSelected map[string]struct{}, avoidHost bool) 
 	}
 
 	size := l.peerHeap.Len()
+
+	var connectionCount uint32
 	for i := 0; i < size; i++ {
 		popped := l.peerHeap.popPeer()
+		poppedList = append(poppedList, popped)
 
 		if canChoosePeer(popped.HostPort()) {
-			ps = popped
-			break
+			chosenPSList = append(chosenPSList, popped)
+			connectionCount++
+			if connectionCount >= l.peerConnectionCount {
+				break
+			}
 		}
-		psPopList = append(psPopList, popped)
+
 	}
 
-	for _, p := range psPopList {
-		heap.Push(l.peerHeap, p)
+	for _, p := range poppedList {
+		l.peerHeap.pushPeer(p)
 	}
-
-	if ps == nil {
+	if len(chosenPSList) == 0 {
 		return nil
 	}
 
-	l.peerHeap.pushPeer(ps)
+	ps := randomSampling(chosenPSList)
+	if ps == nil {
+		return nil
+	}
 	ps.chosenCount.Inc()
 	return ps.Peer
+}
+
+func randomSampling(psList []*peerScore) *peerScore {
+	peerRand := trand.NewSeeded()
+	r := peerRand.Intn(len(psList))
+	return psList[r]
 }
 
 // GetOrAdd returns a peer for the given hostPort, creating one if it doesn't yet exist.


### PR DESCRIPTION
This closes #630 

I have also verified the change for a `client => server` with low number of client/server nodes, where the imbalance was more severe (note that here I used `peerConnectionCount`>= `numPeers=5`, which is the extreme case but it's enough to verify the solution):

<img width="1308" alt="screen shot 2017-06-16 at 10 51 25 pm" src="https://user-images.githubusercontent.com/3223733/27250495-65056392-52e6-11e7-9f1b-121ceeb6e3e3.png">

