### PR TITLE
Don't double-log on explicit connection closes

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -830,6 +830,7 @@ func (c *Connection) closeNetwork() {
 	// channel would be dangerous since other goroutine might be sending)
 	c.log.Debugf("Closing underlying network connection")
 	c.stopHealthCheck()
+	c.closeNetworkCalled.Inc()
 	if err := c.conn.Close(); err != nil {
 		c.log.WithFields(
 			LogField{"remotePeer", c.remotePeerInfo},


### PR DESCRIPTION
We are never incrementing closeNetworkCalled, so when a connection is
closed, we log both the original trigger of the close, as well as from
readFrames (usually for "use of closed connection") even though we
explicitly called Close on the network connection. Instead we should
only log info logs from readFrames if it was not caused by an explicit
Close.