### PR TITLE
Fix flaky TestHealthCheckIntegration

### DIFF
--- a/health_ext_test.go
+++ b/health_ext_test.go
@@ -157,7 +157,7 @@ func TestHealthCheckIntegration(t *testing.T) {
 		{
 			msg:                 "single failure with failuresToClose=1",
 			failuresToClose:     1,
-			pingResponses:       []bool{true, false, true, true},
+			pingResponses:       []bool{true, false},
 			wantActive:          false,
 			wantHealthCheckLogs: 1,
 		},
@@ -222,11 +222,6 @@ func TestHealthCheckIntegration(t *testing.T) {
 
 					waitForNHealthChecks(t, conn, i+1)
 					assert.Equal(t, tt.pingResponses[:i+1], introspectConn(conn).HealthChecks, "Unexpectd health check history")
-
-					// No point performing more pings if the connection has been closed.
-					if !conn.IsActive() {
-						break
-					}
 				}
 
 				// Once the health check is done, we trigger a Close, it's possible we are still


### PR DESCRIPTION
Fixes flaky test seen in:
https://travis-ci.org/uber/tchannel-go/jobs/295494508

The test currently checks if a connection is active after making a ping
request, but there's a chance the connection hasn't yet been closed
(e.g., we are still processing the ping response in the background
goroutine).

We already have logic outside of the for loop to avoid this race, the
test just needed to have less ping respones. When failuresToClose is set
to 1, we only need a single failure for the connection to be closed.