### PR TITLE
relay: Fix timer release before it has stopped/completed

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -383,14 +383,14 @@ func (r *Relayer) IntrospectState(opts *IntrospectionOptions) RelayerRuntimeStat
 
 // IntrospectState returns the runtime state for this relayItems.
 func (ri *relayItems) IntrospectState(opts *IntrospectionOptions, name string) RelayItemSetState {
-	ri.RLock()
-	defer ri.RUnlock()
-
 	setState := RelayItemSetState{
 		Name:  name,
 		Count: ri.Count(),
 	}
 	if opts.IncludeExchanges {
+		ri.RLock()
+		defer ri.RUnlock()
+
 		setState.Items = make(map[string]RelayItemState, len(ri.items))
 		for k, v := range ri.items {
 			if !opts.IncludeTombstones && v.tomb {

--- a/relay_internal_test.go
+++ b/relay_internal_test.go
@@ -1,7 +1,6 @@
 package tchannel
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -93,22 +92,4 @@ func TestRelayTimerPoolMisuse(t *testing.T) {
 			tt.f(rt)
 		}, tt.msg)
 	}
-}
-
-func TestRelayTimerStopConcurrently(t *testing.T) {
-	trigger := func(*relayItems, uint32, bool) {}
-	rtp := newRelayTimerPool(trigger, true /* verify */)
-	timer := rtp.Get()
-	timer.Start(time.Nanosecond, nil, 0 /* items */, false /* isOriginator */)
-
-	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			timer.Stop()
-		}()
-	}
-
-	wg.Wait()
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -974,7 +974,6 @@ func TestRelayRaceCompletionAndTimeout(t *testing.T) {
 
 	opts := testutils.NewOpts().
 		AddLogFilter("simpleHandler OnError.", numCalls).
-		// DisableLogVerification().
 		SetRelayOnly()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)

--- a/relay_test.go
+++ b/relay_test.go
@@ -968,3 +968,37 @@ func TestRelayRaceTimerCausesStuckConnectionOnClose(t *testing.T) {
 		wg.Wait()
 	})
 }
+
+func TestRelayRaceCompletionAndTimeout(t *testing.T) {
+	const numCalls = 10
+
+	opts := testutils.NewOpts().
+		AddLogFilter("simpleHandler OnError.", numCalls).
+		// DisableLogVerification().
+		SetRelayOnly()
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
+		testutils.RegisterEcho(ts.Server(), nil)
+
+		client := ts.NewClient(nil)
+		started := time.Now()
+		testutils.AssertEcho(t, client, ts.HostPort(), ts.ServiceName())
+		callTime := time.Since(started)
+
+		// Make many calls with the same timeout, with the goal of
+		// timing out right as we process the response frame.
+		var wg sync.WaitGroup
+		for i := 0; i < numCalls; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				ctx, cancel := NewContext(callTime)
+				raw.Call(ctx, client, ts.HostPort(), ts.ServiceName(), "echo", nil, nil)
+				cancel()
+			}()
+		}
+
+		// Some of those calls should triger the race.
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
The added test causes a race between the respones frame completing
the call, and the timeout firing causing the call to fail in the
background timer goroutine. It fails with:

```
panic: only stopped or completed timers can be released

code.uber.internal/rpc/muttley/vendor/github.com/uber/tchannel-go.(*relayTimer).Release(0xc0095953b0)
        root/github.com/uber/tchannel-go/relay_timer_pool.go:140 +0x83
code.uber.internal/rpc/muttley/vendor/github.com/uber/tchannel-go.(*relayItems).Delete(0xc00c0381c0, 0xc00000012f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        root/github.com/uber/tchannel-go/relay.go:128 +0x1c0
code.uber.internal/rpc/muttley/vendor/github.com/uber/tchannel-go.(*Relayer).finishRelayItem(0xc007aa16c0, 0xc00c0381c0, 0x12f)
        root/github.com/uber/tchannel-go/relay.go:543 +0x4b
code.uber.internal/rpc/muttley/vendor/github.com/uber/tchannel-go.(*Relayer).Receive(0xc007aa16c0, 0xc0103c41e0, 0x1, 0x0, 0x0, 0xc007aa16c0)
        root/github.com/uber/tchannel-go/relay.go:295 +0x194
code.uber.internal/rpc/muttley/vendor/github.com/uber/tchannel-go.(*Relayer).handleNonCallReq(0xc00769a310, 0xc0103c41e0, 0x3f, 0x0)
        root/github.com/uber/tchannel-go/relay.go:463 +0x132
```

This is caused by the fix in #731, which avoided stopping the timer, but
this led to timers possibly firing as we called `Delete` which releases
the timeout.

Partially revert the fix in #731, and instead go with a different
approach: modify the return from `timeout.Stop` to indicate whether the
timer was stopped either by this call or previous calls to `Stop`. This
allows us to call `timeout.Stop` multiple times and get the same result.

We only need to detect whether the timeout has fired vs stopped explicitly.

It makes `timeout.Stop` not safe for concurrent use, but it's never used
concurrently.

We should never stop a timeout without checking the result -- that
usually indicates a bug (e.g., as we had in `Delete`). The `Stop` in
`Delete` was not needed, as the timeout is either stopped by finishing
the call, by `failRelayItem` or by `Entomb`. the `Release` verifies that
the timeout has been stopped.

Fix a minor bug in introspection which grabs the relay items `RLock`
before calling `Count` which itself can call `RLock`.