### PR TITLE
Add a way to signal when a Channel has closed

### DIFF
--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -294,6 +294,9 @@ func (ts *TestServer) addChannel(createChannel func(t testing.TB, opts *ChannelO
 func (ts *TestServer) close(ch *tchannel.Channel) {
 	ch.Close()
 	ts.waitForChannelClose(ch)
+
+	_, ok := <-ch.ClosedChan()
+	assert.False(ts.TB, ok, "Channel's close channel should've closed")
 }
 
 func (ts *TestServer) verify(ch *tchannel.Channel) {


### PR DESCRIPTION
Channel has Close() and Closed() methods that tells a Channel to close
and returns whether the Channel is already closed, respectively.  This
adds a CloseChan() that returns a channel that will close once the
Channel has completed closing.