### PR TITLE
Add MaxCloseTime as a graceful close timeout

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -67,7 +67,7 @@ type testHandler struct {
 }
 
 func newTestHandler(t testing.TB) *testHandler {
-	return &testHandler{t: t, blockErr: make(chan error)}
+	return &testHandler{t: t, blockErr: make(chan error, 1)}
 }
 
 func (h *testHandler) Handle(ctx context.Context, args *raw.Args) (*raw.Res, error) {


### PR DESCRIPTION
Currently, a connection waits until all calls are complete before
moving to the "closed" state. However, if there are stuck calls
(either because of long-running user calls, or because of issues
where calls are not tracked properly), the connection can remain
open forever and leak resources.

Add a MaxCloseTime which will close the connection after spending
a maximum amount of time in a close state.

Rather than add another close branch, reuse the existing connection
error branch (by using read deadlines).

We now also ensure checkExchanges will move the connection to the closed
state once exchanges are closed -- important since relay calls are not
forcefully shutdown in `closeNetwork`, so we wouldn't actually change
state previously.

Fixes #699