### PR TITLE
Use codecov instead of coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - docker
   include:
   - go: 1.9
-    env: LINT=yes
+    env: NO_TEST=yes COVERAGE=yes LINT=yes
 
 env:
   global:
@@ -39,8 +39,8 @@ install:
 - make install_ci
 
 script:
-- make test_ci
-- make cover_ci
+- test -n "$NO_TEST" || make test_ci
+- test -z "$COVERAGE" || make cover_ci
 - test -z "$LINT" || make install_lint lint
 - make crossdock_logs_ci
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ install_glide:
 	GOPATH=$(OLD_GOPATH) go get -u github.com/Masterminds/glide && cd $(OLD_GOPATH)/src/github.com/Masterminds/glide && git checkout v0.12.3 && go install
 
 install_ci: $(BIN)/thrift install_glide install
-	GOPATH=$(OLD_GOPATH) go get -u github.com/mattn/goveralls
 ifdef CROSSDOCK
 	$(MAKE) install_docker_ci
 endif
@@ -108,12 +107,10 @@ cover: cover_profile
 	go tool cover -html=$(BUILD)/coverage.out
 
 cover_ci:
-ifdef CROSSDOCK
-	@echo Skipping coverage
-else
+	@echo "Uploading coverage"
 	$(MAKE) cover_profile
-	goveralls -coverprofile=$(BUILD)/coverage.out -service=travis-ci || echo -e "\x1b[31mCoveralls failed\x1b[m"
-endif
+	curl -s https://codecov.io/bash > $(BUILD)/codecov.bash
+	bash $(BUILD)/codecov.bash -f $(BUILD)/coverage.out
 
 
 FILTER := grep -v -e '_string.go' -e '/gen-go/' -e '/mocks/' -e 'vendor/'


### PR DESCRIPTION
We've moved most of our new Go projects to Codecov which has worked
better than Coveralls. Currently, the Coveralls hook just blocks
merging and doesn't report status. Migrate to codecov and clean up the
Travis configuration so we run lint+coverage in a single run, and don't
do the standard tests in that run.