### PR TITLE
Allow blackholing requests

### DIFF
--- a/inbound.go
+++ b/inbound.go
@@ -93,6 +93,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	if response.span != nil {
 		mex.ctx = opentracing.ContextWithSpan(mex.ctx, response.span)
 	}
+	response.blackhole = make(chan struct{})
 	response.mex = mex
 	response.conn = c
 	response.cancel = cancel
@@ -194,6 +195,10 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall, fram
 			// TODO: move the cancel to the parent context at connnection level
 			call.response.cancel()
 			call.mex.inboundExpired()
+		case <-call.response.blackhole:
+			// close go routine, release resources
+			call.mex.inboundExpired()
+			return
 		}
 	}()
 
@@ -329,6 +334,8 @@ type InboundCallResponse struct {
 	span             opentracing.Span
 	statsReporter    StatsReporter
 	commonStatsTags  map[string]string
+	// blackhole is a channel that gets closed when the repsonse should be blackholed.
+	blackhole chan struct{}
 }
 
 // SendSystemError returns a system error response to the peer.  The call is considered
@@ -359,6 +366,12 @@ func (response *InboundCallResponse) SetApplicationError() error {
 	}
 	response.applicationError = true
 	return nil
+}
+
+// Blackhole indicates that there should be no response and provides
+// an opportunity to clean up resources.
+func (response *InboundCallResponse) Blackhole() {
+	close(response.blackhole)
 }
 
 // Arg2Writer returns a WriteCloser that can be used to write the second argument.

--- a/inbound.go
+++ b/inbound.go
@@ -361,8 +361,9 @@ func (response *InboundCallResponse) SetApplicationError() error {
 	return nil
 }
 
-// Blackhole indicates that there should be no response and provides
-// an opportunity to clean up resources.
+// Blackhole indicates no response will be sent, and cleans up any resources
+// associated with this request. This allows for services to trigger a timeout in
+// clients without holding on to any goroutines on the server.
 func (response *InboundCallResponse) Blackhole() {
 	response.cancel()
 }

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -180,6 +180,8 @@ func TestBlackhole(t *testing.T) {
 		require.Error(t, err, "expected call error")
 
 		errCode := GetSystemErrorCode(err)
+		// Providing 'got: %q' is necessary since SystemErrCode is a type alias of byte; testify's
+		// failed test ouput would otherwise print out hex codes.
 		assert.Equal(t, ErrCodeCancelled, errCode, "expected cancelled error code, got: %q", errCode)
 	})
 }

--- a/mex.go
+++ b/mex.go
@@ -390,7 +390,7 @@ func (mexset *messageExchangeSet) removeExchange(msgID uint32) {
 // will write to the send channel.
 func (mexset *messageExchangeSet) expireExchange(msgID uint32) {
 	mexset.log.Debugf(
-		"Removing %s message exchange %d due to timeout or cancelation",
+		"Removing %s message exchange %d due to timeout, cancelation or blackhole",
 		mexset.name,
 		msgID,
 	)

--- a/mex.go
+++ b/mex.go
@@ -390,7 +390,7 @@ func (mexset *messageExchangeSet) removeExchange(msgID uint32) {
 // will write to the send channel.
 func (mexset *messageExchangeSet) expireExchange(msgID uint32) {
 	mexset.log.Debugf(
-		"Removing %s message exchange %d due to timeout, cancelation or blackhole",
+		"Removing %s message exchange %d due to timeout, cancellation or blackhole",
 		mexset.name,
 		msgID,
 	)


### PR DESCRIPTION
This enables us to blackhole requests and release unnecessary long-lived goroutines.

Confirmed with pprof and YARPC that the only goroutines left running are for each connection.

Relates to yarpc/yarpc-go#1436.