### PR TITLE
Remove double hostPort field in log

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -319,11 +319,7 @@ func (ch *Channel) Serve(l net.Listener) error {
 	mutable.peerInfo.HostPort = l.Addr().String()
 	mutable.peerInfo.IsEphemeral = false
 	ch.log = ch.log.WithFields(LogField{"hostPort", mutable.peerInfo.HostPort})
-
-	peerInfo := mutable.peerInfo
-	ch.log.WithFields(
-		LogField{"hostPort", peerInfo.HostPort},
-	).Info("Channel is listening.")
+	ch.log.Info("Channel is listening.")
 	go ch.serve()
 	return nil
 }


### PR DESCRIPTION
Currently, we add the hostPort field to the channel logger, then add it
again inline in the log call.

This doesn't cause an issue for most users as they use logrus/similar
loggers which use a map for fields. However, when using zap, this ends
up logging the same field multiple times.