### PR TITLE
relay: Fix stuck calls when client TCP buffer is full

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -252,10 +252,6 @@ func (r *Relayer) Receive(f *Frame, fType frameType) (sent bool, failureReason s
 		// TODO: metrics for late-arriving frames.
 		return true, ""
 	}
-	if finished && !item.timeout.Stop() {
-		// Timeout is firing, so no point proxying this frame
-		return true, ""
-	}
 
 	// call res frames don't include the OK bit, so we can't wait until the last
 	// frame of a relayed RPC to determine if the call succeeded.
@@ -444,10 +440,6 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	if item.tomb {
 		// Call timed out, ignore this frame. (We've already handled stats.)
 		// TODO: metrics for late-arriving frames.
-		return nil
-	}
-	if finished && !item.timeout.Stop() {
-		// Timeout is firing, so no point proxying this frame
 		return nil
 	}
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -786,7 +786,6 @@ func TestRelayStalledClientConnection(t *testing.T) {
 		// Expect errors from dropped frames.
 		AddLogFilter("Dropping call due to slow connection to destination.", _calls).
 		AddLogFilter("Couldn't send outbound frame.", _calls).
-		// DisableLogVerification(). // we expect warnings due to removed relay item.
 		SetSendBufferSize(10). // We want to hit the buffer size earlier.
 		SetServiceName("s1").
 		SetRelayOnly()

--- a/relay_test.go
+++ b/relay_test.go
@@ -817,7 +817,11 @@ func TestRelayStalledClientConnection(t *testing.T) {
 
 		var calls []*OutboundCall
 
-		// Data to fit one frame fully, large enough to fill TCP buffers.
+		// Data to fit one frame fully, but large enough that a number of these frames will fill
+		// all the buffers and cause the relay to drop the response frame. Buffers are:
+		// 1. Relay's sendCh on the connection to the client (set to 10 frames explicitly)
+		// 2. Relay's TCP send buffer for the connection to the client.
+		// 3. Client's TCP receive buffer on the connection to the relay.
 		data := bytes.Repeat([]byte("test"), 256*60)
 		for i := 0; i < _calls; i++ {
 			call, err := client.BeginCall(ctx, blockerHostPort, ts.ServiceName(), "echo", nil)


### PR DESCRIPTION
See #700 for the cause of the bug. The summary:
 * When a frame finishes the relay item, we explicitly stop the timeout
 * If the frame fails to send, failRelayItem is called
 * failRelayItem returns early (without cleaning up) if it can't stop
 the timeout

The double-stop of the timeout caused the call to not be cleaned up. The
fix is simple: avoid stopping the timeout initially. The code already
handles the timeout firing right as we do the check, so there's no
advantage in checking. It's stopped a few lines later (after we write
the frame to the sendCh).

Added a test to reproduce client buffer filling up, which fails in a few
ways without the fix:
 * Not all calls are marked as "Ended"
 * Leftover pending calls
 * Channels fail to close.

Fixes #700.