### PR TITLE
log: Use serviceName key for channel logs, DRY up logger creation

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -195,10 +195,6 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 	if logger == nil {
 		logger = NullLogger
 	}
-	logger = logger.WithFields(
-		LogField{"service", serviceName},
-		LogField{"process", processName},
-	)
 
 	statsReporter := opts.StatsReporter
 	if statsReporter == nil {
@@ -216,12 +212,15 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 	}
 
 	chID := _nextChID.Inc()
+	logger = logger.WithFields(
+		LogField{"serviceName", serviceName},
+		LogField{"process", processName},
+		LogField{"chID", chID},
+	)
+
 	ch := &Channel{
 		channelConnectionCommon: channelConnectionCommon{
-			log: logger.WithFields(
-				LogField{"chID", chID},
-				LogField{"service", serviceName},
-				LogField{"process", processName}),
+			log:           logger,
 			relayLocal:    toStringSet(opts.RelayLocalHandlers),
 			statsReporter: statsReporter,
 			subChannels:   &subChannelMap{},

--- a/channel_test.go
+++ b/channel_test.go
@@ -73,11 +73,11 @@ func TestLoggers(t *testing.T) {
 
 	peerInfo := ch.PeerInfo()
 	fields := toMap(ch.Logger().Fields())
-	assert.Equal(t, peerInfo.ServiceName, fields["service"])
+	assert.Equal(t, peerInfo.ServiceName, fields["serviceName"])
 
 	sc := ch.GetSubChannel("subch")
 	fields = toMap(sc.Logger().Fields())
-	assert.Equal(t, peerInfo.ServiceName, fields["service"])
+	assert.Equal(t, peerInfo.ServiceName, fields["serviceName"])
 	assert.Equal(t, "subch", fields["subchannel"])
 }
 


### PR DESCRIPTION
Currently, we use "service" as the log field, which is used to identify
the service that produced the log and we end up accidentally clobbering.

Use "serviceName" which doesn't clash, and DRY up the logger creation.