### PR TITLE
stats: Add tally reporter to emit tagged metrics

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,16 @@
-hash: d6093eb1a6d4c1eaa9f2ad996ebf07748b0b3a0413f4ab9b9435df1d255567a5
-updated: 2017-09-25T17:19:51.449837394-07:00
+hash: b75ed7f632cfd185b6a8f8bc037b09d32e292f908af6c1e257e444e17a3a39ef
+updated: 2018-01-30T12:06:17.405736-08:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
-  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
+  version: 138b925ccdf617776955904ba7759fce64406cec
   subpackages:
   - statsd
+- name: github.com/facebookgo/clock
+  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/opentracing/opentracing-go
   version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
@@ -20,12 +22,15 @@ imports:
   subpackages:
   - parser
 - name: github.com/uber-go/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
   subpackages:
   - utils
+- name: github.com/uber-go/tally
+  version: 6c4631652c6aab57c64f65c2e0aaec2e9aae3a64
 - name: github.com/uber/jaeger-client-go
-  version: 3e3870040def0ebdaf65a003863fa64f5cb26139
+  version: 3ac96c6e679cb60a74589b0d0aa7c70a906183f7
   subpackages:
+  - internal/baggage
   - internal/spanlog
   - log
   - thrift-gen/agent
@@ -34,7 +39,7 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: golang.org/x/net
-  version: 8351a756f30f1297fe94bbf4b767ec589c6ea6d0
+  version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
   - bpf
   - context
@@ -61,24 +66,24 @@ testImports:
   - ext
   - mocktracer
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/prashantv/protectmem
-  version: d0cabd7ce64237b84414449086fa42810ae01a92
+  version: e20412882b3adb9cabd3e9013d68adbfff9ea946
 - name: github.com/streadway/quantile
   version: b0c588724d25ae13f5afb3d90efec0edc636432b
 - name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
+  version: 8a3f7159479fbc75b30357fbc48f380b7320f08e
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
   subpackages:
   - assert
   - mock
   - require
 - name: github.com/uber/jaeger-lib
-  version: 21a3da6d66fe0e278072676fdc84cd4c9ccb9b67
+  version: 7f95f4f7e80028096410abddaae2556e4c61b59f
   subpackages:
   - metrics
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: d670f9405373e636a5a2765eea47fac0c9bc91a4

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,6 +31,8 @@ import:
   version: ^1
 - package: github.com/uber/jaeger-client-go
   version: ^2.7
+- package: github.com/uber-go/tally
+  version: ^3
 testImport:
 - package: github.com/jessevdk/go-flags
   version: ^1

