### PR TITLE
Fix flaky TestRaceExchangesWithClose, TestRelayBasedSweep

### DIFF
--- a/idle_sweep_test.go
+++ b/idle_sweep_test.go
@@ -59,7 +59,7 @@ func (pl *peerStatusListener) waitForZeroConnections(t testing.TB, channels ...*
 				return true
 			}
 
-		case <-time.After(testutils.Timeout(500 * time.Millisecond)):
+		case <-time.After(testutils.Timeout(time.Second)):
 			t.Fatalf("Some connections are still open: %s", connectionStatus(channels))
 			return false
 		}


### PR DESCRIPTION
 * TestRaceExchangesWithClose failed because the channel did not close
   within the timeout, but the logs showed that the channel did close
   soon after. Bump up the timeout to a second for the close, since
   there are ~100 connections to close/clean-up after, which can take
   a while on Travis.
 * TestRelayBasedSweep was failing similarly due to not waiting long
   enough for all connections to be closed. Use time.Second to be
   consistent with above channel close timeout.

Minor cleanup: Use IntrospectJSON to dump introspection output.