### PR TITLE
Support go1.10, and remove go1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,20 @@ cache:
   - $HOME/.glide/cache
 
 go:
-- 1.7
-- 1.8
-- 1.9
+- 1.8.x
+- 1.9.x
+- 1.10.x
 
 matrix:
   include:
-  - go: 1.9
+  - go: 1.10.x
     env: CROSSDOCK=true
     sudo: required
     dist: trusty
     services:
     - docker
   include:
-  - go: 1.9
+  - go: 1.10.x
     env: NO_TEST=yes COVERAGE=yes LINT=yes
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test: clean setup install_test check_no_test_deps $(BIN)/thrift
 	PATH=$(BIN):$$PATH go test -run TestFramesReleased -stressTest $(TEST_ARG)
 
 check_no_test_deps:
-	! go list -json $(PROD_PKGS) | jq -r .Deps[] | grep -e test -e mock
+	! go list -json $(PROD_PKGS) | jq -r '.Deps | select ((. | length) > 0) | .[]' | grep -e test -e mock | grep -v '^internal/testlog'
 
 benchmark: clean setup $(BIN)/thrift
 	echo Running benchmarks:


### PR DESCRIPTION
go1.10 now has an "internal/testlog" package that's used by production
packages, but it shouldn't count as a test-dependency, so ignore it.