### PR TITLE
Pass in testing.TB to WithTestServer test function

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -51,7 +51,7 @@ func makeCall(client *Channel, server *testutils.TestServer) error {
 	return err
 }
 
-func assertStateChangesTo(t *testing.T, ch *Channel, state ChannelState) {
+func assertStateChangesTo(t testing.TB, ch *Channel, state ChannelState) {
 	var lastState ChannelState
 	require.True(t, testutils.WaitFor(time.Second, func() bool {
 		lastState = ch.State()
@@ -89,7 +89,7 @@ func TestCloseAfterTimeout(t *testing.T) {
 	// and the relay might still be reading/writing to the connection.
 	// TODO: Ideally, we only disable log verification on the relay.
 	opts := testutils.NewOpts().DisableLogVerification()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		testHandler := newTestHandler(t)
 		ts.Register(ignoreError(testHandler), "block")
 
@@ -114,7 +114,7 @@ func TestRelayCloseTimeout(t *testing.T) {
 		DisableLogVerification() // we're causing errors on purpose.
 	opts.DefaultConnectionOptions.MaxCloseTime = 100 * time.Millisecond
 
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		gotCall := make(chan struct{})
 		unblock := make(chan struct{})
 		defer close(unblock)
@@ -152,7 +152,7 @@ func TestRaceExchangesWithClose(t *testing.T) {
 	defer cancel()
 
 	opts := testutils.NewOpts().DisableLogVerification()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		server := ts.Server()
 
 		gotCall := make(chan struct{})
@@ -230,7 +230,7 @@ func TestCloseStress(t *testing.T) {
 	for i := 0; i < numHandlers; i++ {
 		wg.Add(1)
 		go func() {
-			testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+			testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 				ts.Register(raw.Wrap(handler), "test")
 
 				chState := &channelState{

--- a/conn_leak_test.go
+++ b/conn_leak_test.go
@@ -68,7 +68,7 @@ func TestPeerConnectionLeaks(t *testing.T) {
 		})
 	}
 
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		s2Opts := testutils.NewOpts().SetServiceName("s2")
 		s2Opts.Logger = NewLogger(ioutil.Discard)
 		s2 := ts.NewServer(s2Opts)

--- a/frame_pool_test.go
+++ b/frame_pool_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 type swapper struct {
-	t *testing.T
+	t testing.TB
 }
 
 func (s *swapper) OnError(ctx context.Context, err error) {
@@ -58,7 +58,7 @@ func (*swapper) Handle(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 	}, nil
 }
 
-func doPingAndCall(t *testing.T, clientCh *Channel, hostPort string) {
+func doPingAndCall(t testing.TB, clientCh *Channel, hostPort string) {
 	ctx, cancel := NewContext(time.Second * 5)
 	defer cancel()
 
@@ -82,7 +82,7 @@ func doPingAndCall(t *testing.T, clientCh *Channel, hostPort string) {
 	}
 }
 
-func doErrorCall(t *testing.T, clientCh *Channel, hostPort string) {
+func doErrorCall(t testing.TB, clientCh *Channel, hostPort string) {
 	ctx, cancel := NewContext(time.Second * 5)
 	defer cancel()
 
@@ -106,7 +106,7 @@ func TestFramesReleased(t *testing.T) {
 		SetFramePool(pool).
 		AddLogFilter("Couldn't find handler.", 2*numGoroutines*requestsPerGoroutine)
 
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		ts.Register(raw.Wrap(&swapper{t}), "swap")
 
 		clientOpts := testutils.NewOpts().SetFramePool(pool)
@@ -163,7 +163,7 @@ func TestDirtyFrameRequests(t *testing.T) {
 		SetServiceName("swap-server").
 		SetFramePool(dirtyFramePool{})
 
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		ts.Register(raw.Wrap(&swapper{t}), "swap")
 
 		for _, argSize := range argSizes {

--- a/health_ext_test.go
+++ b/health_ext_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestHealthCheckStopBeforeStart(t *testing.T) {
 	opts := testutils.NewOpts().NoRelay()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 
 		var pingCount int
 		frameRelay, cancel := testutils.FrameRelay(t, ts.HostPort(), func(outgoing bool, f *Frame) *Frame {
@@ -70,7 +70,7 @@ func TestHealthCheckStopBeforeStart(t *testing.T) {
 
 func TestHealthCheckStopNoError(t *testing.T) {
 	opts := testutils.NewOpts().NoRelay()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 
 		var pingCount int
 		frameRelay, cancel := testutils.FrameRelay(t, ts.HostPort(), func(outgoing bool, f *Frame) *Frame {
@@ -159,7 +159,7 @@ func TestHealthCheckIntegration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
 			opts := testutils.NewOpts().NoRelay()
-			testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+			testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 				var pingCount int
 				frameRelay, cancel := testutils.FrameRelay(t, ts.HostPort(), func(outgoing bool, f *Frame) *Frame {
 					if strings.Contains(f.Header.String(), "PingRes") {
@@ -206,7 +206,7 @@ func TestHealthCheckIntegration(t *testing.T) {
 	}
 }
 
-func waitForNHealthChecks(t *testing.T, conn *Connection, n int) {
+func waitForNHealthChecks(t testing.TB, conn *Connection, n int) {
 	require.True(t, testutils.WaitFor(time.Second, func() bool {
 		return len(introspectConn(conn).HealthChecks) >= n
 	}), "Failed while waiting for %v health checks", n)

--- a/idle_sweep_test.go
+++ b/idle_sweep_test.go
@@ -51,7 +51,7 @@ func (pl *peerStatusListener) onStatusChange(p *Peer) {
 	pl.changes <- struct{}{}
 }
 
-func (pl *peerStatusListener) waitForZeroConnections(t *testing.T, channels ...*Channel) bool {
+func (pl *peerStatusListener) waitForZeroConnections(t testing.TB, channels ...*Channel) bool {
 	for {
 		select {
 		case <-pl.changes:
@@ -117,7 +117,7 @@ func TestServerBasedSweep(t *testing.T) {
 	clientOpts := testutils.NewOpts().
 		SetOnPeerStatusChanged(listener.onStatusChange)
 
-	testutils.WithTestServer(t, serverOpts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, serverOpts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 
 		client := ts.NewClient(clientOpts)
@@ -160,7 +160,7 @@ func TestClientBasedSweep(t *testing.T) {
 		SetOnPeerStatusChanged(listener.onStatusChange).
 		SetIdleCheckInterval(30 * time.Second)
 
-	testutils.WithTestServer(t, serverOpts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, serverOpts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 
 		client := ts.NewClient(clientOpts)
@@ -201,7 +201,7 @@ func TestRelayBasedSweep(t *testing.T) {
 		SetOnPeerStatusChanged(listener.onStatusChange).
 		SetRelayOnly()
 
-	testutils.WithTestServer(t, relayOpts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, relayOpts, func(t testing.TB, ts *testutils.TestServer) {
 		// Replace the auto-created server with a new one that doesn't have
 		// an idle-connection poller.
 		ts.Relay().GetSubChannel(ts.ServiceName()).Peers().Remove(
@@ -248,7 +248,7 @@ func TestIdleSweepWithPings(t *testing.T) {
 		SetIdleCheckInterval(30 * time.Second).
 		SetOnPeerStatusChanged(listener.onStatusChange)
 
-	testutils.WithTestServer(t, serverOpts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, serverOpts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 
 		client := ts.NewClient(clientOpts)
@@ -301,7 +301,7 @@ func TestIdleSweepIgnoresConnectionsWithCalls(t *testing.T) {
 		SetMaxIdleTime(3 * time.Minute).
 		SetIdleCheckInterval(30 * time.Second)
 
-	testutils.WithTestServer(t, serverOpts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, serverOpts, func(t testing.TB, ts *testutils.TestServer) {
 		var (
 			gotCall = make(chan struct{})
 			block   = make(chan struct{})

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -92,7 +92,7 @@ func TestInboundConnection(t *testing.T) {
 
 	// Disable relay since relays hide host:port on outbound calls.
 	opts := testutils.NewOpts().NoRelay()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		s2 := ts.NewServer(nil)
 
 		ts.RegisterFunc("test", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
@@ -110,7 +110,7 @@ func TestInboundConnection_CallOptions(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	testutils.WithTestServer(t, nil, func(server *testutils.TestServer) {
+	testutils.WithTestServer(t, nil, func(t testing.TB, server *testutils.TestServer) {
 		server.RegisterFunc("test", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 			assert.Equal(t, "client", CurrentCall(ctx).CallerName(), "Expected caller name to be passed through")
 			return &raw.Res{}, nil
@@ -146,7 +146,7 @@ func TestInboundConnection_CallOptions(t *testing.T) {
 func TestBlackhole(t *testing.T) {
 	ctx, cancel := NewContext(testutils.Timeout(time.Hour))
 
-	testutils.WithTestServer(t, nil, func(server *testutils.TestServer) {
+	testutils.WithTestServer(t, nil, func(t testing.TB, server *testutils.TestServer) {
 		serviceName := server.ServiceName()
 		handlerName := "test-handler"
 

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -35,7 +35,7 @@ import (
 // Purpose of this test is to ensure introspection doesn't cause any panics
 // and we have coverage of the introspection code.
 func TestIntrospection(t *testing.T) {
-	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 		client := testutils.NewClient(t, nil)
 		defer client.Close()
 
@@ -72,7 +72,7 @@ func TestIntrospectClosedConn(t *testing.T) {
 	// Disable the relay, since the relay does not maintain a 1:1 mapping betewen
 	// incoming connections vs outgoing connections.
 	opts := testutils.NewOpts().NoRelay()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		blockEcho := make(chan struct{})
 		gotEcho := make(chan struct{})
 		testutils.RegisterEcho(ts.Server(), func() {

--- a/peer_test.go
+++ b/peer_test.go
@@ -1074,7 +1074,7 @@ func TestPeerScoreOnNewConnection(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+		testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 			ctx, cancel := NewContext(time.Second)
 			defer cancel()
 
@@ -1104,7 +1104,7 @@ func TestPeerScoreOnNewConnection(t *testing.T) {
 }
 
 func TestConnectToPeerHostPortMismatch(t *testing.T) {
-	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 		ctx, cancel := NewContext(time.Second)
 		defer cancel()
 
@@ -1128,7 +1128,7 @@ func TestConnectToPeerHostPortMismatch(t *testing.T) {
 func TestPeerConnectionsClosing(t *testing.T) {
 	// Disable the relay since we check the host:port directly.
 	opts := testutils.NewOpts().NoRelay()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		unblock := make(chan struct{})
 		gotCall := make(chan struct{})
 		testutils.RegisterEcho(ts.Server(), func() {

--- a/retry_request_test.go
+++ b/retry_request_test.go
@@ -37,7 +37,7 @@ func TestRequestStateRetry(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 		ts.Register(raw.Wrap(newTestHandler(t)), "echo")
 
 		closedHostPorts := make([]string, 4)

--- a/stream_test.go
+++ b/stream_test.go
@@ -59,7 +59,7 @@ func writeFlushBytes(w ArgWriter, bs []byte) error {
 }
 
 type streamHelper struct {
-	t *testing.T
+	t testing.TB
 }
 
 // startCall starts a call to echoStream and returns the arg3 reader and writer.
@@ -90,7 +90,7 @@ func (h streamHelper) startCall(ctx context.Context, ch *Channel, hostPort, serv
 // streamPartialHandler returns a streaming handler that has the following contract:
 // read a byte, write N bytes where N = the byte that was read.
 // The results are be written as soon as the byte is read.
-func streamPartialHandler(t *testing.T, reportErrors bool) HandlerFunc {
+func streamPartialHandler(t testing.TB, reportErrors bool) HandlerFunc {
 	return func(ctx context.Context, call *InboundCall) {
 		response := call.Response()
 		onError := func(err error) {
@@ -244,7 +244,7 @@ func TestStreamCancelled(t *testing.T) {
 	// Since the cancel message is unimplemented, the relay does not know that the
 	// call was cancelled, andwill block closing till the timeout.
 	opts := testutils.NewOpts().NoRelay()
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		ts.Register(streamPartialHandler(t, false /* report errors */), "echoStream")
 
 		ctx, cancel := NewContext(testutils.Timeout(time.Second))
@@ -288,7 +288,7 @@ func TestStreamCancelled(t *testing.T) {
 }
 
 func TestResponseClosedBeforeRequest(t *testing.T) {
-	testutils.WithTestServer(t, nil, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 		ts.Register(streamPartialHandler(t, false /* report errors */), "echoStream")
 
 		ctx, cancel := NewContext(testutils.Timeout(time.Second))

--- a/subchannel_test.go
+++ b/subchannel_test.go
@@ -256,7 +256,7 @@ func TestGetSubchannelOptionsOnNew(t *testing.T) {
 func TestHandlerWithoutSubChannel(t *testing.T) {
 	opts := testutils.NewOpts().NoRelay()
 	opts.Handler = raw.Wrap(newTestHandler(t))
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		client := ts.NewClient(nil)
 		testutils.AssertEcho(t, client, ts.HostPort(), ts.ServiceName())
 		testutils.AssertEcho(t, client, ts.HostPort(), "larry")

--- a/testutils/relay.go
+++ b/testutils/relay.go
@@ -36,7 +36,7 @@ import (
 type frameRelay struct {
 	sync.Mutex // protects conns
 
-	t           *testing.T
+	t           testing.TB
 	destination string
 	relayFunc   func(outgoing bool, f *tchannel.Frame) *tchannel.Frame
 	closed      atomic.Uint32
@@ -134,7 +134,7 @@ func (r *frameRelay) relayBetween(outgoing bool, c net.Conn, outC net.Conn) {
 }
 
 // FrameRelay sets up a relay that can modify frames using relayFunc.
-func FrameRelay(t *testing.T, destination string, relayFunc func(outgoing bool, f *tchannel.Frame) *tchannel.Frame) (listenHostPort string, cancel func()) {
+func FrameRelay(t testing.TB, destination string, relayFunc func(outgoing bool, f *tchannel.Frame) *tchannel.Frame) (listenHostPort string, cancel func()) {
 	relay := &frameRelay{
 		t:           t,
 		destination: destination,

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -113,7 +113,7 @@ func runSubTest(t testing.TB, name string, f func(testing.TB)) {
 
 // WithTestServer creates a new TestServer, runs the passed function, and then
 // verifies that no resources were leaked.
-func WithTestServer(t testing.TB, chanOpts *ChannelOpts, f func(*TestServer)) {
+func WithTestServer(t testing.TB, chanOpts *ChannelOpts, f func(testing.TB, *TestServer)) {
 	chanOpts = chanOpts.Copy()
 	runCount := chanOpts.RunCount
 	if runCount < 1 {
@@ -447,13 +447,13 @@ func describeLeakedExchangesSingleConn(cs *tchannel.ConnectionRuntimeState) stri
 	return fmt.Sprintf("Connection %d has leftover exchanges:\n\t%v", cs.ID, strings.Join(exchanges, "\n\t"))
 }
 
-func withServer(t testing.TB, chanOpts *ChannelOpts, f func(*TestServer)) {
+func withServer(t testing.TB, chanOpts *ChannelOpts, f func(testing.TB, *TestServer)) {
 	ts := NewTestServer(t, chanOpts)
 	// Note: We use defer, as we want the postFns to run even if the test
 	// goroutine exits (e.g. user calls t.Fatalf).
 	defer ts.post()
 
-	f(ts)
+	f(t, ts)
 	ts.Server().Logger().Debugf("TEST: Test function complete")
 	ts.CloseAndVerify()
 }

--- a/verify_utils_test.go
+++ b/verify_utils_test.go
@@ -31,7 +31,7 @@ import (
 // WithVerifiedServer runs the given test function with a server channel that is verified
 // at the end to make sure there are no leaks (e.g. no exchanges leaked).
 func WithVerifiedServer(t *testing.T, opts *testutils.ChannelOpts, f func(serverCh *Channel, hostPort string)) {
-	testutils.WithTestServer(t, opts, func(ts *testutils.TestServer) {
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		f(ts.Server(), ts.HostPort())
 	})
 }


### PR DESCRIPTION
WithTestServer runs the same test multiple times with different
configurations (e.g., no relay, relay, relay with timer verification,
etc)

Each variation is run with `t.Run`, but we don't pass in the
sub-test's testing.T in to the test function itself, which causes
problems if we use `t.Fatalf` with the parent `*testing.T`:

```
testing.go:820: test executed panic(nil) or runtime.Goexit:
subtest may have called FailNow on a parent test
```
https://play.golang.org/p/JWEgMmUum4r

To avoid these useless errors, we should pass the sub-test's
*testing.T to the test function and use that.