### PR TITLE
Add Tchannel-Thrift Arg2 Key/Value pair iterator

### DIFF
--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -4,7 +4,11 @@
 // backwards-compatibility guarantee.
 package arg2
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
 
 // KeyValIterator is a iterator for reading tchannel-thrift Arg2 Scheme,
 // which has key/value pairs (k~2 v~2).
@@ -18,16 +22,16 @@ type KeyValIterator struct {
 }
 
 // NewKeyValIterator inits a KeyValIterator with the buffer pointing at
-// start of Arg2.
+// start of Arg2. Return io.EOF if no iterator is available.
 // NOTE: tchannel-thrift Arg Scheme starts with number of key/value pair.
-func NewKeyValIterator(arg2Payload []byte) (KeyValIterator, bool) {
+func NewKeyValIterator(arg2Payload []byte) (KeyValIterator, error) {
 	if len(arg2Payload) < 2 {
-		return KeyValIterator{}, false
+		return KeyValIterator{}, io.EOF
 	}
 
 	nh := int(binary.BigEndian.Uint16(arg2Payload[0:2]))
 	if nh <= 0 {
-		return KeyValIterator{}, false
+		return KeyValIterator{}, io.EOF
 	}
 
 	return KeyValIterator{
@@ -36,7 +40,7 @@ func NewKeyValIterator(arg2Payload []byte) (KeyValIterator, bool) {
 	}.next(2 /*nh*/)
 }
 
-// Key Returns the key
+// Key Returns the key.
 func (i KeyValIterator) Key() []byte {
 	return i.arg2Payload[i.keyOffset : i.valueOffset-2 /*2B length*/]
 }
@@ -46,10 +50,11 @@ func (i KeyValIterator) Value() []byte {
 	return i.arg2Payload[i.valueOffset : i.valueOffset+i.valueLen]
 }
 
-// Next returns next iterator. Return nil if no more key/value pair available.
-func (i KeyValIterator) Next() (KeyValIterator, bool) {
+// Next returns next iterator. Return io.EOF if no more key/value pair is
+// available.
+func (i KeyValIterator) Next() (KeyValIterator, error) {
 	if i.leftPairCount <= 0 {
-		return KeyValIterator{}, false
+		return KeyValIterator{}, io.EOF
 	}
 
 	return i.next(i.valueOffset + i.valueLen)
@@ -57,10 +62,10 @@ func (i KeyValIterator) Next() (KeyValIterator, bool) {
 
 // cur is the offset from the start of Arg2 payload to next key/value pair
 // we want to iterate to.
-func (i KeyValIterator) next(cur int) (KeyValIterator, bool) {
+func (i KeyValIterator) next(cur int) (KeyValIterator, error) {
 	arg2Len := len(i.arg2Payload)
 	if cur+2 > arg2Len {
-		return KeyValIterator{}, false
+		return KeyValIterator{}, fmt.Errorf("invalid key offset %v (arg2 len %v)", cur, arg2Len)
 	}
 	keyLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
 	cur += 2
@@ -68,14 +73,14 @@ func (i KeyValIterator) next(cur int) (KeyValIterator, bool) {
 	cur += keyLen
 
 	if cur+2 > arg2Len {
-		return KeyValIterator{}, false
+		return KeyValIterator{}, fmt.Errorf("invalid value offset %v (key offset %v, key len %v, arg2 len %v)", cur, keyOffset, keyLen, arg2Len)
 	}
 	valueLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
 	cur += 2
 	valueOffset := cur
 
 	if valueOffset+valueLen > arg2Len {
-		return KeyValIterator{}, false
+		return KeyValIterator{}, fmt.Errorf("value exceeds arg2 range (offset %v, len %v, arg2 len %v)", valueOffset, valueLen, arg2Len)
 	}
 
 	return KeyValIterator{
@@ -84,5 +89,5 @@ func (i KeyValIterator) next(cur int) (KeyValIterator, bool) {
 		keyOffset:     keyOffset,
 		valueOffset:   valueOffset,
 		valueLen:      valueLen,
-	}, true
+	}, nil
 }

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -17,10 +17,10 @@ type KeyValIterator struct {
 	valueOffset, valueLen int
 }
 
-// InitKeyValIterator inits a KeyValIterator with the buffer pointing at
+// NewKeyValIterator inits a KeyValIterator with the buffer pointing at
 // start of Arg2.
 // NOTE: tchannel-thrift Arg Scheme starts with number of key/value pair.
-func InitKeyValIterator(arg2Payload []byte) (KeyValIterator, bool) {
+func NewKeyValIterator(arg2Payload []byte) (KeyValIterator, bool) {
 	if len(arg2Payload) < 2 {
 		return KeyValIterator{}, false
 	}

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -18,6 +18,10 @@ type KeyValIterator struct {
 // start of Arg2.
 // NOTE: tchannel-thrift Arg Scheme starts with number of key/value pair.
 func InitKeyValIterator(arg2Payload []byte, arg2Len int) (KeyValIterator, bool) {
+	if arg2Len < 2 {
+		return KeyValIterator{}, false
+	}
+
 	nh := int(binary.BigEndian.Uint16(arg2Payload[0:2]))
 	if nh <= 0 {
 		return KeyValIterator{}, false

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -1,0 +1,69 @@
+package arg2
+
+import "encoding/binary"
+
+// KeyValIterator is a iterator for reading tchannel-thrift Arg2 Scheme,
+// which has key/value pairs (k~2 v~2).
+// NOTE: to be optimized for performance, we try to limit the allocation
+// done in the process of iteration.
+type KeyValIterator struct {
+	leftPairCount         int
+	start                 []byte
+	keyOffset, keyLen     int
+	valueOffset, valueLen int
+}
+
+// InitKeyValIterator inits a KeyValIterator with the buffer pointing at
+// start of Arg2.
+// NOTE: tchannel-thrift Arg Scheme starts with number of key/value pair.
+func InitKeyValIterator(arg2Start []byte) (KeyValIterator, bool) {
+	nh := int(binary.BigEndian.Uint16(arg2Start[0:2]))
+	if nh <= 0 {
+		return KeyValIterator{}, false
+	}
+
+	return createKVIterator(nh, arg2Start[2:]), true
+}
+
+// Key Returns the key
+func (i KeyValIterator) Key() []byte {
+	return i.start[i.keyOffset : i.keyOffset+i.keyLen]
+}
+
+// Value returns value.
+func (i KeyValIterator) Value() []byte {
+	return i.start[i.valueOffset : i.valueOffset+i.valueLen]
+}
+
+// Next returns next iterator. Return nil if no more key/value pair available.
+func (i KeyValIterator) Next() (KeyValIterator, bool) {
+	if i.leftPairCount <= 0 {
+		return KeyValIterator{}, false
+	}
+
+	return createKVIterator(
+		i.leftPairCount,
+		i.start[2 /*uint16 len*/ +i.keyLen+2 /*uint16 len*/ +i.valueLen:],
+	), true
+}
+
+func createKVIterator(pairCount int, bufferStart []byte) KeyValIterator {
+	var cur int
+	keyLen := int(binary.BigEndian.Uint16(bufferStart[cur : cur+2]))
+	cur += 2
+	keyOffset := cur
+	cur += keyLen
+
+	valueLen := int(binary.BigEndian.Uint16(bufferStart[cur : cur+2]))
+	cur += 2
+	valueOffset := cur
+
+	return KeyValIterator{
+		start:         bufferStart,
+		leftPairCount: pairCount - 1,
+		keyOffset:     keyOffset,
+		keyLen:        keyLen,
+		valueOffset:   valueOffset,
+		valueLen:      valueLen,
+	}
+}

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -7,32 +7,37 @@ import "encoding/binary"
 // NOTE: to be optimized for performance, we try to limit the allocation
 // done in the process of iteration.
 type KeyValIterator struct {
+	arg2Len               int
 	leftPairCount         int
-	start                 []byte
 	keyOffset, keyLen     int
 	valueOffset, valueLen int
+	arg2Payload           []byte
 }
 
 // InitKeyValIterator inits a KeyValIterator with the buffer pointing at
 // start of Arg2.
 // NOTE: tchannel-thrift Arg Scheme starts with number of key/value pair.
-func InitKeyValIterator(arg2Start []byte) (KeyValIterator, bool) {
-	nh := int(binary.BigEndian.Uint16(arg2Start[0:2]))
+func InitKeyValIterator(arg2Payload []byte, arg2Len int) (KeyValIterator, bool) {
+	nh := int(binary.BigEndian.Uint16(arg2Payload[0:2]))
 	if nh <= 0 {
 		return KeyValIterator{}, false
 	}
 
-	return createKVIterator(nh, arg2Start[2:]), true
+	return KeyValIterator{
+		leftPairCount: nh,
+		arg2Len:       arg2Len,
+		arg2Payload:   arg2Payload,
+	}.next(2 /*nh*/)
 }
 
 // Key Returns the key
 func (i KeyValIterator) Key() []byte {
-	return i.start[i.keyOffset : i.keyOffset+i.keyLen]
+	return i.arg2Payload[i.keyOffset : i.keyOffset+i.keyLen]
 }
 
 // Value returns value.
 func (i KeyValIterator) Value() []byte {
-	return i.start[i.valueOffset : i.valueOffset+i.valueLen]
+	return i.arg2Payload[i.valueOffset : i.valueOffset+i.valueLen]
 }
 
 // Next returns next iterator. Return nil if no more key/value pair available.
@@ -41,29 +46,38 @@ func (i KeyValIterator) Next() (KeyValIterator, bool) {
 		return KeyValIterator{}, false
 	}
 
-	return createKVIterator(
-		i.leftPairCount,
-		i.start[2 /*uint16 len*/ +i.keyLen+2 /*uint16 len*/ +i.valueLen:],
-	), true
+	return i.next(i.valueOffset + i.valueLen)
 }
 
-func createKVIterator(pairCount int, bufferStart []byte) KeyValIterator {
-	var cur int
-	keyLen := int(binary.BigEndian.Uint16(bufferStart[cur : cur+2]))
+// cur is the offset from the start of Arg2 payload to next key/value pair
+// we want to iterate to.
+func (i KeyValIterator) next(cur int) (KeyValIterator, bool) {
+	if cur+2 > i.arg2Len {
+		return KeyValIterator{}, false
+	}
+	keyLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
 	cur += 2
 	keyOffset := cur
 	cur += keyLen
 
-	valueLen := int(binary.BigEndian.Uint16(bufferStart[cur : cur+2]))
+	if cur+2 > i.arg2Len {
+		return KeyValIterator{}, false
+	}
+	valueLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
 	cur += 2
 	valueOffset := cur
 
+	if valueOffset+valueLen > i.arg2Len {
+		return KeyValIterator{}, false
+	}
+
 	return KeyValIterator{
-		start:         bufferStart,
-		leftPairCount: pairCount - 1,
+		arg2Len:       i.arg2Len,
+		arg2Payload:   i.arg2Payload,
+		leftPairCount: i.leftPairCount - 1,
 		keyOffset:     keyOffset,
 		keyLen:        keyLen,
 		valueOffset:   valueOffset,
 		valueLen:      valueLen,
-	}
+	}, true
 }

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -1,3 +1,7 @@
+// Package arg2 contains tchannel thrift Arg2 interfaces for external use.
+//
+// These interfaces are currently unstable, and aren't covered by the API
+// backwards-compatibility guarantee.
 package arg2
 
 import "encoding/binary"
@@ -7,18 +11,17 @@ import "encoding/binary"
 // NOTE: to be optimized for performance, we try to limit the allocation
 // done in the process of iteration.
 type KeyValIterator struct {
-	arg2Len               int
-	leftPairCount         int
-	keyOffset, keyLen     int
-	valueOffset, valueLen int
 	arg2Payload           []byte
+	leftPairCount         int
+	keyOffset             int
+	valueOffset, valueLen int
 }
 
 // InitKeyValIterator inits a KeyValIterator with the buffer pointing at
 // start of Arg2.
 // NOTE: tchannel-thrift Arg Scheme starts with number of key/value pair.
-func InitKeyValIterator(arg2Payload []byte, arg2Len int) (KeyValIterator, bool) {
-	if arg2Len < 2 {
+func InitKeyValIterator(arg2Payload []byte) (KeyValIterator, bool) {
+	if len(arg2Payload) < 2 {
 		return KeyValIterator{}, false
 	}
 
@@ -29,14 +32,13 @@ func InitKeyValIterator(arg2Payload []byte, arg2Len int) (KeyValIterator, bool) 
 
 	return KeyValIterator{
 		leftPairCount: nh,
-		arg2Len:       arg2Len,
 		arg2Payload:   arg2Payload,
 	}.next(2 /*nh*/)
 }
 
 // Key Returns the key
 func (i KeyValIterator) Key() []byte {
-	return i.arg2Payload[i.keyOffset : i.keyOffset+i.keyLen]
+	return i.arg2Payload[i.keyOffset : i.valueOffset-2 /*2B length*/]
 }
 
 // Value returns value.
@@ -56,7 +58,8 @@ func (i KeyValIterator) Next() (KeyValIterator, bool) {
 // cur is the offset from the start of Arg2 payload to next key/value pair
 // we want to iterate to.
 func (i KeyValIterator) next(cur int) (KeyValIterator, bool) {
-	if cur+2 > i.arg2Len {
+	arg2Len := len(i.arg2Payload)
+	if cur+2 > arg2Len {
 		return KeyValIterator{}, false
 	}
 	keyLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
@@ -64,23 +67,21 @@ func (i KeyValIterator) next(cur int) (KeyValIterator, bool) {
 	keyOffset := cur
 	cur += keyLen
 
-	if cur+2 > i.arg2Len {
+	if cur+2 > arg2Len {
 		return KeyValIterator{}, false
 	}
 	valueLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
 	cur += 2
 	valueOffset := cur
 
-	if valueOffset+valueLen > i.arg2Len {
+	if valueOffset+valueLen > arg2Len {
 		return KeyValIterator{}, false
 	}
 
 	return KeyValIterator{
-		arg2Len:       i.arg2Len,
 		arg2Payload:   i.arg2Payload,
 		leftPairCount: i.leftPairCount - 1,
 		keyOffset:     keyOffset,
-		keyLen:        keyLen,
 		valueOffset:   valueOffset,
 		valueLen:      valueLen,
 	}, true

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -31,6 +31,12 @@ func TestKeyValIterator(t *testing.T) {
 	}
 	assert.False(t, ok)
 
+	t.Run("init iterator w/o Arg2", func(t *testing.T) {
+		var buf []byte
+		_, ok := InitKeyValIterator(buf, 0)
+		assert.False(t, ok)
+	})
+
 	t.Run("init iterator w/o pairs", func(t *testing.T) {
 		buf := make([]byte, 2)
 		wb := typed.NewWriteBuffer(buf)

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -1,0 +1,41 @@
+package arg2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/typed"
+)
+
+func TestKeyValIterator(t *testing.T) {
+	const (
+		testBufSize = 100
+		nh          = 5
+	)
+
+	buf := make([]byte, testBufSize)
+	wb := typed.NewWriteBuffer(buf)
+	wb.WriteUint16(nh)
+	for i := 0; i < nh; i++ {
+		wb.WriteLen16String(fmt.Sprintf("key%v", i))
+		wb.WriteLen16String(fmt.Sprintf("value%v", i))
+	}
+
+	iter, ok := InitKeyValIterator(buf)
+	for i := 0; i < nh; i++ {
+		assert.True(t, ok)
+		assert.Equal(t, fmt.Sprintf("key%v", i), string(iter.Key()))
+		assert.Equal(t, fmt.Sprintf("value%v", i), string(iter.Value()))
+		iter, ok = iter.Next()
+	}
+	assert.False(t, ok)
+
+	t.Run("init iterator w/o pairs", func(t *testing.T) {
+		buf := make([]byte, 2)
+		wb := typed.NewWriteBuffer(buf)
+		wb.WriteUint16(0)
+		_, ok := InitKeyValIterator(buf)
+		assert.False(t, ok)
+	})
+}

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -54,35 +54,35 @@ func TestKeyValIterator(t *testing.T) {
 		wb.WriteLen16String("key")
 		wb.WriteLen16String("value")
 		tests := []struct {
-			msg          string
-			arg2Len      int
-			wantIterator string
+			msg     string
+			arg2Len int
+			wantErr string
 		}{
 			{
 				msg:     "ok",
 				arg2Len: wb.BytesWritten(),
 			},
 			{
-				msg:          "not enough to read key len",
-				arg2Len:      3, // nh (2) + 1
-				wantIterator: "invalid key offset 2 (arg2 len 3)",
+				msg:     "not enough to read key len",
+				arg2Len: 3, // nh (2) + 1
+				wantErr: "invalid key offset 2 (arg2 len 3)",
 			},
 			{
-				msg:          "not enough to read value len",
-				arg2Len:      8, // nh (2) + 2 + len(key) + 1
-				wantIterator: "invalid value offset 7 (key offset 4, key len 3, arg2 len 8)",
+				msg:     "not enough to read value len",
+				arg2Len: 8, // nh (2) + 2 + len(key) + 1
+				wantErr: "invalid value offset 7 (key offset 4, key len 3, arg2 len 8)",
 			},
 			{
-				msg:          "not enough to iterate value",
-				arg2Len:      13, // nh (2) + 2 + len(key) + 2 + len(value) = 14
-				wantIterator: "value exceeds arg2 range (offset 9, len 5, arg2 len 13)",
+				msg:     "not enough to iterate value",
+				arg2Len: 13, // nh (2) + 2 + len(key) + 2 + len(value) = 14
+				wantErr: "value exceeds arg2 range (offset 9, len 5, arg2 len 13)",
 			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.msg, func(t *testing.T) {
 				iter, err := NewKeyValIterator(buf[:tt.arg2Len])
-				if tt.wantIterator == "" {
+				if tt.wantErr == "" {
 					assert.NoError(t, err)
 					assert.Equal(t, "key", string(iter.Key()))
 					assert.Equal(t, "value", string(iter.Value()))
@@ -90,7 +90,7 @@ func TestKeyValIterator(t *testing.T) {
 				}
 
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantIterator)
+				assert.Contains(t, err.Error(), tt.wantErr)
 			})
 		}
 	})

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -22,7 +22,7 @@ func TestKeyValIterator(t *testing.T) {
 		wb.WriteLen16String(fmt.Sprintf("value%v", i))
 	}
 
-	iter, ok := InitKeyValIterator(buf)
+	iter, ok := InitKeyValIterator(buf, wb.BytesWritten())
 	for i := 0; i < nh; i++ {
 		assert.True(t, ok)
 		assert.Equal(t, fmt.Sprintf("key%v", i), string(iter.Key()))
@@ -35,7 +35,53 @@ func TestKeyValIterator(t *testing.T) {
 		buf := make([]byte, 2)
 		wb := typed.NewWriteBuffer(buf)
 		wb.WriteUint16(0)
-		_, ok := InitKeyValIterator(buf)
+		_, ok := InitKeyValIterator(buf, wb.BytesWritten())
 		assert.False(t, ok)
+	})
+
+	t.Run("bad key value length", func(t *testing.T) {
+		buf := make([]byte, testBufSize)
+		wb := typed.NewWriteBuffer(buf)
+		wb.WriteUint16(1)
+		wb.WriteLen16String("key")
+		wb.WriteLen16String("value")
+		tests := []struct {
+			msg          string
+			arg2Len      int
+			wantIterator bool
+		}{
+			{
+				msg:          "ok",
+				arg2Len:      wb.BytesWritten(),
+				wantIterator: true,
+			},
+			{
+				msg:          "not enough to read key len",
+				arg2Len:      3, // nh (2) + 1
+				wantIterator: false,
+			},
+			{
+				msg:          "not enough to read value len",
+				arg2Len:      8, // nh (2) + 2 + len(key) + 1
+				wantIterator: false,
+			},
+			{
+				msg:          "not enough to iterate key",
+				arg2Len:      13, // nh (2) + 2 + len(key) + 2 + len(value) = 14
+				wantIterator: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.msg, func(t *testing.T) {
+				iter, ok := InitKeyValIterator(buf, tt.arg2Len)
+				assert.Equal(t, tt.wantIterator, ok)
+
+				if tt.wantIterator {
+					assert.Equal(t, "key", string(iter.Key()))
+					assert.Equal(t, "value", string(iter.Value()))
+				}
+			})
+		}
 	})
 }

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -22,7 +22,7 @@ func TestKeyValIterator(t *testing.T) {
 		wb.WriteLen16String(fmt.Sprintf("value%v", i))
 	}
 
-	iter, ok := InitKeyValIterator(buf[:wb.BytesWritten()])
+	iter, ok := NewKeyValIterator(buf[:wb.BytesWritten()])
 	for i := 0; i < nh; i++ {
 		assert.True(t, ok)
 		assert.Equal(t, fmt.Sprintf("key%v", i), string(iter.Key()))
@@ -33,7 +33,7 @@ func TestKeyValIterator(t *testing.T) {
 
 	t.Run("init iterator w/o Arg2", func(t *testing.T) {
 		var buf []byte
-		_, ok := InitKeyValIterator(buf)
+		_, ok := NewKeyValIterator(buf)
 		assert.False(t, ok)
 	})
 
@@ -41,7 +41,7 @@ func TestKeyValIterator(t *testing.T) {
 		buf := make([]byte, 2)
 		wb := typed.NewWriteBuffer(buf)
 		wb.WriteUint16(0)
-		_, ok := InitKeyValIterator(buf[:wb.BytesWritten()])
+		_, ok := NewKeyValIterator(buf[:wb.BytesWritten()])
 		assert.False(t, ok)
 	})
 
@@ -80,7 +80,7 @@ func TestKeyValIterator(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.msg, func(t *testing.T) {
-				iter, ok := InitKeyValIterator(buf[:tt.arg2Len])
+				iter, ok := NewKeyValIterator(buf[:tt.arg2Len])
 				assert.Equal(t, tt.wantIterator, ok)
 
 				if tt.wantIterator {

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -22,7 +22,7 @@ func TestKeyValIterator(t *testing.T) {
 		wb.WriteLen16String(fmt.Sprintf("value%v", i))
 	}
 
-	iter, ok := InitKeyValIterator(buf, wb.BytesWritten())
+	iter, ok := InitKeyValIterator(buf[:wb.BytesWritten()])
 	for i := 0; i < nh; i++ {
 		assert.True(t, ok)
 		assert.Equal(t, fmt.Sprintf("key%v", i), string(iter.Key()))
@@ -33,7 +33,7 @@ func TestKeyValIterator(t *testing.T) {
 
 	t.Run("init iterator w/o Arg2", func(t *testing.T) {
 		var buf []byte
-		_, ok := InitKeyValIterator(buf, 0)
+		_, ok := InitKeyValIterator(buf)
 		assert.False(t, ok)
 	})
 
@@ -41,7 +41,7 @@ func TestKeyValIterator(t *testing.T) {
 		buf := make([]byte, 2)
 		wb := typed.NewWriteBuffer(buf)
 		wb.WriteUint16(0)
-		_, ok := InitKeyValIterator(buf, wb.BytesWritten())
+		_, ok := InitKeyValIterator(buf[:wb.BytesWritten()])
 		assert.False(t, ok)
 	})
 
@@ -80,7 +80,7 @@ func TestKeyValIterator(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.msg, func(t *testing.T) {
-				iter, ok := InitKeyValIterator(buf, tt.arg2Len)
+				iter, ok := InitKeyValIterator(buf[:tt.arg2Len])
 				assert.Equal(t, tt.wantIterator, ok)
 
 				if tt.wantIterator {


### PR DESCRIPTION
The goal of the iterator is to allow RelayHost to have a way to inspect
the Arg2 header and make the relay decision based on some application
header.

To optimize for performance, we try to avoid allocation as possible.

TODO: we should add more checks to avoid accessing out of bound.