### PR TITLE
introspection: Include channel state in output

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -55,7 +55,8 @@ type RuntimeVersion struct {
 
 // RuntimeState is a snapshot of the runtime state for a channel.
 type RuntimeState struct {
-	ID uint32 `json:"id"`
+	ID           uint32 `json:"id"`
+	ChannelState string `json:"channelState"`
 
 	// CreatedStack is the stack for how this channel was created.
 	CreatedStack string `json:"createdStack"`
@@ -209,6 +210,7 @@ func (ch *Channel) IntrospectState(opts *IntrospectionOptions) *RuntimeState {
 	}
 
 	ch.mutable.RLock()
+	state := ch.mutable.state
 	numConns := len(ch.mutable.conns)
 	inactiveConns := make([]*Connection, 0, numConns)
 	connIDs := make([]uint32, 0, numConns)
@@ -221,8 +223,10 @@ func (ch *Channel) IntrospectState(opts *IntrospectionOptions) *RuntimeState {
 
 	ch.mutable.RUnlock()
 
+	ch.State()
 	return &RuntimeState{
 		ID:                  ch.chID,
+		ChannelState:        state.String(),
 		CreatedStack:        ch.createdStack,
 		LocalPeer:           ch.PeerInfo(),
 		SubChannels:         ch.subChannels.IntrospectState(opts),

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -391,6 +391,9 @@ func comparableState(ch *tchannel.Channel, opts *tchannel.IntrospectionOptions) 
 	s := ch.IntrospectState(opts)
 	s.SubChannels = nil
 	s.Peers = nil
+
+	// Tests start with ChannelClient or ChannelListening, but end with ChannelClosed.
+	s.ChannelState = ""
 	return s
 }
 

--- a/verify_utils_test.go
+++ b/verify_utils_test.go
@@ -21,39 +21,12 @@
 package tchannel_test
 
 import (
-	"runtime"
 	"testing"
-	"time"
 
 	. "github.com/uber/tchannel-go"
 
 	"github.com/uber/tchannel-go/testutils"
 )
-
-func waitForChannelClose(t *testing.T, ch *Channel) bool {
-	// TODO: remove standalone use (outside testutils.TestServer).
-	started := time.Now()
-
-	var state ChannelState
-	for i := 0; i < 50; i++ {
-		if state = ch.State(); state == ChannelClosed {
-			return true
-		}
-
-		runtime.Gosched()
-		if i < 5 {
-			continue
-		}
-
-		sleepFor := time.Duration(i) * 100 * time.Microsecond
-		time.Sleep(testutils.Timeout(sleepFor))
-	}
-
-	// Channel is not closing, fail the test.
-	sinceStart := time.Since(started)
-	t.Errorf("Channel did not close after %v, last state: %v", sinceStart, state)
-	return false
-}
 
 // WithVerifiedServer runs the given test function with a server channel that is verified
 // at the end to make sure there are no leaks (e.g. no exchanges leaked).


### PR DESCRIPTION
We'll need to exclude channel state from the pre/post state verification
since the channel state is expected to change.

Remove an unused function, all verification is now part of testutils.