### PR TITLE
Fix flaky TestRelayRaceTimerCausesStuckConnectionOnClose

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -955,7 +955,9 @@ func TestRelayRaceTimerCausesStuckConnectionOnClose(t *testing.T) {
 		concurrentClients = 15
 		callsPerClient    = 100
 	)
-	opts := testutils.NewOpts().SetRelayOnly()
+	opts := testutils.NewOpts().
+		SetRelayOnly().
+		SetSendBufferSize(concurrentClients * callsPerClient) // Avoid dropped frames causing unexpected logs.
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 		// Create clients and ensure we can make a successful request.


### PR DESCRIPTION
Example failure log:
https://travis-ci.com/github/uber/tchannel-go/jobs/335298103

```
    TestRelayRaceTimerCausesStuckConnectionOnClose/with_relay: logger.go:192: Unexpected log: [Warn]: Dropping call due to slow connection. [{serviceName relay} {process relay-45435} {chID 1861} {hostPort 127.0.0.1:45435} {connID 976} {localAddr 127.0.0.1:60636} {remoteAddr 127.0.0.1:36905} {remoteHostPort 127.0.0.1:36905} {remoteIsEphemeral false} {remoteProcess testService-36905} {outboundHP 127.0.0.1:36905} {connectionDirection outbound} {id 955} {destConnSendBufferCurrent 0} {destConnSendBufferLimit 2626560} {sendChQueued 512} {sendChCapacity 512} {lastActivityRead 1589567534497367996} {lastActivityWrite 1589567534497367996} {sinceLastActivityRead 1.163554304s} {sinceLastActivityWrite 95.151099ms}]
```

(many such logs).

Increase the send buffer size to avoid flakiness caused by the test environment running slow enough that packets are not being forwarded.