### PR TITLE
Only test go1.7-1.9, lint on latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,25 @@ cache:
   - $HOME/.glide/cache
 
 go:
-- 1.5
-- 1.6
 - 1.7
 - 1.8
 - 1.9
 
 matrix:
   include:
-  - go: 1.6
+  - go: 1.9
     env: CROSSDOCK=true
     sudo: required
     dist: trusty
     services:
     - docker
+  include:
+  - go: 1.9
+    env: LINT=yes
 
 env:
   global:
+  - LINT=no
   - DOCKER_COMPOSE_VERSION=1.8.0
   - COMMIT=${TRAVIS_COMMIT::8}
   # Set higher timeouts for Travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
 
 env:
   global:
-  - LINT=no
   - DOCKER_COMPOSE_VERSION=1.8.0
   - COMMIT=${TRAVIS_COMMIT::8}
   # Set higher timeouts for Travis
@@ -42,7 +41,7 @@ install:
 script:
 - make test_ci
 - make cover_ci
-- make lint
+- test -z "$LINT" || make install_lint lint
 - make crossdock_logs_ci
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,4 @@
 export GO15VENDOREXPERIMENT=1
-GO_VERSION := $(shell go version | awk '{ print $$3 }')
-GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 6
-FMTABLE_MINOR_VERSIONS := 7
-ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
-SHOULD_LINT := true
-endif
-ifneq ($(filter $(FMTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
-SHOULD_LINT_FMT := true
-endif
 
 PATH := $(GOPATH)/bin:$(PATH)
 EXAMPLES=./examples/bench/server ./examples/bench/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server
@@ -58,11 +48,11 @@ install:
 	GOPATH=$(OLD_GOPATH) glide --debug install --cache --cache-gopath
 
 install_lint:
-ifdef SHOULD_LINT
-	@echo "Installing golint, since we expect to lint on" $(GO_VERSION)
-	GOPATH=$(OLD_GOPATH) go get -u -f github.com/golang/lint/golint
-else
+ifeq ($(LINT),no)
 	@echo "Not installing golint, since we don't lint on" $(GO_VERSION)
+else
+	@echo "Installing golint, since we expect to lint"
+	GOPATH=$(OLD_GOPATH) go get -u -f github.com/golang/lint/golint
 endif
 
 install_glide:
@@ -132,24 +122,20 @@ endif
 
 FILTER := grep -v -e '_string.go' -e '/gen-go/' -e '/mocks/' -e 'vendor/'
 lint:
-ifdef SHOULD_LINT
-	@echo "Linters are enabled on" $(GO_VERSION)
-	@echo "Running golint"
-	-golint ./... | $(FILTER) | tee lint.log
-	@echo "Running go vet"
-	-go vet $(PKGS) 2>&1 | tee -a lint.log
-ifdef SHOULD_LINT_FMT
-	@echo "Checking gofmt"
-	-gofmt -l . | $(FILTER) | tee -a lint.log
+ifeq ($(LINT),no)
+	@echo "Skipping lint/fmt"
 else
-	@echo "Not checking gofmt on" $(GO_VERSION)
+	@echo "Linting is enabled"
+	@echo "Running golint"
+	-golint $(ALL_PKGS) | $(FILTER) | tee lint.log
+	@echo "Running go vet"
+	-go vet $(PKGS) 2>&1 | fgrep -v -e "possible formatting directiv" -e "exit status" | tee -a lint.log
+	@echo "Verifying files are gofmt'd"
+	-gofmt -l . | $(FILTER) | tee -a lint.log
 endif
 	@echo "Checking for unresolved FIXMEs"
 	-git grep -i -n fixme | $(FILTER) | grep -v -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]
-else
-	@echo "Skipping linters on" $(GO_VERSION)
-endif
 
 thrift_example: thrift_gen
 	go build -o $(BUILD)/examples/thrift       ./examples/thrift/main.go

--- a/http/buf_test.go
+++ b/http/buf_test.go
@@ -31,8 +31,8 @@ import (
 
 func TestHeaders(t *testing.T) {
 	tests := []http.Header{
-		http.Header{},
-		http.Header{
+		{},
+		{
 			"K1": []string{"K1V1", "K1V2", "K1V3"},
 			"K2": []string{"K2V2", "K2V2"},
 		},

--- a/hyperbahn/call.go
+++ b/hyperbahn/call.go
@@ -77,9 +77,5 @@ func (c *Client) sendAdvertise() error {
 
 	var resp AdResponse
 	c.opts.Handler.On(SendAdvertise)
-	if err := c.jsonClient.Call(ctx, "ad", c.createRequest(), &resp); err != nil {
-		return err
-	}
-
-	return nil
+	return c.jsonClient.Call(ctx, "ad", c.createRequest(), &resp)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -30,8 +30,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func field(k string, v interface{}) LogField {
+	return LogField{Key: k, Value: v}
+}
+
 func TestErrField(t *testing.T) {
-	assert.Equal(t, LogField{"error", "foo"}, ErrField(errors.New("foo")))
+	assert.Equal(t, field("error", "foo"), ErrField(errors.New("foo")))
 }
 
 func TestWriterLogger(t *testing.T) {
@@ -50,8 +54,8 @@ func TestWriterLogger(t *testing.T) {
 	}
 
 	for _, level := range levels {
-		tagLogger1 := bufLogger.WithFields(LogField{"key1", "value1"})
-		tagLogger2 := bufLogger.WithFields(LogField{"key2", "value2"}, LogField{"key3", "value3"})
+		tagLogger1 := bufLogger.WithFields(field("key1", "value1"))
+		tagLogger2 := bufLogger.WithFields(field("key2", "value2"), field("key3", "value3"))
 
 		verifyMsgAndPrefix := func(logger Logger) {
 			buf.Reset()
@@ -96,8 +100,8 @@ func TestWriterLoggerNoSubstitution(t *testing.T) {
 	}
 
 	for _, level := range levels {
-		tagLogger1 := bufLogger.WithFields(LogField{"key1", "value1"})
-		tagLogger2 := bufLogger.WithFields(LogField{"key2", "value2"}, LogField{"key3", "value3"})
+		tagLogger1 := bufLogger.WithFields(field("key1", "value1"))
+		tagLogger2 := bufLogger.WithFields(field("key2", "value2"), field("key3", "value3"))
 
 		verifyMsgAndPrefix := func(logger Logger) {
 			buf.Reset()

--- a/raw/handler.go
+++ b/raw/handler.go
@@ -80,10 +80,7 @@ func WriteResponse(response *tchannel.InboundCallResponse, resp *Res) error {
 	if err := tchannel.NewArgWriter(response.Arg2Writer()).Write(resp.Arg2); err != nil {
 		return err
 	}
-	if err := tchannel.NewArgWriter(response.Arg3Writer()).Write(resp.Arg3); err != nil {
-		return err
-	}
-	return nil
+	return tchannel.NewArgWriter(response.Arg3Writer()).Write(resp.Arg3)
 }
 
 // Wrap wraps a Handler as a tchannel.Handler that can be passed to tchannel.Register.

--- a/relay_test.go
+++ b/relay_test.go
@@ -83,7 +83,7 @@ func TestRelay(t *testing.T) {
 		}
 
 		calls := relaytest.NewMockStats()
-		for _ = range tests {
+		for range tests {
 			calls.Add("client", "test", "echo").Succeeded().End()
 		}
 		ts.AssertRelayStats(calls)

--- a/retry.go
+++ b/retry.go
@@ -190,8 +190,8 @@ func (rs *RequestState) AddSelectedPeer(hostPort string) {
 	host := getHost(hostPort)
 	if rs.SelectedPeers == nil {
 		rs.SelectedPeers = map[string]struct{}{
-			hostPort: struct{}{},
-			host:     struct{}{},
+			hostPort: {},
+			host:     {},
 		}
 	} else {
 		rs.SelectedPeers[hostPort] = struct{}{}

--- a/typed/reader_test.go
+++ b/typed/reader_test.go
@@ -65,9 +65,9 @@ func TestReaderErr(t *testing.T) {
 	}{
 		{
 			chunks: [][]byte{
-				[]byte{0, 1},
+				{0, 1},
 				nil,
-				[]byte{2, 3},
+				{2, 3},
 			},
 			validation: func(reader *Reader) {
 				assert.Equal(t, uint16(1), reader.ReadUint16(), "Read unexpected value")
@@ -76,10 +76,10 @@ func TestReaderErr(t *testing.T) {
 		},
 		{
 			chunks: [][]byte{
-				[]byte{0, 4},
+				{0, 4},
 				[]byte("test"),
 				nil,
-				[]byte{'A', 'b'},
+				{'A', 'b'},
 			},
 			validation: func(reader *Reader) {
 				assert.Equal(t, "test", reader.ReadLen16String(), "Read unexpected value")


### PR DESCRIPTION
Currently, we run tests for go1.5 upwards which takes quite a while on
Travis. go1.7 was released over a year ago, so keeping compatibility
with it as the oldest is reasonable.

As part of this, clean up the versions we run LINT on, and simplify
configuration rather than having the Makefile check the version to run
lint on. Include some minor cleanup to pass lint with latest versions.