### PR TITLE
relay: Add IsOutbound to relay.Conn

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -204,6 +204,7 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 		relayConn: &relay.Conn{
 			RemoteAddr:        conn.conn.RemoteAddr().String(),
 			RemoteProcessName: conn.RemotePeerInfo().ProcessName,
+			IsOutbound:        conn.connDirection == outbound,
 		},
 		logger: conn.log,
 	}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -46,6 +46,10 @@ type Conn struct {
 
 	// RemoteProcessName is the process name sent in the TChannel handshake.
 	RemoteProcessName string
+
+	// IsOutbound returns whether this connection is an outbound connection
+	// initiated via the relay.
+	IsOutbound bool
 }
 
 // RateLimitDropError is the error that should be returned from


### PR DESCRIPTION
The relay will typically receive calls on connections made from a
service to the relay (inbound connections as far as the relay is
concerned). However, the relay may make outbound connections and
receive calls on that connection (since TChannel is bi-direcitonal)
so add IsOutbound to identify when calls are received on outbound
connections created from the relay to the service.