### PR TITLE
Export FakeFrame.Arg2KVIterator to faciliate tests

### DIFF
--- a/testutils/call.go
+++ b/testutils/call.go
@@ -100,7 +100,7 @@ type FakeCallFrame struct {
 	Arg2StartOffsetVal, Arg2EndOffsetVal int
 	IsArg2Fragmented                     bool
 
-	arg2KVIterator    arg2.KeyValIterator
+	Arg2KVIterator    arg2.KeyValIterator
 	hasArg2KVIterator error
 }
 
@@ -146,7 +146,7 @@ func (f FakeCallFrame) Arg2EndOffset() (int, bool) {
 // Arg2Iterator returns the iterator for reading Arg2 key value pair
 // of TChannel-Thrift Arg Scheme.
 func (f FakeCallFrame) Arg2Iterator() (arg2.KeyValIterator, error) {
-	return f.arg2KVIterator, f.hasArg2KVIterator
+	return f.Arg2KVIterator, f.hasArg2KVIterator
 }
 
 // CopyCallFrame copies the relay.CallFrame and returns a FakeCallFrame with
@@ -163,7 +163,7 @@ func CopyCallFrame(f relay.CallFrame) FakeCallFrame {
 		Arg2StartOffsetVal: f.Arg2StartOffset(),
 		Arg2EndOffsetVal:   endOffset,
 		IsArg2Fragmented:   hasMore,
-		arg2KVIterator:     copyIterator,
+		Arg2KVIterator:     copyIterator,
 		hasArg2KVIterator:  err,
 	}
 }


### PR DESCRIPTION
With arg2KVIterator unexported, it is extremely difficult for consumers to test with call frames when arg2 is involved. This change simply exports that attr so that is is possible to supply a custom iterator, such as via `arg2.NewKeyValIterator`.