### PR TITLE
bugfix: cancel server context on client tcp close

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -984,10 +984,9 @@ func TestContextCanceledOnTCPClose(t *testing.T) {
 
 		ts.RegisterFunc("test", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 			defer close(serverDoneC)
-			assert.Equal(t, "client", CurrentCall(ctx).CallerName(), "wrong caller name")
 			close(callForwarded)
 			<-ctx.Done()
-			assert.Equal(t, "context canceled", ctx.Err().Error(), "ctx.Err() returned unexpected error")
+			assert.EqualError(t, ctx.Err(), "context canceled")
 			return &raw.Res{}, nil
 		})
 
@@ -1005,9 +1004,7 @@ func TestContextCanceledOnTCPClose(t *testing.T) {
 		ctx, cancel := NewContext(20 * time.Second)
 		defer cancel()
 
-		clientCh := ts.NewClient(&testutils.ChannelOpts{
-			ServiceName: "client",
-		})
+		clientCh := ts.NewClient(nil)
 		// initiate the call in a background routine and
 		// make it wait for the response
 		clientDoneC := make(chan struct{})

--- a/connection_test.go
+++ b/connection_test.go
@@ -21,7 +21,6 @@
 package tchannel_test
 
 import (
-	goctx "context"
 	"errors"
 	"fmt"
 	"io"
@@ -988,7 +987,7 @@ func TestContextCanceledOnTCPClose(t *testing.T) {
 			assert.Equal(t, "client", CurrentCall(ctx).CallerName(), "wrong caller name")
 			close(callForwarded)
 			<-ctx.Done()
-			assert.Equal(t, goctx.Canceled, ctx.Err(), "ctx.Err() returned unexpected error")
+			assert.Equal(t, "context canceled", ctx.Err().Error(), "ctx.Err() returned unexpected error")
 			return &raw.Res{}, nil
 		})
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -1006,7 +1006,6 @@ func TestContextCanceledOnClientTCPClose(t *testing.T) {
 		tcpConn := conn.(*net.TCPConn)
 		tcpConn.CloseWrite() // half-close the tcp conn
 
-		fmt.Println(server.HostPort())
 		succ = AwaitWaitGroup(&callDoneWG, time.Second*10) // wait for the server call to return
 		assert.True(t, succ, "timed out waiting for server context to be closed")
 

--- a/inbound.go
+++ b/inbound.go
@@ -189,10 +189,9 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 			if c.log.Enabled(LogLevelDebug) {
 				call.log.Debugf("Wait for timeout/cancellation interrupted by error: %v", call.mex.errCh.err)
 			}
-			// conn error, cancel the inbound call
-			// and mark the exchg as expired in mex
-			// TODO: move the cancel to the parent
-			// context at connnection level
+			// when an exchange errors out, mark the exchange as expired
+			// and call cancel so the server handler's context is canceled
+			// TODO: move the cancel to the parent context at connnection level
 			call.response.cancel()
 			call.mex.inboundExpired()
 		}

--- a/inbound.go
+++ b/inbound.go
@@ -189,6 +189,12 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 			if c.log.Enabled(LogLevelDebug) {
 				call.log.Debugf("Wait for timeout/cancellation interrupted by error: %v", call.mex.errCh.err)
 			}
+			// conn error, cancel the inbound call
+			// and mark the exchg as expired in mex
+			// TODO: move the cancel to the parent
+			// context at connnection level
+			call.response.cancel()
+			call.mex.inboundExpired()
 		}
 	}()
 

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/uber/tchannel-go/typed"
 	"golang.org/x/net/context"
 	"io"
-	"sync"
 )
 
 // MexChannelBufferSize is the size of the message exchange channel buffer.
