### PR TITLE
Pin Apache Thrift to version range ~0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+# next
+
+* Locks Apache Thrift to version ~0.9 to maintain backward-compatibility, this
+  time for real.
+
 # v1.6.0
 
 * Locks Apache Thrift to version 0.9.3 to maintain backward-compatibility.

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 111bdf9797d23d4b9f8833a9780e382dd53153af70ad286f99815cea4c2fdf4b
-updated: 2016-08-05T18:02:17.171302481-04:00
+hash: 43b7af12b6726c5165735c28a8df0e526968afe92e99a99dc5958b16b0467fde
+updated: 2017-08-03T18:30:51.640403792-07:00
 imports:
 - name: github.com/apache/thrift
-  version: b2a4d4ae21c789b689dd162deb819665567f481c
+  version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
   subpackages:
   - lib/go/thrift
 - name: github.com/bmizerany/perks

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/uber/tchannel-go
 import:
 - package: github.com/apache/thrift
-  version: ">=0.9.3, <0.11.0"
+  version: ~0.9
   subpackages:
   - lib/go/thrift
 - package: github.com/cactus/go-statsd-client


### PR DESCRIPTION
Finishing #615.

Apache Thrift introduces breaking API changes in version 0.10.0.
This pin will shield dependees from breaking changes impacting TChannel.