### PR TITLE
Support for factory method for outbound connections

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -114,8 +114,7 @@ type ChannelOptions struct {
 	// default handler that delegates to a subchannel.
 	Handler Handler
 
-
-	Dialer *net.Dialer
+	Dialer func(ctx context.Context, hostPort string) (net.Conn, error)
 }
 
 // ChannelState is the state of a channel.
@@ -161,7 +160,7 @@ type Channel struct {
 	internalHandlers    *handlerMap
 	handler             Handler
 	onPeerStatusChanged func(*Peer)
-	dialer              *net.Dialer
+	dialer              func(ctx context.Context, hostPort string) (net.Conn, error)
 	closed              chan struct{}
 
 	// mutable contains all the members of Channel which are mutable.
@@ -571,7 +570,7 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, e
 	var tcpConn net.Conn
 	var err error
 	if ch.dialer != nil {
-		tcpConn, err = ch.dialer.DialContext(ctx, "tcp", hostPort)
+		tcpConn, err = ch.dialer(ctx, hostPort)
 	} else {
 		tcpConn, err = dialContext(ctx, hostPort)
 	}

--- a/channel.go
+++ b/channel.go
@@ -116,7 +116,7 @@ type ChannelOptions struct {
 
 	// Dialer is optional factory method which can be used for overriding
 	// outbound connections for things like TLS handshake
-	Dialer func(ctx context.Context, hostPort string) (net.Conn, error)
+	Dialer func(ctx context.Context, network, hostPort string) (net.Conn, error)
 }
 
 // ChannelState is the state of a channel.
@@ -249,6 +249,14 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		return nil, err
 	}
 
+	// Default to dialContext if dialer is not passed in as an option
+	dialCtx := dialContext
+	if opts.Dialer != nil {
+		dialCtx = func (ctx context.Context, hostPort string) (net.Conn, error) {
+			return opts.Dialer(ctx, "tcp", hostPort)
+		}
+	}
+
 	ch := &Channel{
 		channelConnectionCommon: channelConnectionCommon{
 			log:           logger,
@@ -264,7 +272,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		relayHost:         opts.RelayHost,
 		relayMaxTimeout:   validateRelayMaxTimeout(opts.RelayMaxTimeout, logger),
 		relayTimerVerify:  opts.RelayTimerVerification,
-		dialer:            opts.Dialer,
+		dialer:            dialCtx,
 		closed:            make(chan struct{}),
 	}
 	ch.peers = newRootPeerList(ch, opts.OnPeerStatusChanged).newChild()
@@ -569,13 +577,7 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string) (*Connection, e
 	}
 
 	timeout := getTimeout(ctx)
-	var tcpConn net.Conn
-	var err error
-	if ch.dialer != nil {
-		tcpConn, err = ch.dialer(ctx, hostPort)
-	} else {
-		tcpConn, err = dialContext(ctx, hostPort)
-	}
+	tcpConn, err := ch.dialer(ctx, hostPort)
 	if err != nil {
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
 			ch.log.WithFields(

--- a/channel.go
+++ b/channel.go
@@ -114,6 +114,8 @@ type ChannelOptions struct {
 	// default handler that delegates to a subchannel.
 	Handler Handler
 
+	// Dialer is optional factory method which can be used for overriding
+	// outbound connections for things like TLS handshake
 	Dialer func(ctx context.Context, hostPort string) (net.Conn, error)
 }
 

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -236,7 +236,7 @@ func (o *ChannelOpts) SetIdleCheckInterval(d time.Duration) *ChannelOpts {
 }
 
 // SetDialer sets the dialer used for outbound connections
-func (o *ChannelOpts) SetDialer(f func(context.Context, string) (net.Conn, error)) *ChannelOpts {
+func (o *ChannelOpts) SetDialer(f func(context.Context, string, string) (net.Conn, error)) *ChannelOpts {
 	o.ChannelOptions.Dialer = f
 	return o
 }

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -22,6 +22,7 @@ package testutils
 
 import (
 	"flag"
+	"net"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/uber/tchannel-go/tos"
 
 	"go.uber.org/atomic"
+	"golang.org/x/net/context"
 )
 
 var connectionLog = flag.Bool("connectionLog", false, "Enables connection logging in tests")
@@ -230,6 +232,12 @@ func (o *ChannelOpts) SetMaxIdleTime(d time.Duration) *ChannelOpts {
 // stale connections from the channel.
 func (o *ChannelOpts) SetIdleCheckInterval(d time.Duration) *ChannelOpts {
 	o.ChannelOptions.IdleCheckInterval = d
+	return o
+}
+
+// SetDialer sets the dialer used for outbound connections
+func (o *ChannelOpts) SetDialer(f func(context.Context, string) (net.Conn, error)) *ChannelOpts {
+	o.ChannelOptions.Dialer = f
 	return o
 }
 


### PR DESCRIPTION
New optional factory method on ChannelOptions to allow passing in custom dialer
for outbound connections.  This could be used for things like TLS handshake
considering tchannel already has support for custom TLS listener.