### PR TITLE
introspection: Introspect any channel by ID

### DIFF
--- a/all_channels.go
+++ b/all_channels.go
@@ -67,3 +67,18 @@ func removeClosedChannel(ch *Channel) {
 
 	channelMap.existing[ch.ServiceName()] = channels
 }
+
+func findChannelByID(id uint32) (*Channel, bool) {
+	channelMap.Lock()
+	defer channelMap.Unlock()
+
+	for _, channels := range channelMap.existing {
+		for _, ch := range channels {
+			if ch.chID == id {
+				return ch, true
+			}
+		}
+	}
+
+	return nil, false
+}


### PR DESCRIPTION
Currently, the introspection endpoint only lets you (fully) introspect
the channel that received the request. This restricts introspection to
only work for channels that listen, but there are some services that
create multiple channels: 1 for listening, and then 1 per client.

Since the per-client channels may not be listening, we can only get
limited information on their state. Since we already have unique IDs
for each channel (and this is exposed via the `includeOtherChannels`),
provide a way to introspect a specific channel by ID.

This is backwards compatible -- if no ID is specified, the current
channel is introspected as it is today.