### PR TITLE
relay: Export TCP connection's RemoteAddr with calls

### DIFF
--- a/benchmark/real_relay.go
+++ b/benchmark/real_relay.go
@@ -36,7 +36,7 @@ type fixedHosts struct {
 	pickI atomic.Int32
 }
 
-func (fh *fixedHosts) Get(cf relay.CallFrame, _ *tchannel.Connection) (string, error) {
+func (fh *fixedHosts) Get(cf relay.CallFrame, _ *relay.Conn) (string, error) {
 	peers := fh.hosts[string(cf.Service())]
 	if len(peers) == 0 {
 		return "", errors.New("no peers")

--- a/relay.go
+++ b/relay.go
@@ -184,12 +184,11 @@ type Relayer struct {
 	// It allows timer re-use, while allowing timers to be created and started separately.
 	timeouts *relayTimerPool
 
-	peers      *RootPeerList
-	conn       *Connection
-	relayConn  *relay.Conn
-	remoteAddr string
-	logger     Logger
-	pending    atomic.Uint32
+	peers     *RootPeerList
+	conn      *Connection
+	relayConn *relay.Conn
+	logger    Logger
+	pending   atomic.Uint32
 }
 
 // NewRelayer constructs a Relayer.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -39,6 +39,15 @@ type CallFrame interface {
 	RoutingKey() []byte
 }
 
+// Conn contains information about the underlying connection.
+type Conn struct {
+	// RemoteAddr is the remote address of the underlying TCP connection.
+	RemoteAddr string
+
+	// RemoteProcessName is the process name sent in the TChannel handshake.
+	RemoteProcessName string
+}
+
 // RateLimitDropError is the error that should be returned from
 // RelayHosts.Get if the request should be dropped silently.
 // This is bit of a hack, because rate limiting of this nature isn't part of

--- a/relay/relaytest/func_host.go
+++ b/relay/relaytest/func_host.go
@@ -8,7 +8,7 @@ import (
 type hostFunc struct {
 	ch    *tchannel.Channel
 	stats *MockStats
-	fn    func(relay.CallFrame, *tchannel.Connection) (string, error)
+	fn    func(relay.CallFrame, *relay.Conn) (string, error)
 }
 
 type hostFuncPeer struct {
@@ -18,7 +18,7 @@ type hostFuncPeer struct {
 }
 
 // HostFunc wraps a given function to implement tchannel.RelayHost.
-func HostFunc(fn func(relay.CallFrame, *tchannel.Connection) (string, error)) tchannel.RelayHost {
+func HostFunc(fn func(relay.CallFrame, *relay.Conn) (string, error)) tchannel.RelayHost {
 	return &hostFunc{fn: fn}
 }
 
@@ -27,7 +27,7 @@ func (hf *hostFunc) SetChannel(ch *tchannel.Channel) {
 	hf.stats = NewMockStats()
 }
 
-func (hf *hostFunc) Start(cf relay.CallFrame, conn *tchannel.Connection) (tchannel.RelayCall, error) {
+func (hf *hostFunc) Start(cf relay.CallFrame, conn *relay.Conn) (tchannel.RelayCall, error) {
 	var peer *tchannel.Peer
 
 	peerHP, err := hf.fn(cf, conn)

--- a/relay/relaytest/stub_host.go
+++ b/relay/relaytest/stub_host.go
@@ -57,7 +57,7 @@ func (rh *StubRelayHost) SetChannel(ch *tchannel.Channel) {
 }
 
 // Start starts a new RelayCall for the given call on a specific connection.
-func (rh *StubRelayHost) Start(cf relay.CallFrame, _ *tchannel.Connection) (tchannel.RelayCall, error) {
+func (rh *StubRelayHost) Start(cf relay.CallFrame, _ *relay.Conn) (tchannel.RelayCall, error) {
 	// Get a peer from the subchannel.
 	peer, err := rh.ch.GetSubChannel(string(cf.Service())).Peers().Get(nil)
 	return &stubCall{rh.stats.Begin(cf), peer}, err

--- a/relay_api.go
+++ b/relay_api.go
@@ -32,7 +32,7 @@ type RelayHost interface {
 	// Start starts a new RelayCall given the call frame and connection.
 	// It may return a call and an error, in which case the caller will
 	// call Failed/End on the RelayCall.
-	Start(relay.CallFrame, *Connection) (RelayCall, error)
+	Start(relay.CallFrame, *relay.Conn) (RelayCall, error)
 }
 
 // RelayCall abstracts away peer selection, stats, and any other business


### PR DESCRIPTION
This will be used internally to track connections with what they are
calling.