### PR TITLE
Add codecov.yml file with ignores for _string.go

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  range: 75..100
+  round: down
+  precision: 2
+
+  status:
+    project:
+      default:
+        enabled: yes
+        target: 85%
+        if_not_found: success
+        if_ci_failed: error
+ignore:
+- "*_string.go"
+


### PR DESCRIPTION
We would ideally use `.codecov.yml`, but we are unable to due to:
https://github.com/codecov/support/issues/431