--- a/stats/tally.go
+++ b/stats/tally.go
@@ -1,0 +1,188 @@
+package stats
+
+import (
+	"sync"
+	"time"
+
+	"github.com/uber/tchannel-go"
+
+	"github.com/uber-go/tally"
+)
+
+type wrapper struct {
+	sync.RWMutex
+
+	scope  tally.Scope
+	byTags map[knownTags]*taggedScope
+}
+
+type knownTags struct {
+	dest       string
+	source     string
+	procedure  string
+	retryCount string
+}
+
+type taggedScope struct {
+	sync.RWMutex
+
+	scope tally.Scope // already tagged with some set of tags
+
+	counters map[string]tally.Counter
+	gauges   map[string]tally.Gauge
+	timers   map[string]tally.Timer
+}
+
+// NewTallyReporter takes a tally.Scope and wraps it so it ca be used as a
+// StatsReporter. The list of metrics emitted is documented on:
+// https://tchannel.readthedocs.io/en/latest/metrics/
+// The tags emitted are similar to Muttley/YARPC, the tags emitted are:
+// source, dest, procedure, and retry-count.
+func NewTallyReporter(scope tally.Scope) tchannel.StatsReporter {
+	return &wrapper{
+		scope:  scope,
+		byTags: make(map[knownTags]*taggedScope),
+	}
+}
+
+func (w *wrapper) IncCounter(name string, tags map[string]string, value int64) {
+	ts := w.getTaggedScope(tags)
+	ts.getCounter(name).Inc(value)
+}
+
+func (w *wrapper) UpdateGauge(name string, tags map[string]string, value int64) {
+	ts := w.getTaggedScope(tags)
+	ts.getGauge(name).Update(float64(value))
+}
+
+func (w *wrapper) RecordTimer(name string, tags map[string]string, d time.Duration) {
+	ts := w.getTaggedScope(tags)
+	ts.getTimer(name).Record(d)
+}
+
+func (w *wrapper) getTaggedScope(tags map[string]string) *taggedScope {
+	kt := convertTags(tags)
+
+	w.RLock()
+	ts, ok := w.byTags[kt]
+	w.RUnlock()
+	if ok {
+		return ts
+	}
+
+	w.Lock()
+	defer w.Unlock()
+
+	// Always double-check under the write-lock.
+	if ts, ok := w.byTags[kt]; ok {
+		return ts
+	}
+
+	ts = &taggedScope{
+		scope:    w.scope.Tagged(kt.tallyTags()),
+		counters: make(map[string]tally.Counter),
+		gauges:   make(map[string]tally.Gauge),
+		timers:   make(map[string]tally.Timer),
+	}
+	w.byTags[kt] = ts
+	return ts
+}
+
+func convertTags(tags map[string]string) knownTags {
+	if ts, ok := tags["target-service"]; ok {
+		// Outbound call.
+		return knownTags{
+			dest:       ts,
+			source:     tags["service"],
+			procedure:  tags["target-endpoint"],
+			retryCount: tags["retry-count"],
+		}
+	}
+
+	if cs, ok := tags["calling-service"]; ok {
+		// Inbound call.
+		return knownTags{
+			dest:       tags["service"],
+			source:     cs,
+			procedure:  tags["endpoint"],
+			retryCount: tags["retry-count"],
+		}
+	}
+
+	// TChannel doesn't use any other tags, so ignore all others for now.
+	return knownTags{}
+}
+
+// Create a sub-scope for this set of known tags.
+func (kt knownTags) tallyTags() map[string]string {
+	tallyTags := make(map[string]string, 5)
+
+	if kt.dest != "" {
+		tallyTags["dest"] = kt.dest
+	}
+	if kt.source != "" {
+		tallyTags["source"] = kt.source
+	}
+	if kt.procedure != "" {
+		tallyTags["procedure"] = kt.procedure
+	}
+	if kt.retryCount != "" {
+		tallyTags["retry-count"] = kt.retryCount
+	}
+
+	return tallyTags
+}
+
+func (ts *taggedScope) getCounter(name string) tally.Counter {
+	ts.RLock()
+	counter, ok := ts.counters[name]
+	ts.RUnlock()
+	if ok {
+		return counter
+	}
+
+	ts.Lock()
+	defer ts.Unlock()
+
+	// No double-check under the lock, as overwriting the counter has
+	// no impact.
+	counter = ts.scope.Counter(name)
+	ts.counters[name] = counter
+	return counter
+}
+
+func (ts *taggedScope) getGauge(name string) tally.Gauge {
+	ts.RLock()
+	gauge, ok := ts.gauges[name]
+	ts.RUnlock()
+	if ok {
+		return gauge
+	}
+
+	ts.Lock()
+	defer ts.Unlock()
+
+	// No double-check under the lock, as overwriting the counter has
+	// no impact.
+	gauge = ts.scope.Gauge(name)
+	ts.gauges[name] = gauge
+	return gauge
+}
+
+func (ts *taggedScope) getTimer(name string) tally.Timer {
+	ts.RLock()
+	timer, ok := ts.timers[name]
+	ts.RUnlock()
+	if ok {
+		return timer
+	}
+
+	ts.Lock()
+	defer ts.Unlock()
+
+	// No double-check under the lock, as overwriting the counter has
+	// no impact.
+	timer = ts.scope.Timer(name)
+	ts.timers[name] = timer
+	return timer
+}

