### PR TITLE
testutils: ts.Server should be created without RelayHost

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -91,6 +91,19 @@ func TestRelay(t *testing.T) {
 	})
 }
 
+func TestRelaySetHost(t *testing.T) {
+	rh := relaytest.NewStubRelayHost()
+	opts := serviceNameOpts("test").SetRelayHost(rh).SetRelayOnly()
+	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
+		testutils.RegisterEcho(ts.Server(), nil)
+		rh.Add(ts.Server().ServiceName(), ts.Server().PeerInfo().HostPort)
+
+		client := ts.NewClient(serviceNameOpts("client"))
+		client.Peers().Add(ts.HostPort())
+		testutils.AssertEcho(t, client, ts.HostPort(), ts.Server().ServiceName())
+	})
+}
+
 func TestRelayHandlesClosedPeers(t *testing.T) {
 	opts := serviceNameOpts("test").SetRelayOnly().
 		// Disable logs as we are closing connections that can error in a lot of places.

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -84,7 +84,11 @@ func NewTestServer(t testing.TB, opts *ChannelOpts) *TestServer {
 		},
 	}
 
-	ts.NewServer(opts)
+	// Remove any relay options, since those should only be applied to addRelay.
+	serverOpts := opts.Copy()
+	serverOpts.RelayHost = nil
+	ts.NewServer(serverOpts)
+
 	if opts == nil || !opts.DisableRelay {
 		ts.addRelay(opts)
 	}


### PR DESCRIPTION
If RelayHost is set when creating TestServer, the ts.Server() ends up
being a relay as well as ts.Relay(). ts.Server() should not be created
with a RelayHost.

Add a test that uses SetRelayHost and verifies that the call works
correctly.