### PR TITLE
relay: Limit connection timeouts to avoid stalls

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -79,6 +79,10 @@ type ChannelOptions struct {
 	// This is an unstable API - breaking changes are likely.
 	RelayMaxTimeout time.Duration
 
+	// If the relay needs to connect while processing a frame, this specifies
+	// the max connection timeout used.
+	RelayMaxConnectionTimeout time.Duration
+
 	// RelayTimerVerification will disable pooling of relay timers, and instead
 	// verify that timers are not used once they are released.
 	// This is an unstable API - breaking changes are likely.
@@ -158,6 +162,7 @@ type Channel struct {
 	peers               *PeerList
 	relayHost           RelayHost
 	relayMaxTimeout     time.Duration
+	relayMaxConnTimeout time.Duration
 	relayTimerVerify    bool
 	internalHandlers    *handlerMap
 	handler             Handler
@@ -267,13 +272,14 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 			timeTicker:    timeTicker,
 			tracer:        opts.Tracer,
 		},
-		chID:              chID,
-		connectionOptions: opts.DefaultConnectionOptions.withDefaults(),
-		relayHost:         opts.RelayHost,
-		relayMaxTimeout:   validateRelayMaxTimeout(opts.RelayMaxTimeout, logger),
-		relayTimerVerify:  opts.RelayTimerVerification,
-		dialer:            dialCtx,
-		closed:            make(chan struct{}),
+		chID:                chID,
+		connectionOptions:   opts.DefaultConnectionOptions.withDefaults(),
+		relayHost:           opts.RelayHost,
+		relayMaxTimeout:     validateRelayMaxTimeout(opts.RelayMaxTimeout, logger),
+		relayMaxConnTimeout: opts.RelayMaxConnectionTimeout,
+		relayTimerVerify:    opts.RelayTimerVerification,
+		dialer:              dialCtx,
+		closed:              make(chan struct{}),
 	}
 	ch.peers = newRootPeerList(ch, opts.OnPeerStatusChanged).newChild()
 