--- a/stats/tally.go
+++ b/stats/tally.go
@@ -36,7 +36,7 @@ type taggedScope struct {
 // NewTallyReporter takes a tally.Scope and wraps it so it ca be used as a
 // StatsReporter. The list of metrics emitted is documented on:
 // https://tchannel.readthedocs.io/en/latest/metrics/
-// The tags emitted are similar to Muttley/YARPC, the tags emitted are:
+// The metrics emitted are similar to YARPC, the tags emitted are:
 // source, dest, procedure, and retry-count.
 func NewTallyReporter(scope tally.Scope) tchannel.StatsReporter {
 	return &wrapper{

--- a/stats/tally_test.go
+++ b/stats/tally_test.go
@@ -1,0 +1,173 @@
+package stats
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+func TestConvertTags(t *testing.T) {
+	tests := []struct {
+		tags map[string]string
+		want map[string]string
+	}{
+		{
+			tags: nil,
+			want: map[string]string{},
+		},
+		{
+			// unknown tags are ignored.
+			tags: map[string]string{"foo": "bar"},
+			want: map[string]string{},
+		},
+		{
+			// Outbound call
+			tags: map[string]string{
+				"target-service":  "tsvc",
+				"service":         "foo",
+				"target-endpoint": "te",
+				"retry-count":     "4",
+
+				// ignored tag
+				"foo": "bar",
+			},
+			want: map[string]string{
+				"dest":        "tsvc",
+				"source":      "foo",
+				"procedure":   "te",
+				"retry-count": "4",
+			},
+		},
+		{
+			// Inbound call
+			tags: map[string]string{
+				"service":         "foo",
+				"calling-service": "bar",
+				"endpoint":        "ep",
+			},
+			want: map[string]string{
+				"dest":      "foo",
+				"source":    "bar",
+				"procedure": "ep",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprint(tt.tags), func(t *testing.T) {
+			got := convertTags(tt.tags)
+			assert.Equal(t, tt.want, got.tallyTags())
+		})
+	}
+}
+
+func TestNewTallyReporter(t *testing.T) {
+	want := tally.NewTestScope("" /* prefix */, nil /* tags */)
+	scope := tally.NewTestScope("" /* prefix */, nil /* tags */)
+	wrapped := NewTallyReporter(scope)
+
+	for i := 0; i < 10; i++ {
+		wrapped.IncCounter("outbound.calls", map[string]string{
+			"target-service":  "tsvc",
+			"service":         "foo",
+			"target-endpoint": "te",
+		}, 3)
+		want.Tagged(map[string]string{
+			"dest":      "tsvc",
+			"source":    "foo",
+			"procedure": "te",
+		}).Counter("outbound.calls").Inc(3)
+
+		wrapped.UpdateGauge("num-connections", map[string]string{
+			"service": "foo",
+		}, 3)
+		want.Gauge("num-connections").Update(3)
+
+		wrapped.RecordTimer("inbound.call.latency", map[string]string{
+			"service":         "foo",
+			"calling-service": "bar",
+			"endpoint":        "ep",
+		}, time.Second)
+		want.Tagged(map[string]string{
+			"dest":      "foo",
+			"source":    "bar",
+			"procedure": "ep",
+		}).Timer("inbound.call.latency").Record(time.Second)
+	}
+
+	assert.Equal(t, want.Snapshot(), scope.Snapshot())
+}
+
+func TestTallyIntegration(t *testing.T) {
+	clientScope := tally.NewTestScope("" /* prefix */, nil /* tags */)
+	serverScope := tally.NewTestScope("" /* prefix */, nil /* tags */)
+
+	server := testutils.NewServer(t, testutils.NewOpts().SetStatsReporter(NewTallyReporter(serverScope)))
+	defer server.Close()
+	testutils.RegisterEcho(server, nil)
+
+	client := testutils.NewClient(t, testutils.NewOpts().SetStatsReporter(NewTallyReporter(clientScope)))
+	defer client.Close()
+
+	testutils.AssertEcho(t, client, server.PeerInfo().HostPort, server.ServiceName())
+
+	// Verify the tagged metrics from that call.
+	tests := []struct {
+		msg      string
+		scope    tally.TestScope
+		counters []string
+		timers   []string
+	}{
+		{
+			msg:   "client metrics",
+			scope: clientScope,
+			counters: []string{
+				"outbound.calls.send+dest=testService,procedure=echo,source=testService-client",
+				"outbound.calls.success+dest=testService,procedure=echo,source=testService-client",
+			},
+			timers: []string{
+				"outbound.calls.per-attempt.latency+dest=testService,procedure=echo,source=testService-client",
+				"outbound.calls.latency+dest=testService,procedure=echo,source=testService-client",
+			},
+		},
+		{
+			msg:   "server metrics",
+			scope: serverScope,
+			counters: []string{
+				"inbound.calls.recvd+dest=testService,procedure=echo,source=testService-client",
+				"inbound.calls.success+dest=testService,procedure=echo,source=testService-client",
+			},
+			timers: []string{
+				"inbound.calls.latency+dest=testService,procedure=echo,source=testService-client",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		snapshot := tt.scope.Snapshot()
+		for _, counter := range tt.counters {
+			assert.Contains(t, snapshot.Counters(), counter, "missing counter")
+		}
+		for _, timer := range tt.timers {
+			assert.Contains(t, snapshot.Timers(), timer, "missing timer")
+		}
+	}
+}
+
+func BenchmarkTallyCounter(b *testing.B) {
+	scope := tally.NewTestScope("" /* prefix */, nil /* tags */)
+	wrapped := NewTallyReporter(scope)
+
+	tags := map[string]string{
+		"target-service":  "tsvc",
+		"service":         "foo",
+		"target-endpoint": "te",
+	}
+	for i := 0; i < b.N; i++ {
+		wrapped.IncCounter("outbound.calls", tags, 1)
+	}
+}


### PR DESCRIPTION
This is an open-sourcing of the tally StatsReporter which will emit
tagged metrics rather than statsd metrics.