### PR TITLE
relay: Verify no use-after-free in timer pool

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -76,7 +76,13 @@ type ChannelOptions struct {
 
 	// The maximum allowable timeout for relayed calls (longer timeouts are
 	// clamped to this value). Passing zero uses the default of 2m.
+	// This is an unstable API - breaking changes are likely.
 	RelayMaxTimeout time.Duration
+
+	// RelayTimerVerification will disable pooling of relay timers, and instead
+	// verify that timers are not used once they are released.
+	// This is an unstable API - breaking changes are likely.
+	RelayTimerVerification bool
 
 	// The reporter to use for reporting stats for this channel.
 	StatsReporter StatsReporter
@@ -148,6 +154,7 @@ type Channel struct {
 	peers               *PeerList
 	relayHost           RelayHost
 	relayMaxTimeout     time.Duration
+	relayTimerVerify    bool
 	handler             Handler
 	onPeerStatusChanged func(*Peer)
 
@@ -249,6 +256,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		connectionOptions: opts.DefaultConnectionOptions.withDefaults(),
 		relayHost:         opts.RelayHost,
 		relayMaxTimeout:   validateRelayMaxTimeout(opts.RelayMaxTimeout, logger),
+		relayTimerVerify:  opts.RelayTimerVerification,
 	}
 	ch.peers = newRootPeerList(ch, opts.OnPeerStatusChanged).newChild()
 

--- a/relay.go
+++ b/relay.go
@@ -202,7 +202,7 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 		conn:         conn,
 		logger:       conn.log,
 	}
-	r.timeouts = newRelayTimerPool(r.timeoutRelayItem)
+	r.timeouts = newRelayTimerPool(r.timeoutRelayItem, ch.relayTimerVerify)
 	return r
 }
 

--- a/relay/relaytest/func_host.go
+++ b/relay/relaytest/func_host.go
@@ -19,11 +19,12 @@ type hostFuncPeer struct {
 
 // HostFunc wraps a given function to implement tchannel.RelayHost.
 func HostFunc(fn func(relay.CallFrame, *tchannel.Connection) (string, error)) tchannel.RelayHost {
-	return &hostFunc{nil, NewMockStats(), fn}
+	return &hostFunc{fn: fn}
 }
 
 func (hf *hostFunc) SetChannel(ch *tchannel.Channel) {
 	hf.ch = ch
+	hf.stats = NewMockStats()
 }
 
 func (hf *hostFunc) Start(cf relay.CallFrame, conn *tchannel.Connection) (tchannel.RelayCall, error) {

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -79,7 +79,7 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 
 	for _, tt := range tests {
 		trigger := func(*relayItems, uint32, bool) {}
-		rtp := newRelayTimerPool(trigger, true /* verifyPool */)
+		rtp := newRelayTimerPool(trigger, true /* verify */)
 
 		rt := rtp.Get()
 		assert.Panics(t, func() {
@@ -90,7 +90,7 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 
 func TestRelayTimerStopConcurrently(t *testing.T) {
 	trigger := func(*relayItems, uint32, bool) {}
-	rtp := newRelayTimerPool(trigger, true /* verifyPool */)
+	rtp := newRelayTimerPool(trigger, true /* verify */)
 	timer := rtp.Get()
 	timer.Start(time.Nanosecond, nil, 0 /* items */, false /* isOriginator */)
 

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -75,6 +75,13 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 				rt.Start(time.Hour, &relayItems{}, 0, false /* isOriginator */)
 			},
 		},
+		{
+			msg: "use timer after releasing it",
+			f: func(rt *relayTimer) {
+				rt.Release()
+				rt.Stop()
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -79,7 +79,7 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 
 	for _, tt := range tests {
 		trigger := func(*relayItems, uint32, bool) {}
-		rtp := newRelayTimerPool(trigger)
+		rtp := newRelayTimerPool(trigger, true /* verifyPool */)
 
 		rt := rtp.Get()
 		assert.Panics(t, func() {
@@ -90,7 +90,7 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 
 func TestRelayTimerStopConcurrently(t *testing.T) {
 	trigger := func(*relayItems, uint32, bool) {}
-	rtp := newRelayTimerPool(trigger)
+	rtp := newRelayTimerPool(trigger, true /* verifyPool */)
 	timer := rtp.Get()
 	timer.Start(time.Nanosecond, nil, 0 /* items */, false /* isOriginator */)
 

--- a/relay_timer_pool.go
+++ b/relay_timer_pool.go
@@ -29,9 +29,9 @@ import (
 type relayTimerTrigger func(items *relayItems, id uint32, isOriginator bool)
 
 type relayTimerPool struct {
-	pool       sync.Pool
-	trigger    relayTimerTrigger
-	verifyPool bool
+	pool    sync.Pool
+	trigger relayTimerTrigger
+	verify  bool
 }
 
 type relayTimer struct {
@@ -52,10 +52,10 @@ func (rt *relayTimer) OnTimer() {
 	rt.pool.trigger(items, id, isOriginator)
 }
 
-func newRelayTimerPool(trigger relayTimerTrigger, verifyPool bool) *relayTimerPool {
+func newRelayTimerPool(trigger relayTimerTrigger, verify bool) *relayTimerPool {
 	return &relayTimerPool{
-		trigger:    trigger,
-		verifyPool: verifyPool,
+		trigger: trigger,
+		verify:  verify,
 	}
 }
 
@@ -83,7 +83,7 @@ func (tp *relayTimerPool) Get() *relayTimer {
 
 // Put returns a relayTimer back to the pool.
 func (tp *relayTimerPool) Put(rt *relayTimer) {
-	if tp.verifyPool {
+	if tp.verify {
 		// If we are trying to verify correct pool behavior, then we don't release
 		// the timer, and instead ensure no methods are called after being released.
 		return

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -119,6 +119,13 @@ func WithTestServer(t testing.TB, chanOpts *ChannelOpts, f func(*TestServer)) {
 		// Run with the relay, unless the user has disabled it.
 		if !chanOpts.DisableRelay {
 			withServer(t, chanOpts.Copy(), f)
+
+			// Re-run the same test with timer verification if this is a relay-only test.
+			if chanOpts.OnlyRelay {
+				verifyOpts := chanOpts.Copy()
+				verifyOpts.RelayTimerVerification = true
+				withServer(t, verifyOpts, f)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Ensure there are no use-after-free issues with the relay timer pool by
adding an option to disable pooling for extra verification.

For relay-only tests, run them twice, with and without the verification
to ensure that there are no issues.

Verified than an erroneous Release will cause issues:
```
=== RUN   TestRelayConcurrentNewConnectionAttempts
panic: Released timer cannot be used

goroutine 9332 [running]:
github.com/uber/tchannel-go.(*relayTimer).verifyNotReleased(0xc42046f230)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/relay_timer_pool.go:147 +0x50
github.com/uber/tchannel-go.(*relayTimer).Stop(0xc42046f230, 0xc420361ef0)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/relay_timer_pool.go:127 +0x2b
github.com/uber/tchannel-go.(*relayItems).Delete(0xc4200ac440, 0xc400000002, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/relay.go:120 +0x195
github.com/uber/tchannel-go.(*relayItems).Entomb.func1()
        /Users/prashant/gocode/src/github.com/uber/tchannel-go/relay.go:154 +0x31
```