--- a/introspection.go
+++ b/introspection.go
@@ -165,10 +165,11 @@ type ConnectionRuntimeState struct {
 
 // RelayerRuntimeState is the runtime state for a single relayer.
 type RelayerRuntimeState struct {
-	Count         int               `json:"count"`
-	InboundItems  RelayItemSetState `json:"inboundItems"`
-	OutboundItems RelayItemSetState `json:"outboundItems"`
-	MaxTimeout    time.Duration     `json:"maxTimeout"`
+	Count                int               `json:"count"`
+	InboundItems         RelayItemSetState `json:"inboundItems"`
+	OutboundItems        RelayItemSetState `json:"outboundItems"`
+	MaxTimeout           time.Duration     `json:"maxTimeout"`
+	MaxConnectionTimeout time.Duration     `json:"maxConnectionTimeout"`
 }
 
 // ExchangeSetRuntimeState is the runtime state for a message exchange set.
@@ -388,10 +389,11 @@ func (c *Connection) IntrospectState(opts *IntrospectionOptions) ConnectionRunti
 func (r *Relayer) IntrospectState(opts *IntrospectionOptions) RelayerRuntimeState {
 	count := r.inbound.Count() + r.outbound.Count()
 	return RelayerRuntimeState{
-		Count:         count,
-		InboundItems:  r.inbound.IntrospectState(opts, "inbound"),
-		OutboundItems: r.outbound.IntrospectState(opts, "outbound"),
-		MaxTimeout:    r.maxTimeout,
+		Count:                count,
+		InboundItems:         r.inbound.IntrospectState(opts, "inbound"),
+		OutboundItems:        r.outbound.IntrospectState(opts, "outbound"),
+		MaxTimeout:           r.maxTimeout,
+		MaxConnectionTimeout: r.maxConnTimeout,
 	}
 }
 

--- a/peer.go
+++ b/peer.go
@@ -419,7 +419,7 @@ func (p *Peer) GetConnection(ctx context.Context) (*Connection, error) {
 
 // getConnectionRelay gets a connection, and uses the given timeout to lazily
 // create a context if a new connection is required.
-func (p *Peer) getConnectionRelay(timeout time.Duration) (*Connection, error) {
+func (p *Peer) getConnectionRelay(callTimeout, relayMaxConnTimeout time.Duration) (*Connection, error) {
 	if conn, ok := p.getActiveConn(); ok {
 		return conn, nil
 	}
@@ -431,6 +431,12 @@ func (p *Peer) getConnectionRelay(timeout time.Duration) (*Connection, error) {
 	// Check active connections again in case someone else got ahead of us.
 	if activeConn, ok := p.getActiveConn(); ok {
 		return activeConn, nil
+	}
+
+	// Use the lower timeout value of the call timeout and the relay connection timeout.
+	timeout := callTimeout
+	if timeout > relayMaxConnTimeout && relayMaxConnTimeout > 0 {
+		timeout = relayMaxConnTimeout
 	}
 
 	// When the relay creates outbound connections, we don't want those services

--- a/relay.go
+++ b/relay.go
@@ -362,7 +362,6 @@ func (r *Relayer) getDestination(f lazyCallReq, call RelayCall) (*Connection, bo
 		return nil, false, errBadRelayHost
 	}
 
-	// TODO: Should connections use the call timeout? Or a separate timeout?
 	remoteConn, err := peer.getConnectionRelay(f.TTL(), r.maxConnTimeout)
 	if err != nil {
 		r.logger.WithFields(

--- a/relay.go
+++ b/relay.go
@@ -169,8 +169,9 @@ const (
 
 // A Relayer forwards frames.
 type Relayer struct {
-	relayHost  RelayHost
-	maxTimeout time.Duration
+	relayHost      RelayHost
+	maxTimeout     time.Duration
+	maxConnTimeout time.Duration
 
 	// localHandlers is the set of service names that are handled by the local
 	// channel.
@@ -200,13 +201,14 @@ type Relayer struct {
 // NewRelayer constructs a Relayer.
 func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 	r := &Relayer{
-		relayHost:    ch.RelayHost(),
-		maxTimeout:   ch.relayMaxTimeout,
-		localHandler: ch.relayLocal,
-		outbound:     newRelayItems(conn.log.WithFields(LogField{"relayItems", "outbound"})),
-		inbound:      newRelayItems(conn.log.WithFields(LogField{"relayItems", "inbound"})),
-		peers:        ch.RootPeers(),
-		conn:         conn,
+		relayHost:      ch.RelayHost(),
+		maxTimeout:     ch.relayMaxTimeout,
+		maxConnTimeout: ch.relayMaxConnTimeout,
+		localHandler:   ch.relayLocal,
+		outbound:       newRelayItems(conn.log.WithFields(LogField{"relayItems", "outbound"})),
+		inbound:        newRelayItems(conn.log.WithFields(LogField{"relayItems", "inbound"})),
+		peers:          ch.RootPeers(),
+		conn:           conn,
 		relayConn: &relay.Conn{
 			RemoteAddr:        conn.conn.RemoteAddr().String(),
 			RemoteProcessName: conn.RemotePeerInfo().ProcessName,
@@ -361,7 +363,7 @@ func (r *Relayer) getDestination(f lazyCallReq, call RelayCall) (*Connection, bo
 	}
 
 	// TODO: Should connections use the call timeout? Or a separate timeout?
-	remoteConn, err := peer.getConnectionRelay(f.TTL())
+	remoteConn, err := peer.getConnectionRelay(f.TTL(), r.maxConnTimeout)
 	if err != nil {
 		r.logger.WithFields(
 			ErrField(err),

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -231,6 +231,12 @@ func (o *ChannelOpts) SetRelayMaxTimeout(d time.Duration) *ChannelOpts {
 	return o
 }
 
+// SetRelayMaxConnectionTimeout sets the maximum timeout for connection attempts.
+func (o *ChannelOpts) SetRelayMaxConnectionTimeout(d time.Duration) *ChannelOpts {
+	o.ChannelOptions.RelayMaxConnectionTimeout = d
+	return o
+}
+
 // SetOnPeerStatusChanged sets the callback for channel status change
 // noficiations.
 func (o *ChannelOpts) SetOnPeerStatusChanged(f func(*tchannel.Peer)) *ChannelOpts {

--- a/utils_for_test.go
+++ b/utils_for_test.go
@@ -25,7 +25,6 @@ package tchannel
 
 import (
 	"net"
-	"time"
 
 	"golang.org/x/net/context"
 )
@@ -39,11 +38,6 @@ func (p *Peer) SetOnUpdate(f func(*Peer)) {
 	p.Lock()
 	p.onUpdate = f
 	p.Unlock()
-}
-
-// GetConnectionRelay exports the getConnectionRelay for tests.
-func (p *Peer) GetConnectionRelay(timeout time.Duration) (*Connection, error) {
-	return p.getConnectionRelay(timeout)
 }
 
 // SetRandomSeed seeds all the random number generators in the channel so that


### PR DESCRIPTION
Ref T5890079

If we need to connect in the relay path, we're basically stalling the
connection (all calls on the connection will be backed up behind the
connection). If a call has a large timeout (e.g., 5 seconds), and the
backend is unavailable, leading to a timeout, then all calls behind will
likely be timed out by the time we've started processing them.

Limit the connection timeout to a shorter value than the call timeout
since connection time is known at the infrastructural layer.