### PR TITLE
WIP: Add timeout option for writing frames to sendCh

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -146,6 +146,11 @@ type ConnectionOptions struct {
 	// MaxCloseTime controls how long we allow a connection to complete pending
 	// calls before shutting down. Only used if it is non-zero.
 	MaxCloseTime time.Duration
+
+	// RelaySendTimeout is only for relays, and is the timeout to wait if the
+	// send buffer is full.
+	// This is an unstable API - breaking changes are likely.
+	RelaySendTimeout time.Duration
 }
 
 // connectionEvents are the events that can be triggered by a connection.


### PR DESCRIPTION
Ref T2984301

Instead of dropping calls immediately if the sendCh is full, add
a timeout option which will wait for a specified duration of time
for the sendCh to have space.

This helps in the case that the client is actively reading from the
socket, or in the case that the writeFrames goroutine is actively
writing to the socket, and applies some backpressure to the backend
generating large responses.

This does add latency to process all responses from that backend, so
if there's other clients who have responses in the backend socket's
buffer, they will wait for the timeout as well.