### PR TITLE
Use string version for all addresses

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -274,8 +274,8 @@ func (ch *Channel) newConnection(conn net.Conn, initialID uint32, outboundHP str
 	connID := _nextConnID.Inc()
 	log := ch.log.WithFields(LogFields{
 		{"connID", connID},
-		{"localAddr", conn.LocalAddr()},
-		{"remoteAddr", conn.RemoteAddr()},
+		{"localAddr", conn.LocalAddr().String()},
+		{"remoteAddr", conn.RemoteAddr().String()},
 		{"remoteHostPort", remotePeer.HostPort},
 		{"remoteIsEphemeral", remotePeer.IsEphemeral},
 		{"remoteProcess", remotePeer.ProcessName},

--- a/preinit_connection.go
+++ b/preinit_connection.go
@@ -127,8 +127,8 @@ func (ch *Channel) initError(c net.Conn, connDir connectionDirection, id uint32,
 
 	ch.log.WithFields(LogFields{
 		{"connectionDirection", connDir},
-		{"localAddr", c.LocalAddr()},
-		{"remoteAddr", c.RemoteAddr()},
+		{"localAddr", c.LocalAddr().String()},
+		{"remoteAddr", c.RemoteAddr().String()},
 		ErrField(err),
 	}...).Error("Failed during connection handshake.")
 


### PR DESCRIPTION
We currently emit "localAddr" as a string, and as a object. Instead, we
should always emit it as a string.