### PR TITLE
create invalid timeout error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -72,6 +72,9 @@ const (
 	// Callers can retry the request if the request is safe to retry
 	ErrCodeNetwork SystemErrCode = 0x07
 
+	// ErrCodeInvalidDeadline indicates that a request was made with a Deadline that is either too small or 0.
+	ErrCodeInvalidDeadline SystemErrCode = 0x08
+
 	// ErrCodeProtocol indincates a fatal protocol error communicating with the peer.  The connection
 	// will be terminated.
 	ErrCodeProtocol SystemErrCode = 0xFF
@@ -95,6 +98,9 @@ var (
 
 	// ErrMethodTooLarge is a SystemError indicating that the method is too large.
 	ErrMethodTooLarge = NewSystemError(ErrCodeProtocol, "method too large")
+
+	// ErrInvalidDeadline is a SystemError indicating a deadline is too small.
+	ErrInvalidDeadline = NewSystemError(ErrCodeInvalidDeadline, "deadline too small")
 )
 
 // MetricsKey is a string representation of the error code that's suitable for
@@ -120,6 +126,8 @@ func (c SystemErrCode) MetricsKey() string {
 		return "network-error"
 	case ErrCodeProtocol:
 		return "protocol-error"
+	case ErrCodeInvalidDeadline:
+		return "invalid-deadline"
 	default:
 		return c.String()
 	}

--- a/outbound.go
+++ b/outbound.go
@@ -57,10 +57,10 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 	}
 
 	// If the timeToLive is less than a millisecond, it will be encoded as 0 on
-	// the wire, hence we return a timeout immediately.
+	// the wire, hence we return an invalid deadline error.
 	timeToLive := deadline.Sub(now)
 	if timeToLive < time.Millisecond {
-		return nil, ErrTimeout
+		return nil, ErrInvalidDeadline
 	}
 
 	if !c.pendingExchangeMethodAdd() {


### PR DESCRIPTION
In order to address #632 I propose we add a new error type, `ErrInvalidDeadline`. This is potentially a breaking change (at least the way I've coded it). Would love some feedback on whether or not this is a big deal and/or other approaches we might take to address the issue.