### PR TITLE
idle sweeper: Don't close connections with pending calls

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -766,6 +766,11 @@ func (c *Connection) closeSendCh(connID uint32) {
 	close(c.stopCh)
 }
 
+// hasExchanges returns whether there's any pending inbound or outbound calls on this connection.
+func (c *Connection) hasExchanges() bool {
+	return c.inbound.count() > 0 || c.outbound.count() > 0
+}
+
 // checkExchanges is called whenever an exchange is removed, and when Close is called.
 func (c *Connection) checkExchanges() {
 	c.callOnExchangeChange()

--- a/idle_sweep.go
+++ b/idle_sweep.go
@@ -107,6 +107,13 @@ func (is *idleSweep) checkIdleConnections() {
 			continue
 		}
 
+		// We shouldn't get to a state where we have pending calls, but the connection
+		// is idle. This either means the max-idle time is too low, or there's a stuck call.
+		if conn.hasExchanges() {
+			conn.log.Error("Skip closing idle Connection as it has pending calls.")
+			continue
+		}
+
 		is.ch.log.WithFields(
 			LogField{"remotePeer", conn.remotePeerInfo},
 			LogField{"lastActivityTime", conn.getLastActivityTime()},

--- a/idle_sweep_test.go
+++ b/idle_sweep_test.go
@@ -291,6 +291,7 @@ func TestIdleSweepIgnoresConnectionsWithCalls(t *testing.T) {
 	clock := testutils.NewStubClock(time.Now())
 
 	listener := newPeerStatusListener()
+	// TODO: Log filtering doesn't require the message to be seen.
 	serverOpts := testutils.NewOpts().
 		AddLogFilter("Skip closing idle Connection as it has pending calls.", 1).
 		SetOnPeerStatusChanged(listener.onStatusChange).


### PR DESCRIPTION
As documented in #701, we currently attempt closing connections even
if they have pending calls. This can cause issues if the calls is stuck
as the connection enters start-close, so it'll reject new incoming
calls, but it doesn't close, so the remote side keeps sending calls over
the same connection.

Fixes #701.