### PR TITLE
Expose relay span setting in relayer

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -24,6 +24,10 @@
 // backwards-compatibility guarantee.
 package relay
 
+import (
+	"github.com/opentracing/opentracing-go"
+)
+
 // CallFrame is an interface that abstracts access to the call req frame.
 type CallFrame interface {
 	// Caller is the name of the originating service.
@@ -37,6 +41,8 @@ type CallFrame interface {
 	// RoutingKey may refer to an alternate traffic group instead of the
 	// traffic group identified by the service name.
 	RoutingKey() []byte
+	// SetRelaySpan replaces span in frame with a relay span and returns it
+	SetRelaySpan(tracer opentracing.Tracer, operationName string) (opentracing.Span, error)
 }
 
 // RateLimitDropError is the error that should be returned from

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -21,6 +21,7 @@
 package testutils
 
 import (
+	"github.com/opentracing/opentracing-go"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/relay"
 )
@@ -94,6 +95,7 @@ func NewIncomingCall(callerName string) tchannel.IncomingCall {
 // FakeCallFrame is a stub implementation of the CallFrame interface.
 type FakeCallFrame struct {
 	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF string
+	Span                                                      tchannel.Span
 }
 
 var _ relay.CallFrame = FakeCallFrame{}
@@ -121,4 +123,12 @@ func (f FakeCallFrame) RoutingKey() []byte {
 // RoutingDelegate returns the routing delegate field.
 func (f FakeCallFrame) RoutingDelegate() []byte {
 	return []byte(f.RoutingDelegateF)
+}
+
+// SetRelaySpan is a no-op when testing.
+func (f FakeCallFrame) SetRelaySpan(
+	tracer opentracing.Tracer,
+	operationName string,
+) (opentracing.Span, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Expose SetRelaySpan to CallFrame interface. It allows relaying services to report their own spans.