### PR TITLE
Add method to RelayFrame to reveal Arg2 offset

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -37,6 +37,9 @@ type CallFrame interface {
 	// RoutingKey may refer to an alternate traffic group instead of the
 	// traffic group identified by the service name.
 	RoutingKey() []byte
+	// Arg2EndOffset returns the offset from start of frame to the end of Arg2
+	// in bytes.
+	Arg2EndOffset() int
 }
 
 // Conn contains information about the underlying connection.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -37,9 +37,13 @@ type CallFrame interface {
 	// RoutingKey may refer to an alternate traffic group instead of the
 	// traffic group identified by the service name.
 	RoutingKey() []byte
-	// Arg2EndOffset returns the offset from start of frame to the end of Arg2
-	// in bytes.
-	Arg2EndOffset() int
+	// Arg2StartOffset returns the offset from start of frame to the
+	// beginning of Arg2 in bytes.
+	Arg2StartOffset() int
+	// Arg2EndOffset returns the offset from start of frame to the end of
+	// Arg2 in bytes, and isFragmented to indicate if Arg2 is fragmented
+	// (i.e. spans multiple frames).
+	Arg2EndOffset() (_ int, isFragmented bool)
 }
 
 // Conn contains information about the underlying connection.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -37,10 +37,10 @@ type CallFrame interface {
 	// RoutingKey may refer to an alternate traffic group instead of the
 	// traffic group identified by the service name.
 	RoutingKey() []byte
-	// Arg2StartOffset returns the offset from start of frame to the
+	// Arg2StartOffset returns the offset from start of payload to the
 	// beginning of Arg2 in bytes.
 	Arg2StartOffset() int
-	// Arg2EndOffset returns the offset from start of frame to the end of
+	// Arg2EndOffset returns the offset from start of payload to the end of
 	// Arg2 in bytes, and hasMore to indicate if there are mote data from
 	// other frames (i.e. arg2 is fragmented).
 	Arg2EndOffset() (_ int, hasMore bool)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -41,8 +41,8 @@ type CallFrame interface {
 	// beginning of Arg2 in bytes.
 	Arg2StartOffset() int
 	// Arg2EndOffset returns the offset from start of payload to the end of
-	// Arg2 in bytes, and hasMore to indicate if there are mote data from
-	// other frames (i.e. arg2 is fragmented).
+	// Arg2 in bytes, and hasMore to indicate if there are more frames and
+	// Arg3 has not started (i.e. Arg2 is fragmented).
 	Arg2EndOffset() (_ int, hasMore bool)
 }
 

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -41,9 +41,9 @@ type CallFrame interface {
 	// beginning of Arg2 in bytes.
 	Arg2StartOffset() int
 	// Arg2EndOffset returns the offset from start of frame to the end of
-	// Arg2 in bytes, and isFragmented to indicate if Arg2 is fragmented
-	// (i.e. spans multiple frames).
-	Arg2EndOffset() (_ int, isFragmented bool)
+	// Arg2 in bytes, and hasMore to indicate if there are mote data from
+	// other frames (i.e. arg2 is fragmented).
+	Arg2EndOffset() (_ int, hasMore bool)
 }
 
 // Conn contains information about the underlying connection.

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -88,6 +88,8 @@ type lazyCallReq struct {
 	*Frame
 
 	caller, method, delegate, key []byte
+
+	arg2EndOffset int
 }
 
 // TODO: Consider pooling lazyCallReq and using pointers to the struct.
@@ -132,6 +134,10 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 	arg1Len := int(binary.BigEndian.Uint16(f.Payload[cur : cur+2]))
 	cur += 2
 	cr.method = f.Payload[cur : cur+arg1Len]
+
+	// arg2~2
+	cur += arg1Len
+	cr.arg2EndOffset = cur + 2 /*arg2 len*/ + int(binary.BigEndian.Uint16(f.Payload[cur:cur+2]))
 	return cr
 }
 
@@ -181,6 +187,12 @@ func (f lazyCallReq) Span() Span {
 // HasMoreFragments returns whether the callReq has more fragments.
 func (f lazyCallReq) HasMoreFragments() bool {
 	return f.Payload[_flagsIndex]&hasMoreFragmentsFlag != 0
+}
+
+// Arg2EndOffset returns the offset from start of frame to the end of Arg2
+// in bytes.
+func (f lazyCallReq) Arg2EndOffset() int {
+	return f.arg2EndOffset
 }
 
 // finishesCall checks whether this frame is the last one we should expect for

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -194,7 +194,8 @@ func (f lazyCallReq) HasMoreFragments() bool {
 }
 
 // Arg2EndOffset returns the offset from start of payload to the end of Arg2
-// in bytes, and whether there are more data from other frames.
+// in bytes, and hasMore to be true if there are more frames and arg3 has
+// not started.
 func (f lazyCallReq) Arg2EndOffset() (_ int, hasMore bool) {
 	return f.arg2EndOffset, f.isArg2Fragmented
 }

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -139,9 +139,9 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 	// arg2~2
 	cur += arg1Len
 	cr.arg2StartOffset = cur + 2
-	cr.arg2EndOffset = cur + 2 /*arg2 len*/ + int(binary.BigEndian.Uint16(f.Payload[cur:cur+2]))
+	cr.arg2EndOffset = cr.arg2StartOffset + int(binary.BigEndian.Uint16(f.Payload[cur:cur+2]))
 	// arg2 is fragmented if we don't see arg3 in this frame.
-	cr.isArg2Fragmented = int(cr.Header.FrameSize()) <= (FrameHeaderSize+cr.arg2EndOffset) && f.Payload[_flagsIndex]&hasMoreFragmentsFlag != 0
+	cr.isArg2Fragmented = int(cr.Header.PayloadSize()) <= cr.arg2EndOffset && cr.HasMoreFragments()
 	return cr
 }
 
