### PR TITLE
Add integration test for Arg2StartOffset/Arg2EndOFfset methods

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -1061,7 +1061,7 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 		{
 			msg:           "XL arg2 which is fragmented",
 			arg2Data:      string(make([]byte, MaxFrameSize+100)),
-			wantEndOffset: 65519,
+			wantEndOffset: wantArg2Start + payloadLeft,
 			wantHasMore:   true,
 		},
 		{

--- a/relay_test.go
+++ b/relay_test.go
@@ -1022,12 +1022,11 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 	exLargeArg2 := make([]byte, MaxFrameSize+100)
 
 	tests := []struct {
-		msg                string
-		arg2Data           []byte
-		arg2Flush          bool
-		arg3Data           []byte
-		wantArg2Fragmented bool
-		wantHasMore        bool
+		msg         string
+		arg2Data    []byte
+		arg2Flush   bool
+		arg3Data    []byte
+		wantHasMore bool
 	}{
 		{
 			msg:      "all within a frame",
@@ -1046,10 +1045,9 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 			arg3Data: arg3Data,
 		},
 		{
-			msg:                "huge arg2",
-			arg2Data:           exLargeArg2,
-			wantHasMore:        true,
-			wantArg2Fragmented: true,
+			msg:         "huge arg2",
+			arg2Data:    exLargeArg2,
+			wantHasMore: true,
 		},
 	}
 
@@ -1067,7 +1065,9 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 			f := <-inspector.received
 			start := f.Arg2StartOffset()
 			end, hasMore := f.Arg2EndOffset()
-			if tt.wantArg2Fragmented {
+			if len(tt.arg2Data) > MaxFrameSize {
+				// Arg2 is larger than max allowed frame size and
+				// should cause fragmentation.
 				assert.True(t, end > start)
 				assert.Equal(t, MaxFrameSize-FrameHeaderSize, end)
 			} else {

--- a/relay_test.go
+++ b/relay_test.go
@@ -1074,7 +1074,7 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 				wantHasMore:       true,
 			},
 			{
-				msg:           "no arg2",
+				msg:           "no arg2 but flushed",
 				wantEndOffset: wantArg2Start,
 				wantHasMore:   false,
 			},
@@ -1138,14 +1138,14 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 				f := <-inspector.received
 				start := f.Arg2StartOffset()
 				end, hasMore := f.Arg2EndOffset()
-				assert.Equal(t, wantArg2Start, start)
-				assert.Equal(t, tt.wantEndOffset, end)
-				assert.Equal(t, tt.wantHasMore, hasMore)
+				assert.Equal(t, wantArg2Start, start, "arg2 start offset does not match expectation")
+				assert.Equal(t, tt.wantEndOffset, end, "arg2 end offset does not match expectation")
+				assert.Equal(t, tt.wantHasMore, hasMore, "arg2 hasMore bit does not match expectation")
 
 				gotArg2, gotArg3, err := raw.ReadArgsV2(call.Response())
 				assert.NoError(t, err)
-				assert.Equal(t, tt.arg2Data+tt.arg2PostFlushData, string(gotArg2))
-				assert.Equal(t, arg3DataToWrite, string(gotArg3))
+				assert.Equal(t, tt.arg2Data+tt.arg2PostFlushData, string(gotArg2), "arg2 in response does not meet expectation")
+				assert.Equal(t, arg3DataToWrite, string(gotArg3), "arg3 in response does not meet expectation")
 			})
 		}
 	})

