### PR TITLE
Add options to allow overriding SendBufferSize pre process name prefix

### DIFF
--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -133,6 +133,12 @@ func (o *ChannelOpts) SetSendBufferSize(bufSize int) *ChannelOpts {
 	return o
 }
 
+// SetSendBufferSizeOverrides sets the SendBufferOverrides in DefaultConnectionOptions.
+func (o *ChannelOpts) SetSendBufferSizeOverrides(overrides []tchannel.SendBufferSizeOverride) *ChannelOpts {
+	o.DefaultConnectionOptions.SendBufferSizeOverrides = overrides
+	return o
+}
+
 // SetTosPriority set TosPriority in DefaultConnectionOptions.
 func (o *ChannelOpts) SetTosPriority(tosPriority tos.ToS) *ChannelOpts {
 	o.DefaultConnectionOptions.TosPriority = tosPriority


### PR DESCRIPTION
This adds the ability to override SendBufferSize per process name prefix. I'm using prefix instead of regex because prefix seem to be sufficient for most usecases and is significantly faster:

```
➜  regexp_test go test -v -bench=.
goos: darwin
goarch: amd64
pkg: github.com/fiibbb/regexp_test
BenchmarkRegex
BenchmarkRegex-12                5526828               208 ns/op               0 B/op          0 allocs/op
BenchmarkPrefix
BenchmarkPrefix-12              344802882                3.46 ns/op            0 B/op          0 allocs/op
BenchmarkSuffix
BenchmarkSuffix-12              369626205                3.21 ns/op            0 B/op          0 allocs/op
BenchmarkContains
BenchmarkContains-12            142756165                8.41 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/fiibbb/regexp_test   7.896s
```