### PR TITLE
relay: Create timer after adding item to Items list

### DIFF
--- a/idle_sweep_test.go
+++ b/idle_sweep_test.go
@@ -58,7 +58,7 @@ func (pl *peerStatusListener) waitForZeroConnections(t *testing.T, channels ...*
 				return true
 			}
 
-		case <-time.After(testutils.Timeout(50 * time.Millisecond)):
+		case <-time.After(testutils.Timeout(500 * time.Millisecond)):
 			return assert.Fail(t, "Some connections are still open: %s", connectionStatus(channels))
 		}
 	}

--- a/relay.go
+++ b/relay.go
@@ -457,8 +457,8 @@ func (r *Relayer) addRelayItem(isOriginator bool, id, remapID uint32, destinatio
 	if isOriginator {
 		items = r.outbound
 	}
-	item.Timer = time.AfterFunc(ttl, func() { r.timeoutRelayItem(isOriginator, items, id) })
 	items.Add(id, item)
+	item.Timer = time.AfterFunc(ttl, func() { r.timeoutRelayItem(isOriginator, items, id) })
 	return item
 }
 

--- a/relay.go
+++ b/relay.go
@@ -181,7 +181,7 @@ type Relayer struct {
 	inbound *relayItems
 
 	// timeouts is the pool of timers used to track call timeouts.
-	// It allows timer re-use, while allow timers to be created and started separately.
+	// It allows timer re-use, while allowing timers to be created and started separately.
 	timeouts *relayTimerPool
 
 	peers   *RootPeerList

--- a/relay.go
+++ b/relay.go
@@ -185,7 +185,8 @@ type Relayer struct {
 	// It stores remappings for all response frames read on this connection.
 	inbound *relayItems
 
-	// TODO
+	// timeouts is the pool of timers used to track call timeouts.
+	// It allows timer re-use, while allow timers to be created and started separately.
 	timeouts *relayTimerPool
 
 	peers   *RootPeerList

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -67,6 +67,13 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 				rt.Start(time.Hour, &relayItems{}, 0, false /* isOriginator */)
 			},
 		},
+		{
+			msg: "underlying timer is already active",
+			f: func(rt *relayTimer) {
+				rt.timer.Reset(time.Hour)
+				rt.Start(time.Hour, &relayItems{}, 0, false /* isOriginator */)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -1,6 +1,7 @@
 package tchannel
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -85,4 +86,22 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 			tt.f(rt)
 		}, tt.msg)
 	}
+}
+
+func TestRelayTimerStopConcurrently(t *testing.T) {
+	trigger := func(*relayItems, uint32, bool) {}
+	rtp := newRelayTimerPool(trigger)
+	timer := rtp.Get()
+	timer.Start(time.Nanosecond, nil, 0 /* items */, false /* isOriginator */)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			timer.Stop()
+		}()
+	}
+
+	wg.Wait()
 }

--- a/relay_timer_pool.go
+++ b/relay_timer_pool.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package tchannel
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+type relayTimerTrigger func(items *relayItems, id uint32, isOriginator bool)
+
+type relayTimerPool struct {
+	pool    sync.Pool
+	trigger relayTimerTrigger
+}
+
+type relayTimer struct {
+	pool  *relayTimerPool
+	timer *time.Timer
+
+	// Per-timer paramters passed back when the timer is triggered.
+	items        *relayItems
+	id           uint32
+	isOriginator bool
+}
+
+func (rt *relayTimer) OnTimer() {
+	rt.pool.trigger(rt.items, rt.id, rt.isOriginator)
+}
+
+func newRelayTimerPool(trigger relayTimerTrigger) *relayTimerPool {
+	return &relayTimerPool{
+		trigger: trigger,
+	}
+}
+
+// Get returns a Timer that has not started. Timers must be started explicitly
+// using the Start function.
+func (tp *relayTimerPool) Get() *relayTimer {
+	timer, ok := tp.pool.Get().(*relayTimer)
+	if ok {
+		return timer
+	}
+
+	rt := &relayTimer{
+		pool: tp,
+	}
+	rt.timer = time.AfterFunc(time.Duration(math.MaxInt64), rt.OnTimer)
+	if !rt.timer.Stop() {
+		panic("failed to stop timer set for 1 hour")
+	}
+	return rt
+}
+
+// Stop stops the timer and returns whether the timer was stopped. It returns
+// the same behaviour as https://golang.org/pkg/time/#Timer.Stop.
+func (rt *relayTimer) Stop() bool {
+	return rt.timer.Stop()
+}
+
+// Release releases a timer back to the timer pool. The timer MUST be stopped
+// before being released.
+func (rt *relayTimer) Release() {
+	if rt.Stop() {
+		panic("tried to release unstopped timer")
+	}
+	rt.id = 0
+	rt.pool.pool.Put(rt)
+}
+
+// Start starts a timer with the given duration for the specified ID.
+func (rt *relayTimer) Start(d time.Duration, items *relayItems, id uint32, isOriginator bool) {
+	if rt.id != 0 {
+		panic("ID mismatch")
+	}
+
+	rt.items = items
+	rt.id = id
+	rt.isOriginator = isOriginator
+	rt.timer.Reset(d)
+}