--- a/relay_test.go
+++ b/relay_test.go
@@ -1016,130 +1016,159 @@ func TestRelayRaceCompletionAndTimeout(t *testing.T) {
 }
 
 func TestRelayArg2OffsetIntegration(t *testing.T) {
-	const (
-		testRK        = "routingkey"
-		testMethod    = "echo"
-		wantArg2Start = len(testRK) + len(testMethod) + 70 /*data before arg1*/
-		payloadLeft   = MaxFramePayloadSize - wantArg2Start
-
-		arg2Data = "moe"
-	)
-
 	ctx, cancel := NewContext(testutils.Timeout(time.Second))
 	defer cancel()
 
-	inspector := newFailedRelayHost()
+	rh := relaytest.NewStubRelayHost()
+	inspector := newFailedRelayHost(rh)
 	opts := testutils.NewOpts().
 		SetRelayOnly().
 		SetRelayHost(inspector)
 
-	ch := testutils.NewServer(t, opts)
-	defer ch.Close()
+	testutils.WithTestServer(t, opts, func(tb testing.TB, ts *testutils.TestServer) {
+		const (
+			testMethod = "echo"
+			arg2Data   = "arg2-is"
+			arg3Data   = "arg3-here"
+		)
 
-	client := testutils.NewClient(t, nil /*opts*/)
-	defer client.Close()
+		var (
+			wantArg2Start = len(ts.ServiceName()) + len(testMethod) + 70 /*data before arg1*/
+			payloadLeft   = MaxFramePayloadSize - wantArg2Start
+		)
 
-	tests := []struct {
-		msg               string
-		arg2Data          string
-		arg2Flush         bool
-		arg2PostFlushData string
-		wantEndOffset     int
-		wantHasMore       bool
-	}{
-		{
-			msg:           "all within a frame",
-			arg2Data:      arg2Data,
-			wantEndOffset: wantArg2Start + len(arg2Data),
-		},
-		{
-			msg:           "arg2 flushed",
-			arg2Data:      arg2Data,
-			arg2Flush:     true,
-			wantEndOffset: wantArg2Start + len(arg2Data),
-			wantHasMore:   true,
-		},
-		{
-			msg:               "arg2 flushed called then write again",
-			arg2Data:          arg2Data,
-			arg2Flush:         true,
-			arg2PostFlushData: "more data",
-			wantEndOffset:     wantArg2Start + len(arg2Data),
-			wantHasMore:       true,
-		},
-		{
-			msg:           "no arg2",
-			wantEndOffset: wantArg2Start,
-		},
-		{
-			msg:           "XL arg2 which is fragmented",
-			arg2Data:      string(make([]byte, MaxFrameSize+100)),
-			wantEndOffset: wantArg2Start + payloadLeft,
-			wantHasMore:   true,
-		},
-		{
-			msg:           "large arg2 with 3 bytes left for arg3",
-			arg2Data:      string(make([]byte, payloadLeft-3)),
-			wantEndOffset: wantArg2Start + payloadLeft - 3,
-			wantHasMore:   false,
-		},
-		{
-			msg:           "large arg2, 2 bytes left",
-			arg2Data:      string(make([]byte, payloadLeft-2)),
-			wantEndOffset: wantArg2Start + payloadLeft - 2,
-			wantHasMore:   true, // arg3 is fragmented
-		},
-		{
-			msg:           "large arg2, 1 bytes left",
-			arg2Data:      string(make([]byte, payloadLeft-1)),
-			wantEndOffset: wantArg2Start + payloadLeft - 1,
-			wantHasMore:   true, // arg3 is fragmented
-		},
-	}
+		testutils.RegisterEcho(ts.Server(), nil)
 
-	for _, tt := range tests {
-		t.Run(tt.msg, func(t *testing.T) {
-			call, err := client.BeginCall(ctx, ch.PeerInfo().HostPort, testRK, testMethod, nil)
-			require.NoError(t, err, "BeginCall failed")
-			writer, err := call.Arg2Writer()
-			arg2WriteHelper := NewArgWriter(writer, err)
-			require.NoError(t, arg2WriteHelper.Write([]byte(tt.arg2Data)), "arg3 write failed")
-			if tt.arg2Flush {
-				writer.Flush()
-				// tries to write after flush
-				if tt.arg2PostFlushData != "" {
-					arg2WriteHelper.Write([]byte(tt.arg2PostFlushData))
+		rh.Add(ts.ServiceName(), ts.Server().PeerInfo().HostPort)
+		client := testutils.NewClient(t, nil /*opts*/)
+		defer client.Close()
+
+		tests := []struct {
+			msg               string
+			arg2Data          string
+			arg2Flush         bool
+			arg2PostFlushData string
+			noArg3            bool
+			wantEndOffset     int
+			wantHasMore       bool
+		}{
+			{
+				msg:           "all within a frame",
+				arg2Data:      arg2Data,
+				wantEndOffset: wantArg2Start + len(arg2Data),
+				wantHasMore:   false,
+			},
+			{
+				msg:           "arg2 flushed",
+				arg2Data:      arg2Data,
+				arg2Flush:     true,
+				wantEndOffset: wantArg2Start + len(arg2Data),
+				wantHasMore:   true,
+			},
+			{
+				msg:               "arg2 flushed called then write again",
+				arg2Data:          arg2Data,
+				arg2Flush:         true,
+				arg2PostFlushData: "more data",
+				wantEndOffset:     wantArg2Start + len(arg2Data),
+				wantHasMore:       true,
+			},
+			{
+				msg:           "no arg2",
+				wantEndOffset: wantArg2Start,
+				wantHasMore:   false,
+			},
+			{
+				msg:           "XL arg2 which is fragmented",
+				arg2Data:      string(make([]byte, MaxFrameSize+100)),
+				wantEndOffset: wantArg2Start + payloadLeft,
+				wantHasMore:   true,
+			},
+			{
+				msg:           "large arg2 with 3 bytes left for arg3",
+				arg2Data:      string(make([]byte, payloadLeft-3)),
+				wantEndOffset: wantArg2Start + payloadLeft - 3,
+				wantHasMore:   false,
+			},
+			{
+				msg:           "large arg2, 2 bytes left",
+				arg2Data:      string(make([]byte, payloadLeft-2)),
+				wantEndOffset: wantArg2Start + payloadLeft - 2,
+				wantHasMore:   true, // no arg3
+			},
+			{
+				msg:           "large arg2, 2 bytes left, no arg3",
+				arg2Data:      string(make([]byte, payloadLeft-2)),
+				wantEndOffset: wantArg2Start + payloadLeft - 2,
+				noArg3:        true,
+				wantHasMore:   true, // no arg3 and still got CALL_REQ_CONTINUE
+			},
+			{
+				msg:           "large arg2, 1 bytes left",
+				arg2Data:      string(make([]byte, payloadLeft-1)),
+				wantEndOffset: wantArg2Start + payloadLeft - 1,
+				wantHasMore:   true, // no arg3
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.msg, func(t *testing.T) {
+
+				call, err := client.BeginCall(ctx, ts.HostPort(), ts.ServiceName(), testMethod, nil)
+				require.NoError(t, err, "BeginCall failed")
+				writer, err := call.Arg2Writer()
+				arg2WriteHelper := NewArgWriter(writer, err)
+				require.NoError(t, arg2WriteHelper.Write([]byte(tt.arg2Data)), "arg3 write failed")
+				if tt.arg2Flush {
 					writer.Flush()
+					// tries to write after flush
+					if tt.arg2PostFlushData != "" {
+						arg2WriteHelper.Write([]byte(tt.arg2PostFlushData))
+						writer.Flush()
+					}
 				}
-			}
-			const arg3Data = "auto-tconfig"
-			require.NoError(t, NewArgWriter(call.Arg3Writer()).Write([]byte(arg3Data)), "arg3 write failed")
 
-			f := <-inspector.received
-			start := f.Arg2StartOffset()
-			end, hasMore := f.Arg2EndOffset()
-			assert.Equal(t, wantArg2Start, start)
-			assert.Equal(t, tt.wantEndOffset, end)
-			assert.Equal(t, tt.wantHasMore, hasMore)
-		})
-	}
+				arg3DataToWrite := arg3Data
+				if tt.noArg3 {
+					arg3DataToWrite = ""
+				}
+				require.NoError(t, NewArgWriter(call.Arg3Writer()).Write([]byte(arg3DataToWrite)), "arg3 write failed")
+
+				f := <-inspector.received
+				start := f.Arg2StartOffset()
+				end, hasMore := f.Arg2EndOffset()
+				assert.Equal(t, wantArg2Start, start)
+				assert.Equal(t, tt.wantEndOffset, end)
+				assert.Equal(t, tt.wantHasMore, hasMore)
+
+				var resArg []byte
+				assert.NoError(t, NewArgReader(call.Response().Arg2Reader()).Read(&resArg))
+				assert.Equal(t, tt.arg2Data, string(resArg))
+				assert.NoError(t, NewArgReader(call.Response().Arg3Reader()).Read(&resArg))
+				assert.Equal(t, arg3DataToWrite, string(resArg))
+			})
+		}
+	})
 }
 
 // failedRelayHost is a RelayHost which always fails RelayCall,
 // but provides way to introspect the received CallFrame.
 type failedRelayHost struct {
+	RelayHost
+
 	received chan relay.CallFrame
 }
 
-func newFailedRelayHost() *failedRelayHost {
+func newFailedRelayHost(r RelayHost) *failedRelayHost {
 	return &failedRelayHost{
-		received: make(chan relay.CallFrame, 1),
+		RelayHost: r,
+		received:  make(chan relay.CallFrame, 1),
 	}
 }
 
-func (r *failedRelayHost) SetChannel(*Channel) {}
+//func (r *failedRelayHost) SetChannel(*Channel) {}
 
 func (r *failedRelayHost) Start(f relay.CallFrame, conn *relay.Conn) (RelayCall, error) {
 	r.received <- testutils.CopyCallFrame(f)
-	return nil, errors.New("relay failed")
+	return r.RelayHost.Start(f, conn)
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -1117,14 +1117,12 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 				require.NoError(t, err, "BeginCall failed")
 				writer, err := call.Arg2Writer()
 				require.NoError(t, err)
-				wantArg2Data := tt.arg2Data
-				_, err = writer.Write([]byte(wantArg2Data))
+				_, err = writer.Write([]byte(tt.arg2Data))
 				require.NoError(t, err)
 				if tt.arg2Flush {
 					writer.Flush()
 					// tries to write after flush
 					if tt.arg2PostFlushData != "" {
-						wantArg2Data += tt.arg2PostFlushData
 						_, err := writer.Write([]byte(tt.arg2PostFlushData))
 						require.NoError(t, err)
 					}
@@ -1146,7 +1144,7 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 
 				gotArg2, gotArg3, err := raw.ReadArgsV2(call.Response())
 				assert.NoError(t, err)
-				assert.Equal(t, wantArg2Data, string(gotArg2))
+				assert.Equal(t, tt.arg2Data+tt.arg2PostFlushData, string(gotArg2))
 				assert.Equal(t, arg3DataToWrite, string(gotArg3))
 			})
 		}

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -137,3 +137,19 @@ func (f FakeCallFrame) Arg2StartOffset() int {
 func (f FakeCallFrame) Arg2EndOffset() (int, bool) {
 	return f.Arg2EndOffsetVal, f.IsArg2Fragmented
 }
+
+// CopyCallFrame copes the relay.CallFrame and returns a FakeCallFrame with
+// corresponding values
+func CopyCallFrame(f relay.CallFrame) FakeCallFrame {
+	endOffset, hasMore := f.Arg2EndOffset()
+	return FakeCallFrame{
+		ServiceF:           string(f.Service()),
+		MethodF:            string(f.Method()),
+		CallerF:            string(f.Caller()),
+		RoutingKeyF:        string(f.RoutingKey()),
+		RoutingDelegateF:   string(f.RoutingDelegate()),
+		Arg2StartOffsetVal: f.Arg2StartOffset(),
+		Arg2EndOffsetVal:   endOffset,
+		IsArg2Fragmented:   hasMore,
+	}
+}

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -138,7 +138,7 @@ func (f FakeCallFrame) Arg2EndOffset() (int, bool) {
 	return f.Arg2EndOffsetVal, f.IsArg2Fragmented
 }
 
-// CopyCallFrame copes the relay.CallFrame and returns a FakeCallFrame with
+// CopyCallFrame copies the relay.CallFrame and returns a FakeCallFrame with
 // corresponding values
 func CopyCallFrame(f relay.CallFrame) FakeCallFrame {
 	endOffset, hasMore := f.Arg2EndOffset()


### PR DESCRIPTION
Add integration test to ensure the arg2 start/end offsets are properly
set. Several test cases are included:

1. Everything in one frame
2. Arg2 is flushed before reaching frame size limit
3. Arg2 has not data
4. Arg2 is larger than frame size limit and thus fragmented