### PR TITLE
Check max string length when using WriteLenXString

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -136,7 +136,9 @@ type TransportHeaderName string
 
 func (cn TransportHeaderName) String() string { return string(cn) }
 
-// Known transport header keys for call requests. See protocol docs for more information.
+// Known transport header keys for call requests.
+// Note: transport header names must be <= 16 bytes:
+// https://tchannel.readthedocs.io/en/latest/protocol/#transport-headers
 const (
 	// ArgScheme header specifies the format of the args.
 	ArgScheme TransportHeaderName = "as"

--- a/outbound.go
+++ b/outbound.go
@@ -83,6 +83,8 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 		return nil, ErrConnectionClosed
 	}
 
+	// Note: We don't verify number of transport headers as the library doesn't
+	// allow adding arbitrary headers. Ensure we never add >= 256 headers here.
 	headers := transportHeaders{
 		CallerName: c.localPeerInfo.ServiceName,
 	}

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -32,6 +32,10 @@ var (
 
 	// ErrBufferFull is returned when trying to write past end of buffer
 	ErrBufferFull = errors.New("no more room in buffer")
+
+	// errStringTooLong is returned when writing a string with length larger
+	// than the allows length limit.
+	errStringTooLong = errors.New("string is too long")
 )
 
 // A ReadBuffer is a wrapper around an underlying []byte with methods to read from
@@ -196,7 +200,7 @@ func (w *WriteBuffer) WriteSingleByte(n byte) {
 	}
 
 	if len(w.remaining) == 0 {
-		w.err = ErrBufferFull
+		w.setErr(ErrBufferFull)
 		return
 	}
 
@@ -253,12 +257,20 @@ func (w *WriteBuffer) WriteString(s string) {
 
 // WriteLen8String writes an 8-bit length preceded string
 func (w *WriteBuffer) WriteLen8String(s string) {
+	if int(byte(len(s))) != len(s) {
+		w.setErr(errStringTooLong)
+	}
+
 	w.WriteSingleByte(byte(len(s)))
 	w.WriteString(s)
 }
 
 // WriteLen16String writes a 16-bit length preceded string
 func (w *WriteBuffer) WriteLen16String(s string) {
+	if int(uint16(len(s))) != len(s) {
+		w.setErr(errStringTooLong)
+	}
+
 	w.WriteUint16(uint16(len(s)))
 	w.WriteString(s)
 }
@@ -267,7 +279,7 @@ func (w *WriteBuffer) WriteLen16String(s string) {
 // reference that can be used to update that byte later
 func (w *WriteBuffer) DeferByte() ByteRef {
 	if len(w.remaining) == 0 {
-		w.err = ErrBufferFull
+		w.setErr(ErrBufferFull)
 		return ByteRef(nil)
 	}
 
@@ -316,7 +328,7 @@ func (w *WriteBuffer) reserve(n int) []byte {
 	}
 
 	if len(w.remaining) < n {
-		w.err = ErrBufferFull
+		w.setErr(ErrBufferFull)
 		return nil
 	}
 
@@ -343,6 +355,15 @@ func (w *WriteBuffer) BytesWritten() int { return len(w.buffer) - len(w.remainin
 func (w *WriteBuffer) Reset() {
 	w.remaining = w.buffer
 	w.err = nil
+}
+
+func (w *WriteBuffer) setErr(err error) {
+	// Only store the first error
+	if w.err != nil {
+		return
+	}
+
+	w.err = err
 }
 
 // Err returns the current error in the buffer

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -34,7 +34,8 @@ var (
 	ErrBufferFull = errors.New("no more room in buffer")
 
 	// errStringTooLong is returned when writing a string with length larger
-	// than the allows length limit.
+	// than the allows length limit. Intentionally not exported, in case we
+	// want to add more context in future.
 	errStringTooLong = errors.New("string is too long")
 )
 


### PR DESCRIPTION
Previously, if a long string was passed in, we would overflow the length
and write the full string which resulted in a corrupted packet. Instead,
return an error if the passed in string is too long for the specified
max length (defined by size of the prefix).

Plumbing context for the error message would require significant plumbing
and may affect performance, so left it as a generic error.