### PR TITLE
relay: Rename relay-conn-inactive to relay-client-conn-inactive

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -370,8 +370,9 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 		return nil
 	}
 
+	// Check that the current connection is in a valid state to handle a new call.
 	if canHandle, state := r.canHandleNewCall(); !canHandle {
-		call.Failed("relay-conn-inactive")
+		call.Failed("relay-client-conn-inactive")
 		call.End()
 		err := errConnNotActive{"incoming", state}
 		r.conn.SendSystemError(f.Header.ID, f.Span(), NewWrappedSystemError(ErrCodeDeclined, err))

--- a/relay_test.go
+++ b/relay_test.go
@@ -563,7 +563,7 @@ func TestRelayUsesRootPeers(t *testing.T) {
 }
 
 // Ensure that if the relay recieves a call on a connection that is not active,
-// it declines the call, and increments a relay-conn-inactive stat.
+// it declines the call, and increments a relay-client-conn-inactive stat.
 func TestRelayRejectsDuringClose(t *testing.T) {
 	opts := testutils.NewOpts().SetRelayOnly().
 		AddLogFilter("Failed to relay frame.", 1, "error", "incoming connection is not active: connectionStartClose")
@@ -600,7 +600,7 @@ func TestRelayRejectsDuringClose(t *testing.T) {
 			Succeeded().End()
 		calls.Add(client.PeerInfo().ServiceName, ts.ServiceName(), "echo").
 			// No peer is set since we rejected the call before selecting one.
-			Failed("relay-conn-inactive").End()
+			Failed("relay-client-conn-inactive").End()
 		ts.AssertRelayStats(calls)
 	})
 }


### PR DESCRIPTION
This error is emitted if the connection on which we receive a new call
is not in a valid state for a call (E.g., client connection is closing,
but it sends a new RPC).

Make this explicit by prefixing with "relay-client-" rather than
"relay-".