### PR TITLE
relay: Ensure idle sweeper also considers relay calls

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -767,8 +767,15 @@ func (c *Connection) closeSendCh(connID uint32) {
 }
 
 // hasExchanges returns whether there's any pending inbound or outbound calls on this connection.
-func (c *Connection) hasExchanges() bool {
-	return c.inbound.count() > 0 || c.outbound.count() > 0
+func (c *Connection) hasPendingCalls() bool {
+	if c.inbound.count() > 0 || c.outbound.count() > 0 {
+		return true
+	}
+	if !c.relay.canClose() {
+		return true
+	}
+
+	return false
 }
 
 // checkExchanges is called whenever an exchange is removed, and when Close is called.

--- a/idle_sweep.go
+++ b/idle_sweep.go
@@ -109,7 +109,7 @@ func (is *idleSweep) checkIdleConnections() {
 
 		// We shouldn't get to a state where we have pending calls, but the connection
 		// is idle. This either means the max-idle time is too low, or there's a stuck call.
-		if conn.hasExchanges() {
+		if conn.hasPendingCalls() {
 			conn.log.Error("Skip closing idle Connection as it has pending calls.")
 			continue
 		}

--- a/idle_sweep_test.go
+++ b/idle_sweep_test.go
@@ -340,6 +340,7 @@ func TestIdleSweepIgnoresConnectionsWithCalls(t *testing.T) {
 				clientTicker.Tick()
 			},
 		}
+
 		if relay := ts.Relay(); relay != nil {
 			check.ch = relay
 			check.preCloseConns++


### PR DESCRIPTION
The previous fix for #701 avoids the idle sweeper from closing
connections with pending calls. However, it didn't take into account
relay calls (which do not set up exchanges). Ensure we take any pending
relay calls into account as well.

Fixes #701 for pending calls on relays as well as clients/servers.