### PR TITLE
thrift: Better logs on errors

### DIFF
--- a/thrift/server.go
+++ b/thrift/server.go
@@ -94,13 +94,33 @@ func (s *Server) SetContextFn(f func(ctx context.Context, method string, headers
 	s.ctxFn = f
 }
 
-func (s *Server) onError(err error) {
+func (s *Server) onError(ctx context.Context, method string, err error) {
 	// TODO(prashant): Expose incoming call errors through options for NewServer.
-	// Timeouts should not be reported as errors.
+	logger := s.log.WithFields(
+		tchannel.ErrField(err),
+	)
+
+	// Add additional context about the remote peer if available.
+	if call := tchannel.CurrentCall(ctx); call != nil {
+		remotePeer := call.RemotePeer()
+		logger = logger.WithFields(
+			tchannel.LogField{Key: "method", Value: method},
+			tchannel.LogField{Key: "callerName", Value: call.CallerName()},
+
+			// TODO: These are very similar to the connection fields, but we don't
+			// have access to the connection's logger. Consider exposing the
+			// connection through CurrentCall.
+			tchannel.LogField{Key: "localAddr", Value: call.LocalPeer().HostPort},
+			tchannel.LogField{Key: "remoteHostPort", Value: remotePeer.HostPort},
+			tchannel.LogField{Key: "remoteIsEphemeral", Value: remotePeer.IsEphemeral},
+			tchannel.LogField{Key: "remoteProcess", Value: remotePeer.ProcessName},
+		)
+	}
+
 	if tchannel.GetSystemErrorCode(err) == tchannel.ErrCodeTimeout {
-		s.log.Debugf("thrift Server timeout: %v", err)
+		logger.Debug("Thrift server timeout.")
 	} else {
-		s.log.WithFields(tchannel.ErrField(err)).Error("Thrift server error.")
+		logger.Error("Thrift server error.")
 	}
 }
 
@@ -211,6 +231,6 @@ func (s *Server) Handle(ctx context.Context, call *tchannel.InboundCall) {
 	}
 
 	if err := s.handle(ctx, handler, method, call); err != nil {
-		s.onError(err)
+		s.onError(ctx, call.MethodString(), err)
 	}
 }

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -98,13 +98,13 @@ func (s *Server) onError(ctx context.Context, method string, err error) {
 	// TODO(prashant): Expose incoming call errors through options for NewServer.
 	logger := s.log.WithFields(
 		tchannel.ErrField(err),
+		tchannel.LogField{Key: "method", Value: method},
 	)
 
 	// Add additional context about the remote peer if available.
 	if call := tchannel.CurrentCall(ctx); call != nil {
 		remotePeer := call.RemotePeer()
 		logger = logger.WithFields(
-			tchannel.LogField{Key: "method", Value: method},
 			tchannel.LogField{Key: "callerName", Value: call.CallerName()},
 
 			// TODO: These are very similar to the connection fields, but we don't


### PR DESCRIPTION
Since we log using the channel logger, we have minimal information
(current process name, error, and channel name), but no relevant
information about what specifically failed:
 - the method name
 - the remote process information

We should provide as much useful context on errors to make it easier for
users to understand what failed and the impact.

Error changes from:
```
14:47:06.844295 [D] thrift Server timeout: tchannel error ErrCodeTimeout: timeout tags: [{service testService} {process testService-60389} {chID 1} {service testService} {process testService-60389} {hostPort 127.0.0.1:60389}]
```
to
```
14:46:52.565951 [D] Thrift server timeout. tags: [{service testService} {process testService-60364} {chID 1} {service testService} {process testService-60364} {hostPort 127.0.0.1:60364} {error tchannel error ErrCodeTimeout: timeout} {method SecondService::Echo} {callerName testService-client} {localAddr 127.0.0.1:60364} {remoteHostPort 127.0.0.1:60365} {remoteIsEphemeral true} {remoteProcess testService-client-1}]

```