### PR TITLE
Close hyperbahn client when benchmark.internalServer is closed

### DIFF
--- a/benchmark/internal_server.go
+++ b/benchmark/internal_server.go
@@ -37,6 +37,7 @@ import (
 // internalServer represents a benchmark server.
 type internalServer struct {
 	ch          *tchannel.Channel
+	hc          *hyperbahn.Client
 	opts        *options
 	rawCalls    atomic.Int64
 	thriftCalls atomic.Int64
@@ -84,16 +85,22 @@ func (s *internalServer) HostPort() string {
 
 // Advertise advertises with Hyperbahn.
 func (s *internalServer) Advertise(hyperbahnHosts []string) error {
+	var err error
 	config := hyperbahn.Configuration{InitialNodes: hyperbahnHosts}
-	hc, err := hyperbahn.NewClient(s.ch, config, nil)
+	s.hc, err = hyperbahn.NewClient(s.ch, config, nil)
 	if err != nil {
 		panic("failed to setup Hyperbahn client: " + err.Error())
 	}
-	return hc.Advertise()
+	return s.hc.Advertise()
 }
 
 func (s *internalServer) Close() {
-	s.ch.Close()
+	if s.ch != nil {
+		s.ch.Close()
+	}
+	if s.hc != nil {
+		s.hc.Close()
+	}
 }
 
 func (s *internalServer) RawCalls() int {

--- a/benchmark/internal_server.go
+++ b/benchmark/internal_server.go
@@ -95,9 +95,7 @@ func (s *internalServer) Advertise(hyperbahnHosts []string) error {
 }
 
 func (s *internalServer) Close() {
-	if s.ch != nil {
-		s.ch.Close()
-	}
+	s.ch.Close()
 	if s.hc != nil {
 		s.hc.Close()
 	}

--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -132,10 +132,5 @@ func (c *Client) initialAdvertise() error {
 }
 
 func (c *Client) sleep(d time.Duration) {
-	select {
-	case <-time.After(d):
-		return
-	case <-c.quit:
-		return
-	}
+	c.opts.TimeSleep(d)
 }

--- a/hyperbahn/advertise.go
+++ b/hyperbahn/advertise.go
@@ -132,5 +132,10 @@ func (c *Client) initialAdvertise() error {
 }
 
 func (c *Client) sleep(d time.Duration) {
-	c.opts.TimeSleep(d)
+	select {
+	case <-time.After(d):
+		return
+	case <-c.quit:
+		return
+	}
 }

--- a/hyperbahn/client.go
+++ b/hyperbahn/client.go
@@ -106,7 +106,14 @@ func NewClient(ch *tchannel.Channel, config Configuration, opts *ClientOptions) 
 		client.opts.Handler = nullHandler{}
 	}
 	if client.opts.TimeSleep == nil {
-		client.opts.TimeSleep = time.Sleep
+		client.opts.TimeSleep = func(d time.Duration) {
+			select {
+			case <-time.After(d):
+				return
+			case <-client.quit:
+				return
+			}
+		}
 	}
 
 	if err := parseConfig(&config); err != nil {


### PR DESCRIPTION
Currently in package benchmark, when `internalServer.Advertise()` is called, a `hyperbahn.Client` is created but never closed even when the `internalServer` is closed. this can result in a goroutine leak since `hyperbahn.Client.advertiseLoop()` can never return.

This change fixes two things:
1. it keeps track of the allocated `*hyperbahn.Client` in `internalServer`  and  closes the client when `internalServer` is closed.
2. the default function for `hyperbahn.Client.sleep` is changed to a `select` which will not block when the client has been closed.