### PR TITLE
relay: Log send buffer usage and size when dropping calls

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -908,11 +908,7 @@ func (c *Connection) sendBufSize() (sendBufUsage int, sendBufSize int, _ error) 
 }
 
 func getSysConn(conn net.Conn, log Logger) syscall.RawConn {
-	type syscallConner interface {
-		SyscallConn() (syscall.RawConn, error)
-	}
-
-	connSyscall, ok := conn.(syscallConner)
+	connSyscall, ok := conn.(syscall.Conn)
 	if !ok {
 		log.WithFields(LogField{"connectionType", fmt.Sprintf("%T", conn)}).
 			Error("Connection does not implement SyscallConn.")

--- a/connection.go
+++ b/connection.go
@@ -110,6 +110,8 @@ var (
 
 	// ErrConnectionNotReady is no longer used.
 	ErrConnectionNotReady = errors.New("connection is not yet ready")
+
+	errNoSyscallConn = errors.New("no syscall.RawConn available")
 )
 
 // errConnectionInvalidState is returned when the connection is in an unknown state.
@@ -884,7 +886,7 @@ func (c *Connection) sendBufSize() (sendBufUsage int, sendBufSize int, _ error) 
 	sendBufUsage = -1
 
 	if c.sysConn == nil {
-		return sendBufUsage, sendBufSize, fmt.Errorf("no sys call conn")
+		return sendBufUsage, sendBufSize, errNoSyscallConn
 	}
 
 	var (

--- a/connection_internal_test.go
+++ b/connection_internal_test.go
@@ -62,4 +62,21 @@ func TestGetSysConn(t *testing.T) {
 		assert.Contains(t, loggerBuf.String(), "Could not get SyscallConn", "missing log")
 		assert.Contains(t, loggerBuf.String(), assert.AnError.Error(), "missing error in log")
 	})
+
+	t.Run("SyscallConn is successful", func(t *testing.T) {
+		loggerBuf := &bytes.Buffer{}
+		logger := NewLogger(loggerBuf)
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err, "Failed to listen")
+		defer ln.Close()
+
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		require.NoError(t, err, "failed to dial")
+		defer conn.Close()
+
+		sysConn := getSysConn(conn, logger)
+		require.NotNil(t, sysConn)
+		assert.Empty(t, loggerBuf.String(), "expected no logs on success")
+	})
 }