@@ -149,24 +148,4 @@ func SendCallReq(writer io.Writer, msgID int, ttl time.Duration, service string,
 	frame.Header.SetPayloadSize(uint16(wbuf.BytesWritten()))
 
 	return frame.WriteOut(writer)
-}
-
-// AwaitWaitGroup calls Wait on the given wait
-// Returns true if the Wait() call succeeded before the timeout
-// Returns false if the Wait() did not return before the timeout
-func AwaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
-
-	doneC := make(chan struct{})
-
-	go func() {
-		wg.Wait()
-		close(doneC)
-	}()
-
-	select {
-	case <-doneC:
-		return true
-	case <-time.After(timeout):
-		return false
-	}
 }

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -27,7 +27,10 @@ import (
 	"net"
 	"time"
 
+	"github.com/uber/tchannel-go/typed"
 	"golang.org/x/net/context"
+	"io"
+	"sync"
 )
 
 // MexChannelBufferSize is the size of the message exchange channel buffer.
@@ -76,4 +79,94 @@ func InboundConnection(call IncomingCall) (*Connection, net.Conn) {
 
 	conn := inboundCall.conn
 	return conn, conn.conn
+}
+
+// DoInitHandshake performs the initReq/initResp handshake
+// using the given reader/writer stream
+func DoInitHandshake(rw io.ReadWriter, msgID int, clientHostPort string) error {
+
+	req := &initReq{
+		initMessage{
+			id:      uint32(msgID),
+			Version: CurrentProtocolVersion,
+			initParams: initParams{
+				InitParamHostPort:         clientHostPort,
+				InitParamProcessName:      "test",
+				InitParamTChannelLanguage: "go",
+			},
+		},
+	}
+
+	reqFrame := NewFrame(MaxFramePayloadSize)
+	if err := reqFrame.write(req); err != nil {
+		return err
+	}
+	if err := reqFrame.WriteOut(rw); err != nil {
+		return err
+	}
+
+	respFrame := NewFrame(MaxFramePayloadSize)
+	if err := respFrame.ReadIn(rw); err != nil {
+		return err
+	}
+
+	var resp initRes
+	if err := respFrame.read(&resp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SendCallReq sends a call request to the remote server
+// Use this method when you are managing your own tcp
+// conn instead of using a client channel
+func SendCallReq(writer io.Writer, msgID int, ttl time.Duration, service string, arg1, arg2, arg3 string) error {
+
+	callReq := &callReq{
+		id:         uint32(msgID),
+		TimeToLive: ttl,
+		Headers: transportHeaders{
+			CallerName: "test-client",
+		},
+		Service: service,
+	}
+
+	var wbuf typed.WriteBuffer
+
+	frame := NewFrame(MaxFramePayloadSize)
+	wbuf.Wrap(frame.Payload[:])
+	wbuf.WriteSingleByte(0x00) // flags: 0, last fragment
+	callReq.write(&wbuf)       // write the payload
+	wbuf.WriteSingleByte(0x00) // no checksum option
+	wbuf.WriteLen16String(arg1)
+	wbuf.WriteLen16String(arg2)
+	wbuf.WriteLen16String(arg3)
+
+	frame.Header.ID = uint32(msgID)
+	frame.Header.reserved1 = 0
+	frame.Header.messageType = messageTypeCallReq
+	frame.Header.SetPayloadSize(uint16(wbuf.BytesWritten()))
+
+	return frame.WriteOut(writer)
+}
+
+// AwaitWaitGroup calls Wait on the given wait
+// Returns true if the Wait() call succeeded before the timeout
+// Returns false if the Wait() did not return before the timeout
+func AwaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
+
+	doneC := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(doneC)
+	}()
+
+	select {
+	case <-doneC:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }


### PR DESCRIPTION
**Problem Description:**
When a client crashes, the linux kernel will automatically initiate a tcp_close by sending a FIN request to the server. The server kernel, in response, will the ACK the FIN and move to CLOSE_WAIT, waiting for the app to close the socket. However, tchannel doesn't set the context to done on a connection read error on the server, the conn.Close() won't be called until the context deadline expires. This is bad when tchannel is used for long polling. 

**Solution:**
This patch fixes the problem by marking the server side inbound call context as canceled on a tcp read error. It also marks the msgExchange as expired in the mex, so that it can be subsequently removed. There is already a TODO in the existing code to get rid of the goroutine (on Inbound) per call. This patch does not fix this TODO. 

**Testing:**
Created a unit test that reproduces the mentioned problem. The unit test doesn't use the client channel, instead sends a call directly on the tcp connection.  