### PR TITLE
thrift: deal with TStruct serialization failures

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -252,7 +252,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 	// Default to dialContext if dialer is not passed in as an option
 	dialCtx := dialContext
 	if opts.Dialer != nil {
-		dialCtx = func (ctx context.Context, hostPort string) (net.Conn, error) {
+		dialCtx = func(ctx context.Context, hostPort string) (net.Conn, error) {
 			return opts.Dialer(ctx, "tcp", hostPort)
 		}
 	}

--- a/thrift/server.go
+++ b/thrift/server.go
@@ -21,7 +21,6 @@
 package thrift
 
 import (
-	"bytes"
 	"log"
 	"strings"
 	"sync"
@@ -186,17 +185,6 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 		return err
 	}
 
-	// Buffer the response write so we can send a system error to the client.
-	// It's too late to send a system error by the time we write Arg3.
-	var respStruct bytes.Buffer // XXX should we make a buffer pool?
-	wp = getProtocolWriter(&respStruct)
-	if err := resp.Write(wp.protocol); err != nil {
-		call.Response().SendSystemError(err)
-		thriftProtocolPool.Put(wp)
-		return err
-	}
-	thriftProtocolPool.Put(wp)
-
 	if !success {
 		call.Response().SetApplicationError()
 	}
@@ -213,10 +201,13 @@ func (s *Server) handle(origCtx context.Context, handler handler, method string,
 		return err
 	}
 
-	// Write buffered response.
 	writer, err = call.Response().Arg3Writer()
-	if _, err := writer.Write(respStruct.Bytes()); err != nil {
-		writer.Close() // XXX wrap this error?
+
+	wp = getProtocolWriter(writer)
+	defer thriftProtocolPool.Put(wp)
+
+	if err := resp.Write(wp.protocol); err != nil {
+		call.Response().SendSystemError(err)
 		return err
 	}
 

--- a/thrift/server_test.go
+++ b/thrift/server_test.go
@@ -97,9 +97,8 @@ func TestHandleTStructError(t *testing.T) {
 	client := NewClient(
 		server.NewClient(testutils.NewOpts()),
 		tchan.ServiceName(),
-		&ClientOptions{
-			HostPort: server.HostPort(),
-		})
+		&ClientOptions{HostPort: server.HostPort()},
+	)
 
 	t.Run("failing response", func(t *testing.T) {
 		ctx, cancel := NewContext(time.Second)

--- a/thrift/server_test.go
+++ b/thrift/server_test.go
@@ -1,0 +1,95 @@
+package thrift
+
+import (
+	"testing"
+	"time"
+
+	athrift "github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/testutils"
+)
+
+type ioerror struct{}
+
+func (_ ioerror) Error() string {
+	return "IO Error"
+}
+
+// ioless implements TStruct that always fails with ioerror.
+type ioless struct{}
+
+func (i *ioless) Write(p athrift.TProtocol) error {
+	return ioerror{}
+}
+
+func (i *ioless) Read(p athrift.TProtocol) error {
+	return ioerror{}
+}
+
+// null implements TStruct that does nothing at all with no errors.
+type null struct{}
+
+func (i *null) Write(p athrift.TProtocol) error {
+	return nil
+}
+
+func (i *null) Read(p athrift.TProtocol) error {
+	return nil
+}
+
+// thriftStruction is a TChannel service that implements a method that returns
+// success with a TStruct that will always error.
+type thriftStruction struct{}
+
+func (ts *thriftStruction) Handle(
+	ctx Context,
+	methodName string,
+	protocol athrift.TProtocol,
+) (success bool, resp athrift.TStruct, err error) {
+	// successful call with a TStruct that won't IO
+	return true, &ioless{}, nil
+}
+
+func (ts *thriftStruction) Service() string {
+	return "destruct"
+}
+
+func (ts *thriftStruction) Methods() []string {
+	return []string{"destruct"}
+}
+
+func TestHandleTStructError(t *testing.T) {
+	// We should see an ioerror on the server side.
+	expectedLog := testutils.LogVerification{
+		Filters: []testutils.LogFilter{{
+			Filter: "Thrift server error.",
+			Count:  1,
+			FieldFilters: map[string]string{
+				"error": "IO Error",
+			},
+		}}}
+	opts := testutils.ChannelOpts{LogVerification: expectedLog}
+
+	server := testutils.NewTestServer(t, &opts)
+	defer server.CloseAndVerify()
+
+	// Create a thrift server with a handler that returns success with
+	// TStructs that refuse to do I/O.
+	tchan := server.Server()
+	thriftServer := NewServer(tchan)
+	thriftServer.Register(&thriftStruction{})
+
+	// A client should observe a server error.
+	client := NewClient(
+		server.NewClient(nil),
+		tchan.ServiceName(),
+		&ClientOptions{
+			HostPort: server.HostPort(),
+		})
+	ctx, cancel := NewContext(time.Second)
+	defer cancel()
+	_, err := client.Call(ctx, "destruct", "destruct", &null{}, &null{})
+	assert.Error(t, err)
+	assert.IsType(t, tchannel.SystemError{}, err)
+}


### PR DESCRIPTION
A Thrift server handler can return success with a TStruct that may
return an error when writing a serialized form. This error is ignored,
which cause a invalid third argument to be written (or not written at
all).

We can better handle these kinds of errors earlier by buffering a
serialized TStruct and sending along a system error if the
serialization fails.

Fixes #743 