--- a/connection_internal_test.go
+++ b/connection_internal_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"bytes"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type errSyscallConn struct {
+	net.Conn
+}
+
+func (c errSyscallConn) SyscallConn() (syscall.RawConn, error) {
+	return nil, assert.AnError
+}
+
+func TestGetSysConn(t *testing.T) {
+	t.Run("no SyscallConn", func(t *testing.T) {
+		loggerBuf := &bytes.Buffer{}
+		logger := NewLogger(loggerBuf)
+
+		type dummyConn struct {
+			net.Conn
+		}
+
+		syscallConn := getSysConn(dummyConn{}, logger)
+		require.Nil(t, syscallConn, "expected no syscall.RawConn to be returned")
+		assert.Contains(t, loggerBuf.String(), "Connection does not implement SyscallConn", "missing log")
+		assert.Contains(t, loggerBuf.String(), "dummyConn", "missing type in log")
+	})
+
+	t.Run("SyscallConn returns error", func(t *testing.T) {
+		loggerBuf := &bytes.Buffer{}
+		logger := NewLogger(loggerBuf)
+
+		syscallConn := getSysConn(errSyscallConn{}, logger)
+		require.Nil(t, syscallConn, "expected no syscall.RawConn to be returned")
+		assert.Contains(t, loggerBuf.String(), "Could not get SyscallConn", "missing log")
+		assert.Contains(t, loggerBuf.String(), assert.AnError.Error(), "missing error in log")
+	})
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: d360c4cc43e9aee42a71d729286d4bbf5214384277f22d2869b67f7f04e41ccb
-updated: 2019-05-01T16:26:07.049050757-07:00
+hash: 7400b8d3d51badea662da185fd9cc0098c7a1fb0a2731b17ceae4e91f6455d1d
+updated: 2020-03-17T12:48:49.8534584+11:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
-  version: 138b925ccdf617776955904ba7759fce64406cec
+  version: 5ca90424ceb7e5e9affff2765da00e9dd737f274
   subpackages:
   - statsd
 - name: github.com/opentracing/opentracing-go
@@ -16,13 +16,13 @@ imports:
   - log
   - mocktracer
 - name: github.com/samuel/go-thrift
-  version: e9042807f4f5bf47563df6992d3ea0857313e2be
+  version: e8b6b52668fe9c972220addc130edf46a9b466b1
   subpackages:
   - parser
 - name: github.com/uber-go/tally
-  version: e9a67ec1839e1f6e5133dbcca2f57bec12fdeda2
+  version: 85437d773ad6967edfdf75ce51d35c95133c2f6a
 - name: github.com/uber/jaeger-client-go
-  version: 2f47546e3facd43297739439600bcf43f44cce5d
+  version: 2d55657eac169e2a86b4fcc1a421e26a9a485b63
   subpackages:
   - internal/baggage
   - internal/spanlog
@@ -35,11 +35,11 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: go.uber.org/atomic
-  version: df976f2515e274675050de7b3f42545de80594fd
+  version: 845920076a298bdb984fb0f1b86052e4ca0a281c
   subpackages:
   - utils
 - name: golang.org/x/net
-  version: aaf60122140d3fcf75376d319f0554393160eb50
+  version: c00fd9afed17cfdca9b3e1e3b8de7ef2b3f0347b
   subpackages:
   - bpf
   - context
@@ -47,6 +47,11 @@ imports:
   - internal/socket
   - ipv4
   - ipv6
+- name: golang.org/x/sys
+  version: 1a700e749ce29638d0bbcb531cce1094ea096bd3
+  subpackages:
+  - unix
+  - windows
 testImports:
 - name: github.com/bmizerany/perks
   version: d9a9656a3a4b1c2864fdb44db2ef8619772d92aa
@@ -72,18 +77,18 @@ testImports:
 - name: github.com/streadway/quantile
   version: b0c588724d25ae13f5afb3d90efec0edc636432b
 - name: github.com/stretchr/objx
-  version: 8a3f7159479fbc75b30357fbc48f380b7320f08e
+  version: 35313a95ee26395aa17d366c71a2ccf788fa69b6
 - name: github.com/stretchr/testify
-  version: ffdc059bfe9ce6a4e144ba849dbedead332c6053
+  version: 3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9
   subpackages:
   - assert
   - mock
   - require
 - name: github.com/uber/jaeger-lib
-  version: 0e30338a695636fe5bcf7301e8030ce8dd2a8530
+  version: a87ae9d84fb038a8d79266298970720be7c80fcd
   subpackages:
   - metrics
 - name: go.uber.org/multierr
-  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
+  version: b587143a48b62b01d337824eab43700af6ffe222
 - name: gopkg.in/yaml.v2
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,6 +33,11 @@ import:
   version: ^2.7
 - package: github.com/uber-go/tally
   version: ^3
+- package: golang.org/x/sys
+  subpackages:
+  - unix
+- package: go.uber.org/multierr
+  version: ^1.1.0
 testImport:
 - package: github.com/jessevdk/go-flags
   version: ^1
@@ -56,5 +61,3 @@ testImport:
 - package: github.com/streadway/quantile
 - package: gopkg.in/yaml.v2
 - package: github.com/crossdock/crossdock-go
-- package: go.uber.org/multierr
-  version: ^1.1.0

--- a/introspection.go
+++ b/introspection.go
@@ -156,7 +156,8 @@ type ConnectionRuntimeState struct {
 	Relayer          RelayerRuntimeState     `json:"relayer"`
 	HealthChecks     []bool                  `json:"healthChecks,omitempty"`
 	LastActivity     int64                   `json:"lastActivity"`
-	SendChSize       int                     `json:"sendChSize"`
+	SendChQueued     int                     `json:"sendChQueued"`
+	SendChCapacity   int                     `json:"sendChCapacity"`
 	SendBufferUsage  int                     `json:"sendBufferUsage"`
 	SendBufferSize   int                     `json:"sendBufferSize"`
 }
@@ -370,7 +371,8 @@ func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRunti
 		OutboundExchange: c.outbound.IntrospectState(opts),
 		HealthChecks:     c.healthCheckHistory.asBools(),
 		LastActivity:     c.lastActivity.Load(),
-		SendChSize:       len(c.sendCh),
+		SendChQueued:     len(c.sendCh),
+		SendChCapacity:   cap(c.sendCh),
 		SendBufferUsage:  sendBufUsage,
 		SendBufferSize:   sendBufSize,
 	}

--- a/introspection.go
+++ b/introspection.go
@@ -156,6 +156,9 @@ type ConnectionRuntimeState struct {
 	Relayer          RelayerRuntimeState     `json:"relayer"`
 	HealthChecks     []bool                  `json:"healthChecks,omitempty"`
 	LastActivity     int64                   `json:"lastActivity"`
+	SendChSize       int                     `json:"sendChSize"`
+	SendBufferUsage  int                     `json:"sendBufferUsage"`
+	SendBufferSize   int                     `json:"sendBufferSize"`
 }
 
 // RelayerRuntimeState is the runtime state for a single relayer.
