### PR TITLE
Pin apache/thrift 0.10.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -2,7 +2,7 @@ hash: 111bdf9797d23d4b9f8833a9780e382dd53153af70ad286f99815cea4c2fdf4b
 updated: 2016-08-05T18:02:17.171302481-04:00
 imports:
 - name: github.com/apache/thrift
-  version: 0e9fed1e12ed066865e46c6903782b2ef95f4650
+  version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/bmizerany/perks
@@ -10,20 +10,22 @@ imports:
   subpackages:
   - quantile
 - name: github.com/cactus/go-statsd-client
-  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
+  version: ad551ee7f9f3465fb1ce1695899c612f7808a06a
   subpackages:
   - statsd
+- name: github.com/codahale/hdrhistogram
+  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/crossdock/crossdock-go
   version: 228792ab861c86f8900b2db0439577feef9ec9d8
   subpackages:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
   - spew
 - name: github.com/jessevdk/go-flags
-  version: f2785f5820ec967043de79c8be97edfc464ca745
+  version: 6cf8f02b4ae8ba723ddc64dcfd403e530c06d927
 - name: github.com/opentracing/opentracing-go
   version: 855519783f479520497c6b3445611b05fc42f009
   subpackages:
@@ -44,7 +46,7 @@ imports:
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 05e8a0eda380579888eb53c394909df027f06991
   subpackages:
   - assert
   - mock
@@ -60,10 +62,10 @@ imports:
   - utils
   - thrift-gen/agent
 - name: golang.org/x/net
-  version: b400c2eff1badec7022a8c8f5bea058b6315eed7
+  version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
   subpackages:
   - context
   - context/ctxhttp
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
-devImports: []
+  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/uber/tchannel-go
 import:
 - package: github.com/apache/thrift
-  version: master
+  version: ">=0.9.3, <0.11.0"
   subpackages:
   - lib/go/thrift
 - package: github.com/cactus/go-statsd-client
@@ -46,4 +46,5 @@ import:
 - package: github.com/prashantv/protectmem
 - package: github.com/opentracing/opentracing-go
 - package: github.com/uber/jaeger-client-go
+  version: ^2.7
 - package: github.com/crossdock/crossdock-go


### PR DESCRIPTION
apache/thrift/master breaks TChannel with an API change.
If they are playing by the rules, that change will come in 0.11.0, so pinning
to the ~0.10 range.