### PR TITLE
Expose relay span setting in relayer

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -24,6 +24,10 @@
 // backwards-compatibility guarantee.
 package relay
 
+import (
+	"github.com/opentracing/opentracing-go"
+)
+
 // CallFrame is an interface that abstracts access to the call req frame.
 type CallFrame interface {
 	// Caller is the name of the originating service.
@@ -37,6 +41,8 @@ type CallFrame interface {
 	// RoutingKey may refer to an alternate traffic group instead of the
 	// traffic group identified by the service name.
 	RoutingKey() []byte
+	// SetRelaySpan replaces span in frame with a relay span and returns it
+	SetRelaySpan(tracer opentracing.Tracer, operationName string) (opentracing.Span, error)
 }
 
 // RateLimitDropError is the error that should be returned from

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -25,6 +25,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"time"
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/tchannel-go/typed"
 )
 
 var (
@@ -176,6 +178,29 @@ func (f lazyCallReq) SetTTL(d time.Duration) {
 // Span returns the Span
 func (f lazyCallReq) Span() Span {
 	return callReqSpan(f.Frame)
+}
+
+// SetRelaySpan replaces span in frame with a relay span and returns it
+func (f lazyCallReq) SetRelaySpan(tracer opentracing.Tracer, operationName string) (opentracing.Span, error) {
+	// Extract original span information from the frame
+	span := f.Span()
+	spanCtx, err := tracer.Extract(zipkinSpanFormat, &span)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start the relay span as child of the original span
+	relaySpan := tracer.StartSpan(operationName, opentracing.ChildOf(spanCtx))
+
+	// Overwrite relay span information back into frame
+	var injectableSpan injectableSpan
+	injectableSpan.initFromOpenTracing(relaySpan)
+	childSpan := Span(injectableSpan)
+	err = childSpan.write(typed.NewWriteBuffer(f.Payload[_spanIndex : _spanIndex+_spanLength]))
+
+	// Caller of this function can edit
+	// and is responsible for finishing the relay span
+	return relaySpan, err
 }
 
 // HasMoreFragments returns whether the callReq has more fragments.

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/tchannel-go/typed"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/opentracing/opentracing-go/mocktracer"
 )
 
 type testCallReq int
@@ -37,6 +38,7 @@ const (
 	reqHasDelegate
 	reqHasRoutingKey
 	reqHasChecksum
+	reqHasReplacedSpan
 	reqTotalCombinations
 	reqHasAll testCallReq = reqTotalCombinations - 1
 )
@@ -53,7 +55,10 @@ func (cr testCallReq) req() lazyCallReq {
 	payload := typed.NewWriteBuffer(f.Payload)
 	payload.WriteSingleByte(0)           // flags
 	payload.WriteUint32(42)              // TTL
-	payload.WriteBytes(make([]byte, 25)) // tracing
+	payload.WriteUint64(4) 		     // spanID
+	payload.WriteUint64(3) 		     // parentID
+	payload.WriteUint64(2) 		     // traceID
+	payload.WriteSingleByte(1)	     // traceFlag (sampled=true)
 	payload.WriteLen8String("bankmoji")  // service
 
 	headers := make(map[string]string)
@@ -79,7 +84,16 @@ func (cr testCallReq) req() lazyCallReq {
 		payload.WriteUint32(0)                            // checksum contents
 	}
 	payload.WriteLen16String("moneys") // method
-	return newLazyCallReq(f)
+	r := newLazyCallReq(f)
+
+	if cr&reqHasReplacedSpan != 0 {
+		tracer := mocktracer.New()
+		tracer.RegisterExtractor(zipkinSpanFormat, new(zipkinExtractor))
+		tracer.RegisterInjector(zipkinSpanFormat, new(zipkinInjector))
+		span, _ := r.SetRelaySpan(tracer, "relay-op")
+		defer span.Finish()
+	}
+	return r
 }
 
 func withLazyCallReqCombinations(f func(cr testCallReq)) {
@@ -303,5 +317,23 @@ func TestLazyErrorCodes(t *testing.T) {
 	withLazyErrorCombinations(func(ec SystemErrCode) {
 		f := ec.fakeErrFrame()
 		assert.Equal(t, ec, f.Code(), "Mismatch between error code and lazy frame's Code() method.")
+	})
+}
+
+func TestSetRelaySpan(t *testing.T) {
+	withLazyCallReqCombinations(func(crt testCallReq) {
+		cr := crt.req()
+		assert.Equal(t, uint8(1), cr.Span().Flags())
+		if crt&reqHasReplacedSpan == 0 {
+			assert.Equal(t, uint64(4), cr.Span().SpanID())
+			assert.Equal(t, uint64(3), cr.Span().ParentID())
+			assert.Equal(t, uint64(2), cr.Span().TraceID())
+
+		} else {
+			assert.NotEqual(t, uint(4), cr.Span().SpanID())
+			// mockTracker doesn't inject/extract parent IDs
+			assert.Equal(t, uint64(0), cr.Span().ParentID())
+			assert.Equal(t, uint64(2), cr.Span().TraceID())
+		}
 	})
 }

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -23,6 +23,7 @@ package testutils
 import (
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/relay"
+	"github.com/opentracing/opentracing-go"
 )
 
 // FakeIncomingCall implements IncomingCall interface.
@@ -94,6 +95,7 @@ func NewIncomingCall(callerName string) tchannel.IncomingCall {
 // FakeCallFrame is a stub implementation of the CallFrame interface.
 type FakeCallFrame struct {
 	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF string
+	Span tchannel.Span
 }
 
 var _ relay.CallFrame = FakeCallFrame{}
@@ -121,4 +123,11 @@ func (f FakeCallFrame) RoutingKey() []byte {
 // RoutingDelegate returns the routing delegate field.
 func (f FakeCallFrame) RoutingDelegate() []byte {
 	return []byte(f.RoutingDelegateF)
+}
+
+func (f FakeCallFrame) SetRelaySpan(
+	tracer opentracing.Tracer,
+	operationName string,
+)(opentracing.Span, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Expose the ability overriding span ID transport heade. This allows relaying services to report their own tracing.