@@ -352,6 +355,9 @@ func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRunti
 	c.stateMut.RLock()
 	defer c.stateMut.RUnlock()
 
+	// Ignore errors getting send buffer sizes.
+	sendBufUsage, sendBufSize, _ := c.sendBufSize()
+
 	// TODO(prashantv): Add total number of health checks, and health check options.
 	state := ConnectionRuntimeState{
 		ID:               c.connID,
@@ -364,6 +370,9 @@ func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRunti
 		OutboundExchange: c.outbound.IntrospectState(opts),
 		HealthChecks:     c.healthCheckHistory.asBools(),
 		LastActivity:     c.lastActivity.Load(),
+		SendChSize:       len(c.sendCh),
+		SendBufferUsage:  sendBufUsage,
+		SendBufferSize:   sendBufSize,
 	}
 	if c.relay != nil {
 		state.Relayer = c.relay.IntrospectState(opts)

--- a/relay.go
+++ b/relay.go
@@ -289,6 +289,8 @@ func (r *Relayer) Receive(f *Frame, fType frameType) (sent bool, failureReason s
 			{"id", id},
 			{"destConnSendBufferCurrent", sendBuf},
 			{"destConnSendBufferLimit", sendBufLimit},
+			{"sendChQueued", len(r.conn.sendCh)},
+			{"sendChCapacity", cap(r.conn.sendCh)},
 		}
 		if sendBufErr != nil {
 			logFields = append(logFields, LogField{"destConnSendBufferError", sendBufErr.Error()})

--- a/relay.go
+++ b/relay.go
@@ -281,9 +281,20 @@ func (r *Relayer) Receive(f *Frame, fType frameType) (sent bool, failureReason s
 	case r.conn.sendCh <- f:
 	default:
 		// Buffer is full, so drop this frame and cancel the call.
-		r.logger.WithFields(
-			LogField{"id", id},
-		).Warn("Dropping call due to slow connection.")
+
+		// Since this is typically due to the send buffer being full, get send buffer
+		// usage + limit and add that to the log.
+		sendBuf, sendBufLimit, sendBufErr := r.conn.sendBufSize()
+		logFields := []LogField{
+			{"id", id},
+			{"destConnSendBufferCurrent", sendBuf},
+			{"destConnSendBufferLimit", sendBufLimit},
+		}
+		if sendBufErr != nil {
+			logFields = append(logFields, LogField{"destConnSendBufferError", sendBufErr.Error()})
+		}
+
+		r.logger.WithFields(logFields...).Warn("Dropping call due to slow connection.")
 
 		items := r.receiverItems(fType)
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -722,7 +722,7 @@ func TestRelayRateLimitDrop(t *testing.T) {
 // from that server, and we have stats to capture that this is happening.
 func TestRelayStalledConnection(t *testing.T) {
 	opts := testutils.NewOpts().
-		AddLogFilter("Dropping call due to slow connection.", 1).
+		AddLogFilter("Dropping call due to slow connection.", 1, "sendChCapacity", "32").
 		SetSendBufferSize(32). // We want to hit the buffer size earlier, but also ensure we're only dropping once the sendCh is full.
 		SetServiceName("s1").
 		SetRelayOnly()
@@ -773,7 +773,8 @@ func TestRelayStalledConnection(t *testing.T) {
 		// Verify the sendCh is full, and the buffers are utilized.
 		state := ts.Relay().IntrospectState(&IntrospectionOptions{})
 		connState := state.RootPeers[ts.Server().PeerInfo().HostPort].OutboundConnections[0]
-		assert.NotZero(t, connState.SendChSize, "unexpected SendChSize")
+		assert.Equal(t, 32, connState.SendChCapacity, "unexpected SendChCapacity")
+		assert.NotZero(t, connState.SendChQueued, "unexpected SendChQueued")
 		assert.NotZero(t, connState.SendBufferUsage, "unexpected SendBufferUsage")
 		assert.NotZero(t, connState.SendBufferSize, "unexpected SendBufferSize")
 


### PR DESCRIPTION
Ref T5413559

We drop calls when the sendCh is full, which is typically because
writeFrames is not reading from sendCh quickly enough. This could
be because of unfortunate scheduling, or because the send buffer is
full and write syscalls were blocked. Logging the send buffer usage
will help determine which is the cause of dropped calls.

We can get the socket send buffer usage with ioctl, and buffer size
using getsockopt.

ioctl with SIOCOUTQ returns the number of bytes in the send buffer:
See https://linux.die.net/man/7/tcp for details
> Returns the amount of unsent data in the socket send queue.

Extend the introspection output to contain the same buffer sizes as
well as the sendCh length.

Example log message fields added to the log:
```
   "destConnSendBufferCurrent":3994463,
   "destConnSendBufferLimit":4194304
```