### PR TITLE
Expose `CallOptions` caller name for transparent proxying

### DIFF
--- a/calloptions.go
+++ b/calloptions.go
@@ -56,9 +56,10 @@ type CallOptions struct {
 	// to an instance of the intended service.
 	RoutingDelegate string
 
-	// callerName can only be used when forwarding a request. It can only be set internally,
-	// e.g. by calling (*InboundCall).CallOptions() when forwarding a request
-	callerName string
+	// CallerName is the name of the service issuing the call. It can also be used
+	// to support transparent proxying when the inbound caller name varies across
+	// calls.
+	CallerName string
 }
 
 var defaultCallOptions = &CallOptions{}
@@ -82,8 +83,8 @@ func (c *CallOptions) overrideHeaders(headers transportHeaders) {
 	if c.RoutingDelegate != "" {
 		headers[RoutingDelegate] = c.RoutingDelegate
 	}
-	if c.callerName != "" {
-		headers[CallerName] = c.callerName
+	if c.CallerName != "" {
+		headers[CallerName] = c.CallerName
 	}
 }
 

--- a/calloptions.go
+++ b/calloptions.go
@@ -56,9 +56,9 @@ type CallOptions struct {
 	// to an instance of the intended service.
 	RoutingDelegate string
 
-	// CallerName is the name of the service issuing the call. It can also be used
-	// to support transparent proxying when the inbound caller name varies across
-	// calls.
+	// CallerName defaults to the channel's service name for an outbound call.
+	// Optionally override this field to support transparent proxying when inbound
+	// caller names vary across calls.
 	CallerName string
 }
 

--- a/calloptions_test.go
+++ b/calloptions_test.go
@@ -31,6 +31,7 @@ func TestSetHeaders(t *testing.T) {
 		format          Format
 		routingDelegate string
 		routingKey      string
+		callerName      string
 		expectedHeaders transportHeaders
 	}{
 		{
@@ -41,6 +42,13 @@ func TestSetHeaders(t *testing.T) {
 		{
 			format:          Thrift,
 			expectedHeaders: transportHeaders{ArgScheme: Thrift.String()},
+		},
+		{
+			callerName: "foo-caller",
+			expectedHeaders: transportHeaders{
+				ArgScheme:  Raw.String(),
+				CallerName: "foo-caller",
+			},
 		},
 		{
 			format:          JSON,
@@ -65,6 +73,7 @@ func TestSetHeaders(t *testing.T) {
 			Format:          tt.format,
 			RoutingDelegate: tt.routingDelegate,
 			RoutingKey:      tt.routingKey,
+			CallerName:      tt.callerName,
 		}
 		headers := make(transportHeaders)
 		callOpts.setHeaders(headers)

--- a/context.go
+++ b/context.go
@@ -68,9 +68,8 @@ type IncomingCall interface {
 	// connections to the caller.
 	RemotePeer() PeerInfo
 
-	// CallOptions returns the call options set for the incoming call. It can be useful
-	// if you are forwarding a request and wish to retain the CallerName(), which is not
-	// possible to set manually.
+	// CallOptions returns the call options set for the incoming call. It can be
+	// useful for forwarding requests.
 	CallOptions() *CallOptions
 }
 

--- a/inbound.go
+++ b/inbound.go
@@ -261,7 +261,7 @@ func (call *InboundCall) RemotePeer() PeerInfo {
 // CallOptions returns a CallOptions struct suitable for forwarding a request.
 func (call *InboundCall) CallOptions() *CallOptions {
 	return &CallOptions{
-		callerName:      call.CallerName(),
+		CallerName:      call.CallerName(),
 		Format:          call.Format(),
 		ShardKey:        call.ShardKey(),
 		RoutingDelegate: call.RoutingDelegate(),

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -154,12 +154,11 @@ func TestCallOptionsPropogated(t *testing.T) {
 		RoutingDelegate: "test-routing-delegate",
 	}
 
-	var gotCallOptions *CallOptions
+	var gotCallOpts *CallOptions
 
 	testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 		ts.Register(HandlerFunc(func(ctx context.Context, inbound *InboundCall) {
-			gotCallOptions = inbound.CallOptions()
-			require.NotNil(t, gotCallOptions)
+			gotCallOpts = inbound.CallOptions()
 
 			err := raw.WriteResponse(inbound.Response(), &raw.Res{})
 			assert.NoError(t, err, "write response failed")
@@ -174,7 +173,7 @@ func TestCallOptionsPropogated(t *testing.T) {
 		_, _, _, err = raw.WriteArgs(call, nil, nil)
 		require.NoError(t, err, "could not write args")
 
-		assert.Equal(t, giveCallOpts, *gotCallOptions)
+		assert.Equal(t, &giveCallOpts, gotCallOpts)
 	})
 }
 

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -143,6 +143,41 @@ func TestInboundConnection_CallOptions(t *testing.T) {
 	})
 }
 
+func TestCallOptionsPropogated(t *testing.T) {
+	const handler = "handler"
+
+	giveCallOpts := CallOptions{
+		Format:          JSON,
+		CallerName:      "test-caller-name",
+		ShardKey:        "test-shard-key",
+		RoutingKey:      "test-routing-key",
+		RoutingDelegate: "test-routing-delegate",
+	}
+
+	var gotCallOptions *CallOptions
+
+	testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
+		ts.Register(HandlerFunc(func(ctx context.Context, inbound *InboundCall) {
+			gotCallOptions = inbound.CallOptions()
+			require.NotNil(t, gotCallOptions)
+
+			err := raw.WriteResponse(inbound.Response(), &raw.Res{})
+			assert.NoError(t, err, "write response failed")
+		}), handler)
+
+		ctx, cancel := NewContext(testutils.Timeout(time.Second))
+		defer cancel()
+
+		call, err := ts.Server().BeginCall(ctx, ts.HostPort(), ts.ServiceName(), handler, &giveCallOpts)
+		require.NoError(t, err, "could not call test server")
+
+		_, _, _, err = raw.WriteArgs(call, nil, nil)
+		require.NoError(t, err, "could not write args")
+
+		assert.Equal(t, giveCallOpts, *gotCallOptions)
+	})
+}
+
 func TestBlackhole(t *testing.T) {
 	ctx, cancel := NewContext(testutils.Timeout(time.Hour))
 


### PR DESCRIPTION
This makes the existing caller name field on `CallOptions` public. This
enables frameworks like `yarpc-go` to support transparent proxying, 
when the inbound caller is not known until run time.

Fixes #725 and T2469647.