@@ -193,13 +193,13 @@ func (f lazyCallReq) HasMoreFragments() bool {
 	return f.Payload[_flagsIndex]&hasMoreFragmentsFlag != 0
 }
 
-// Arg2EndOffset returns the offset from start of frame to the end of Arg2
+// Arg2EndOffset returns the offset from start of payload to the end of Arg2
 // in bytes, and whether there are more data from other frames.
 func (f lazyCallReq) Arg2EndOffset() (_ int, hasMore bool) {
 	return f.arg2EndOffset, f.isArg2Fragmented
 }
 
-// Arg2StartOffset returns the offset from start of frame to the beginning
+// Arg2StartOffset returns the offset from start of payload to the beginning
 // of Arg2 in bytes.
 func (f lazyCallReq) Arg2StartOffset() int {
 	return f.arg2StartOffset

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -194,8 +194,8 @@ func (f lazyCallReq) HasMoreFragments() bool {
 }
 
 // Arg2EndOffset returns the offset from start of frame to the end of Arg2
-// in bytes, and whether arg2 is fragmented or not.
-func (f lazyCallReq) Arg2EndOffset() (_ int, isFragmented bool) {
+// in bytes, and whether there are more data from other frames.
+func (f lazyCallReq) Arg2EndOffset() (_ int, hasMore bool) {
 	return f.arg2EndOffset, f.isArg2Fragmented
 }
 

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -95,10 +95,6 @@ func (cr testCallReq) reqWithParams(p testCallReqParams) lazyCallReq {
 	return newLazyCallReq(f)
 }
 
-func buildArg2Buffer() []byte {
-	return []byte("test arg2 buf")
-}
-
 func withLazyCallReqCombinations(f func(cr testCallReq)) {
 	for cr := testCallReq(0); cr < reqTotalCombinations; cr++ {
 		f(cr)
@@ -291,7 +287,7 @@ func TestLazyCallReqSetTTL(t *testing.T) {
 
 func TestLazyCallArg2Offset(t *testing.T) {
 	t.Run("arg2 is fully contained in frame", func(t *testing.T) {
-		wantArg2Buf := buildArg2Buffer()
+		wantArg2Buf := []byte("test arg2 buf")
 		withLazyCallReqCombinations(func(crt testCallReq) {
 			cr := crt.reqWithParams(testCallReqParams{arg2Buf: wantArg2Buf})
 			arg2EndOffset, hasMore := cr.Arg2EndOffset()

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -79,7 +79,16 @@ func (cr testCallReq) req() lazyCallReq {
 		payload.WriteUint32(0)                            // checksum contents
 	}
 	payload.WriteLen16String("moneys") // method
+
+	// add Arg2 into frame
+	arg2Buf := buildArg2Buffer()
+	payload.WriteUint16(uint16(len(arg2Buf)))
+	payload.WriteBytes(arg2Buf)
 	return newLazyCallReq(f)
+}
+
+func buildArg2Buffer() []byte {
+	return []byte("test arg2 buf")
 }
 
 func withLazyCallReqCombinations(f func(cr testCallReq)) {
@@ -269,6 +278,16 @@ func TestLazyCallReqSetTTL(t *testing.T) {
 		cr := crt.req()
 		cr.SetTTL(time.Second)
 		assert.Equal(t, time.Second, cr.TTL(), "Failed to write TTL to frame.")
+	})
+}
+
+func TestLazyCallArg2EndOffset(t *testing.T) {
+	wantArg2Buf := buildArg2Buffer()
+	withLazyCallReqCombinations(func(crt testCallReq) {
+		cr := crt.req()
+		arg2EndOffset := cr.Arg2EndOffset()
+		arg2Payload := cr.Payload[arg2EndOffset-len(wantArg2Buf) : arg2EndOffset]
+		assert.Equal(t, wantArg2Buf, arg2Payload)
 	})
 }
 

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -294,8 +294,8 @@ func TestLazyCallArg2Offset(t *testing.T) {
 		wantArg2Buf := buildArg2Buffer()
 		withLazyCallReqCombinations(func(crt testCallReq) {
 			cr := crt.reqWithParams(testCallReqParams{arg2Buf: wantArg2Buf})
-			arg2EndOffset, isFragmented := cr.Arg2EndOffset()
-			assert.False(t, isFragmented)
+			arg2EndOffset, hasMore := cr.Arg2EndOffset()
+			assert.False(t, hasMore)
 			arg2Payload := cr.Payload[cr.Arg2StartOffset():arg2EndOffset]
 			assert.Equal(t, wantArg2Buf, arg2Payload)
 		})
@@ -303,8 +303,8 @@ func TestLazyCallArg2Offset(t *testing.T) {
 	t.Run("has no arg2", func(t *testing.T) {
 		withLazyCallReqCombinations(func(crt testCallReq) {
 			cr := crt.req()
-			endOffset, isFragmented := cr.Arg2EndOffset()
-			assert.False(t, isFragmented)
+			endOffset, hasMore := cr.Arg2EndOffset()
+			assert.False(t, hasMore)
 			assert.Zero(t, endOffset-cr.Arg2StartOffset())
 		})
 	})
@@ -318,8 +318,8 @@ func TestLazyCallArg2Offset(t *testing.T) {
 				flags:   hasMoreFragmentsFlag,
 				arg2Buf: make([]byte, arg2Size),
 			})
-			endOffset, isFragmented := cr.Arg2EndOffset()
-			assert.True(t, isFragmented)
+			endOffset, hasMore := cr.Arg2EndOffset()
+			assert.True(t, hasMore)
 			assert.EqualValues(t, crNoArg2.Header.FrameSize(), endOffset)
 		})
 	})

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -94,6 +94,7 @@ func NewIncomingCall(callerName string) tchannel.IncomingCall {
 // FakeCallFrame is a stub implementation of the CallFrame interface.
 type FakeCallFrame struct {
 	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF string
+	Arg2EndOffsetVal                                          int
 }
 
 var _ relay.CallFrame = FakeCallFrame{}
@@ -121,4 +122,9 @@ func (f FakeCallFrame) RoutingKey() []byte {
 // RoutingDelegate returns the routing delegate field.
 func (f FakeCallFrame) RoutingDelegate() []byte {
 	return []byte(f.RoutingDelegateF)
+}
+
+// Arg2EndOffset returns the offset from start of frame to the end of Arg2.
+func (f FakeCallFrame) Arg2EndOffset() int {
+	return f.Arg2EndOffsetVal
 }

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -94,7 +94,6 @@ func NewIncomingCall(callerName string) tchannel.IncomingCall {
 // FakeCallFrame is a stub implementation of the CallFrame interface.
 type FakeCallFrame struct {
 	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF string
-	Arg2EndOffsetVal                                          int
 }
 
 var _ relay.CallFrame = FakeCallFrame{}
@@ -124,7 +123,14 @@ func (f FakeCallFrame) RoutingDelegate() []byte {
 	return []byte(f.RoutingDelegateF)
 }
 
-// Arg2EndOffset returns the offset from start of frame to the end of Arg2.
-func (f FakeCallFrame) Arg2EndOffset() int {
-	return f.Arg2EndOffsetVal
+// Arg2StartOffset returns the offset from start of frame to
+// the beginning of Arg2.
+func (f FakeCallFrame) Arg2StartOffset() int {
+	return 0
+}
+
+// Arg2EndOffset returns the offset from start of frame to the end
+// of Arg2 and whether Arg2 is fragmented.
+func (f FakeCallFrame) Arg2EndOffset() (int, bool) {
+	return 0, false
 }

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -94,6 +94,9 @@ func NewIncomingCall(callerName string) tchannel.IncomingCall {
 // FakeCallFrame is a stub implementation of the CallFrame interface.
 type FakeCallFrame struct {
 	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF string
+
+	Arg2StartOffsetVal, Arg2EndOffsetVal int
+	IsArg2Fragmented                     bool
 }
 
 var _ relay.CallFrame = FakeCallFrame{}
@@ -123,14 +126,14 @@ func (f FakeCallFrame) RoutingDelegate() []byte {
 	return []byte(f.RoutingDelegateF)
 }
 
-// Arg2StartOffset returns the offset from start of frame to
+// Arg2StartOffset returns the offset from start of payload to
 // the beginning of Arg2.
 func (f FakeCallFrame) Arg2StartOffset() int {
-	return 0
+	return f.Arg2StartOffsetVal
 }
 
-// Arg2EndOffset returns the offset from start of frame to the end
+// Arg2EndOffset returns the offset from start of payload to the end
 // of Arg2 and whether Arg2 is fragmented.
 func (f FakeCallFrame) Arg2EndOffset() (int, bool) {
-	return 0, false
+	return f.Arg2EndOffsetVal, f.IsArg2Fragmented
 }


### PR DESCRIPTION
Add a method "Arg2EndOffset" to RelayFrame interface so that we could
know how much space Arg2 is used. This is the first step to know if it's
possible to add more methods in Relay code to allow Relayer to inject
more headers or read the headers to decide which peer to forward to.

NOTE: this is a breaking change to RelayFrame interface.

Related to #745. Will use this change to know Arg2 usage.