### PR TITLE
Simplify shutdown by removing sendCh ref tracking

### DIFF
--- a/inbound.go
+++ b/inbound.go
@@ -63,12 +63,6 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	call.conn = c
 	ctx, cancel := newIncomingContext(call, callReq.TimeToLive)
 
-	if !c.pendingExchangeMethodAdd() {
-		// Connection is closed, no need to do anything.
-		return true
-	}
-	defer c.pendingExchangeMethodDone()
-
 	mex, err := c.inbound.newExchange(ctx, c.opts.FramePool, callReq.messageType(), frame.Header.ID, mexChannelBufferSize)
 	if err != nil {
 		if err == errDuplicateMex {

--- a/outbound.go
+++ b/outbound.go
@@ -65,12 +65,6 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 		return nil, GetContextError(err)
 	}
 
-	if !c.pendingExchangeMethodAdd() {
-		// Connection is closed, no need to do anything.
-		return nil, ErrInvalidConnectionState
-	}
-	defer c.pendingExchangeMethodDone()
-
 	requestID := c.NextMessageID()
 	mex, err := c.outbound.newExchange(ctx, c.opts.FramePool, messageTypeCallReq, requestID, mexChannelBufferSize)
 	if err != nil {


### PR DESCRIPTION
Previously, the sendCh was closed, we had to carefully track all
references to it, as any send to a closed channel would panic.

However, this was finally removed in #388:
https://github.com/uber/tchannel-go/pull/388/commits/93ef5c112c8b321367ae52d2bd79396e2e874f31

As mentioned in the change, we can simplify the shutdown path
as we no longer need to track references to sendCh. Caller can
attempt writes to sendCh, but those frames will not be sent
as they race with the close.