### PR TITLE
Add tchannel.WithoutHeaders

### DIFF
--- a/context_header.go
+++ b/context_header.go
@@ -117,16 +117,5 @@ func WrapWithHeaders(ctx context.Context, headers map[string]string) ContextWith
 
 // WithoutHeaders hides any TChannel headers from the given context.
 func WithoutHeaders(ctx context.Context) context.Context {
-	return withoutHeaders{ctx}
-}
-
-type withoutHeaders struct {
-	context.Context
-}
-
-func (ctx withoutHeaders) Value(key interface{}) interface{} {
-	if key == contextKeyHeaders || key == contextKeyTChannel {
-		return nil
-	}
-	return ctx.Context.Value(key)
+	return context.WithValue(context.WithValue(ctx, contextKeyTChannel, nil), contextKeyHeaders, nil)
 }

--- a/context_header.go
+++ b/context_header.go
@@ -115,7 +115,7 @@ func WrapWithHeaders(ctx context.Context, headers map[string]string) ContextWith
 	return headerCtx{Context: newCtx}
 }
 
-// WithoutHeaders removes any TChannel headers from the given context.
+// WithoutHeaders hides any TChannel headers from the given context.
 func WithoutHeaders(ctx context.Context) context.Context {
 	return withoutHeaders{ctx}
 }

--- a/context_header.go
+++ b/context_header.go
@@ -114,3 +114,19 @@ func WrapWithHeaders(ctx context.Context, headers map[string]string) ContextWith
 	newCtx := context.WithValue(ctx, contextKeyHeaders, h)
 	return headerCtx{Context: newCtx}
 }
+
+// WithoutHeaders removes any TChannel headers from the given context.
+func WithoutHeaders(ctx context.Context) context.Context {
+	return withoutHeaders{ctx}
+}
+
+type withoutHeaders struct {
+	context.Context
+}
+
+func (ctx withoutHeaders) Value(key interface{}) interface{} {
+	if key == contextKeyHeaders || key == contextKeyTChannel {
+		return nil
+	}
+	return ctx.Context.Value(key)
+}

--- a/context_internal_test.go
+++ b/context_internal_test.go
@@ -55,3 +55,12 @@ func TestCurrentSpan(t *testing.T) {
 	require.NotNil(t, span, "CurrentSpan() should always return something")
 	assert.NotEqual(t, uint64(0), span.TraceID(), "mock tracer is now Zipkin-compatible")
 }
+
+func TestContextWithoutHeaders(t *testing.T) {
+	ctx := WrapWithHeaders(context.Background(), map[string]string{"k1": "v1"})
+	assert.Equal(t, map[string]string{"k1": "v1"}, ctx.Headers())
+	ctx2 := WithoutHeaders(ctx)
+	assert.Nil(t, ctx2.Value(contextKeyHeaders))
+	_, ok := ctx2.(ContextWithHeaders)
+	assert.False(t, ok)
+}

--- a/context_internal_test.go
+++ b/context_internal_test.go
@@ -56,11 +56,19 @@ func TestCurrentSpan(t *testing.T) {
 	assert.NotEqual(t, uint64(0), span.TraceID(), "mock tracer is now Zipkin-compatible")
 }
 
-func TestContextWithoutHeaders(t *testing.T) {
+func TestContextWithoutHeadersKeyHeaders(t *testing.T) {
 	ctx := WrapWithHeaders(context.Background(), map[string]string{"k1": "v1"})
 	assert.Equal(t, map[string]string{"k1": "v1"}, ctx.Headers())
 	ctx2 := WithoutHeaders(ctx)
 	assert.Nil(t, ctx2.Value(contextKeyHeaders))
+	_, ok := ctx2.(ContextWithHeaders)
+	assert.False(t, ok)
+}
+
+func TestContextWithoutHeadersKeyTChannel(t *testing.T) {
+	ctx, _ := NewContextBuilder(time.Second).SetShardKey("s1").Build()
+	ctx2 := WithoutHeaders(ctx)
+	assert.Nil(t, ctx2.Value(contextKeyTChannel))
 	_, ok := ctx2.(ContextWithHeaders)
 	assert.False(t, ok)
 }


### PR DESCRIPTION
This adds a function `tchannel.WithoutHeaders` (name TBD), which hides
TChannel Go-specific information from a Context.

This is needed to alleviate the following issue:

Existing TChannel Go services have been using the standard header
propagation behavior of TChannel Go (incoming headers are copied to
outgoing headers) happily and they start using YARPC+TChannel, or a
library that uses YARPC, to make outgoing calls to a different service.

Their expectation would be to have the headers copied over to that
outgoing call, especially if the underlying transport is TChannel. This
will not be supported in YARPC.

That leaves us with two options: silently ignore TChannel headers, or
reject outgoing requests made with TChannel contexts.

If we silently ignore TChannel headers, service owners who rely on this
behavior will suddenly start seeing hard-to-debug breakages. The number
of support tickets for this will be huge.

A better option is for YARPC to reject TChannel contexts on **all**
transports. YARPC will recommend that users remove the header
information from the context (with the use of `tchannel.WithoutHeaders`)
before passing it to YARPC. In the short-term, this adds a little work
for existing TChannel services but in the long run it saves them a lot
of time in terms of debugging.