### PR TITLE
Make stats_test less sensitive to the number of timeNow calls

### DIFF
--- a/testutils/now.go
+++ b/testutils/now.go
@@ -28,22 +28,8 @@ import (
 // StubClock is a fake wall-clock, exposing a Now() method that returns a
 // test-controlled time.
 type StubClock struct {
-	cur time.Time
 	mu  sync.Mutex
-}
-
-// Now returns the current time stored in StubClock
-func (c *StubClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.cur
-}
-
-// Elapse increments the time returned by Now()
-func (c *StubClock) Elapse(addAmt time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cur = c.cur.Add(addAmt)
+	cur time.Time
 }
 
 // NewStubClock returns a fake wall-clock object
@@ -51,4 +37,20 @@ func NewStubClock(initial time.Time) *StubClock {
 	return &StubClock{
 		cur: initial,
 	}
+}
+
+// Now returns the current time stored in StubClock
+func (c *StubClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.cur
+}
+
+// Elapse increments the time returned by Now()
+func (c *StubClock) Elapse(addAmt time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cur = c.cur.Add(addAmt)
 }

--- a/testutils/now.go
+++ b/testutils/now.go
@@ -25,23 +25,24 @@ import (
 	"time"
 )
 
-// StubClock is a fake wall-clock, exposing a frozen Now()
+// StubClock is a fake wall-clock, exposing a Now() method that returns a
+// test-controlled time.
 type StubClock struct {
 	cur time.Time
-	mut sync.Mutex
+	mu  sync.Mutex
 }
 
 // Now returns the current time stored in StubClock
 func (c *StubClock) Now() time.Time {
-	c.mut.Lock()
-	defer c.mut.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.cur
 }
 
 // Elapse increments the time returned by Now()
 func (c *StubClock) Elapse(addAmt time.Duration) {
-	c.mut.Lock()
-	defer c.mut.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.cur = c.cur.Add(addAmt)
 }
 

--- a/testutils/now.go
+++ b/testutils/now.go
@@ -25,22 +25,29 @@ import (
 	"time"
 )
 
-// NowStub returns a stub time.Now function that allows the return values to
-// to be controller by the caller. It returns two functions:
-// stub: The stub time.Now function.
-// increment: Used to control the increment amount between calls.
-func NowStub(initial time.Time) (stub func() time.Time, increment func(time.Duration)) {
-	var mut sync.Mutex
-	cur := initial
-	var addAmt time.Duration
-	stub = func() time.Time {
-		mut.Lock()
-		defer mut.Unlock()
-		cur = cur.Add(addAmt)
-		return cur
+// StubClock is a fake wall-clock, exposing a frozen Now()
+type StubClock struct {
+	cur time.Time
+	mut sync.Mutex
+}
+
+// Now returns the current time stored in StubClock
+func (c *StubClock) Now() time.Time {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	return c.cur
+}
+
+// Elapse increments the time returned by Now()
+func (c *StubClock) Elapse(addAmt time.Duration) {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	c.cur = c.cur.Add(addAmt)
+}
+
+// NewStubClock returns a fake wall-clock object
+func NewStubClock(initial time.Time) *StubClock {
+	return &StubClock{
+		cur: initial,
 	}
-	increment = func(d time.Duration) {
-		addAmt = d
-	}
-	return stub, increment
 }


### PR DESCRIPTION
The tests were written with a specific number of timeNow calls in place, making the implementation difficult to modify.