### PR TITLE
testutils: Verify "pending" calls before connection close

### DIFF
--- a/deps_test.go
+++ b/deps_test.go
@@ -28,16 +28,12 @@
 package tchannel_test
 
 import (
-	"fmt"
 	"testing"
 
 	jcg "github.com/uber/jaeger-client-go"
-	// why is this not automatically included from jaeger-client-go?
-	// _ "github.com/uber/jaeger-lib/metrics"
 )
 
 func TestJaegerDeps(t *testing.T) {
 	m := jcg.Metrics{}
 	_ = m.SamplerUpdateFailure
-	fmt.Println("m", m)
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -251,10 +251,10 @@ func TestStreamCancelled(t *testing.T) {
 		defer cancel()
 
 		helper := streamHelper{t}
-		ch := ts.NewClient(nil)
+		client := ts.NewClient(nil)
 		cancelContext := make(chan struct{})
 
-		arg3Writer, arg3Reader := helper.startCall(ctx, ch, ts.HostPort(), ts.ServiceName())
+		arg3Writer, arg3Reader := helper.startCall(ctx, client, ts.HostPort(), ts.ServiceName())
 		go func() {
 			for i := 0; i < 10; i++ {
 				assert.NoError(t, writeFlushBytes(arg3Writer, []byte{1}), "Write failed")
@@ -284,6 +284,10 @@ func TestStreamCancelled(t *testing.T) {
 		assert.EqualValues(t, 0, n, "Read should not read any bytes after cancel")
 		assert.Error(t, err, "Read should fail after cancel")
 		assert.Error(t, arg3Reader.Close(), "reader.Close should fail after cancel")
+
+		// Close the client to clear out the pending exchange. Otherwise the test
+		// waits for the timeout, causing a slowdown.
+		client.Close()
 	})
 }
 

--- a/testutils/channel.go
+++ b/testutils/channel.go
@@ -21,6 +21,7 @@
 package testutils
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 
@@ -95,4 +96,15 @@ func RegisterFunc(ch tchannel.Registrar, name string,
 	f func(ctx context.Context, args *raw.Args) (*raw.Res, error)) {
 
 	ch.Register(raw.Wrap(rawFuncHandler{ch, f}), name)
+}
+
+// IntrospectJSON returns the introspected state of the channel as a JSON string.
+func IntrospectJSON(ch *tchannel.Channel, opts *tchannel.IntrospectionOptions) string {
+	state := ch.IntrospectState(opts)
+	marshalled, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("failed to marshal introspected state: %v", err)
+	}
+
+	return string(marshalled)
 }


### PR DESCRIPTION
Currently, we verify that there's no pending calls after closing
a channel, but we should have no pending calls before we start closing.

If we have a bug where A is connected to B, A thinks there are pending
calls, but B closes first, then the connection with pending calls will
be lost, and the tests will pass.

To avoid this, verify all pending calls on all channels before we start
closing any channels.

Some tests end with background goroutines wrapping up (e.g., timed out
call returned, but background goroutine is still processing it). Tests
cannot always wait for these background operations to finish, so retry
a few times if the channel is not free of pending calls.

In doing this cleanup, we also:
 * Add a separate method for getting the introspection output as JSON.
   This is very useful when debugging.
 * Only check if the test has failed once in the `verify` method rather
   than per-verification.