### PR TITLE
ping: Don't close connection on errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ lint.log
 tchannel-go.iml
 .vscode
 .bin/
+.idea/

--- a/connection.go
+++ b/connection.go
@@ -380,13 +380,7 @@ func (c *Connection) ping(ctx context.Context) error {
 		return c.connectionError("send ping", err)
 	}
 
-	res := &pingRes{}
-	err = c.recvMessage(ctx, res, mex)
-	if err != nil {
-		return c.connectionError("receive pong", err)
-	}
-
-	return nil
+	return c.recvMessage(ctx, &pingRes{}, mex)
 }
 
 // handlePingRes calls registered ping handlers.


### PR DESCRIPTION
Pings may return an error (e.g., from the relay) or cause a timeout.
This shouldn't cause the connection to be closed.

Add a test to verify that a ping error keeps the connection open.
Without this fix, the errors are:

```
Unexpected log: [Error]: Connection error.
```
and
```
Error:		Should be true
Messages:	Connection should still be active after error frame
```