--- a/relay_timer_pool.go
+++ b/relay_timer_pool.go
@@ -46,8 +46,9 @@ type relayTimer struct {
 }
 
 func (rt *relayTimer) OnTimer() {
-	rt.pool.trigger(rt.items, rt.id, rt.isOriginator)
+	items, id, isOriginator := rt.items, rt.id, rt.isOriginator
 	rt.markTimerInactive()
+	rt.pool.trigger(items, id, isOriginator)
 }
 
 func newRelayTimerPool(trigger relayTimerTrigger) *relayTimerPool {

--- a/relay_timer_pool.go
+++ b/relay_timer_pool.go
@@ -79,6 +79,11 @@ func (tp *relayTimerPool) Get() *relayTimer {
 	return rt
 }
 
+// Put returns a relayTimer back to the pool.
+func (tp *relayTimerPool) Put(rt *relayTimer) {
+	tp.pool.Put(rt)
+}
+
 // Start starts a timer with the given duration for the specified ID.
 func (rt *relayTimer) Start(d time.Duration, items *relayItems, id uint32, isOriginator bool) {
 	if rt.active {
@@ -121,5 +126,5 @@ func (rt *relayTimer) Release() {
 	if rt.active {
 		panic("only stopped or completed timers can be released")
 	}
-	rt.pool.pool.Put(rt)
+	rt.pool.Put(rt)
 }

--- a/relay_timer_pool.go
+++ b/relay_timer_pool.go
@@ -35,7 +35,7 @@ type relayTimerPool struct {
 
 type relayTimer struct {
 	pool  *relayTimerPool // const
-	timer *time.Timer // const
+	timer *time.Timer     // const
 
 	active bool // mutated on Start/Stop
 
@@ -92,7 +92,6 @@ func (rt *relayTimer) Start(d time.Duration, items *relayItems, id uint32, isOri
 	rt.timer.Reset(d)
 }
 
-
 func (rt *relayTimer) markTimerInactive() {
 	rt.active = false
 	rt.items = nil
@@ -119,4 +118,3 @@ func (rt *relayTimer) Release() {
 	}
 	rt.pool.pool.Put(rt)
 }
-

--- a/relay_timer_pool.go
+++ b/relay_timer_pool.go
@@ -113,7 +113,7 @@ func (rt *relayTimer) Stop() bool {
 // Release releases a timer back to the timer pool. The timer MUST have run or be
 // stopped before Release is called.
 func (rt *relayTimer) Release() {
-	if rt.id != 0 {
+	if rt.active {
 		panic("only stopped or completed timers can be released")
 	}
 	rt.pool.pool.Put(rt)

--- a/relay_timer_pool.go
+++ b/relay_timer_pool.go
@@ -89,7 +89,10 @@ func (rt *relayTimer) Start(d time.Duration, items *relayItems, id uint32, isOri
 	rt.items = items
 	rt.id = id
 	rt.isOriginator = isOriginator
-	rt.timer.Reset(d)
+
+	if wasActive := rt.timer.Reset(d); wasActive {
+		panic("relayTimer's underlying timer was Started multiple times without Stop")
+	}
 }
 
 func (rt *relayTimer) markTimerInactive() {


### PR DESCRIPTION
We currently create a timer before adding the relay item to the list,
but this has the potential to race. If we create a timer which expires
before we add the item, the timeout will not be able to entomb the item
since we won't find the ID in the items list. If this call never
completes, we'll end up leaking the relay item.

To support this use-case, we need to create a timer separately from when we start it. To make this easier, add a new relay timer pool that supports separate creation/start.

As a side-benefit, this ends up reducing allocations per call from 16 allocs to 12 allocs, and improves performance slightly. This is useful since we'll likely take a slight performance hit to fix #688.

Fixes #687, #688