### PR TITLE
context: If parent has deadline, and timeout is 0, use WithCancel

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -303,7 +303,6 @@ func TestContextInheritParentTimeout(t *testing.T) {
 	deadline, ok := ctx.Deadline()
 	require.True(t, ok, "Missing deadline")
 
-	if deadline.Before(deadlineAfter) {
-		t.Fatalf("Expected deadline to be after %v, got %v", deadlineAfter, deadline)
-	}
+	assert.False(t, deadline.Before(deadlineAfter),
+		"Expected deadline to be after %v, got %v", deadlineAfter, deadline)
 }


### PR DESCRIPTION
Currently, if no timeout is passed, we create a context with 0 timeout.
However, in cases where the parent has a timeout, we shouldn't force
users to specify another timeout.

Fixes #685.