### PR TITLE
Fix flaky TestRelayBasedSweep test

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -920,7 +920,7 @@ func TestConnectionIDs(t *testing.T) {
 
 		// We want to reuse the same connection for the rest of the test which
 		// only makes sense when the relay is not used.
-		if ts.Relay() != nil {
+		if ts.HasRelay() {
 			return
 		}
 

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -55,6 +55,10 @@ type ChannelOpts struct {
 	// By default, all tests are run with a relay interposed.
 	DisableRelay bool
 
+	// DisableServer disables creation of the TChannel server.
+	// This is typically only used in relay tests when a custom server is required.
+	DisableServer bool
+
 	// OnlyRelay instructs TestServer the test must only be run with a relay.
 	OnlyRelay bool
 
@@ -172,6 +176,13 @@ func (o *ChannelOpts) NoRelay() *ChannelOpts {
 // SetRelayOnly instructs TestServer to only run with a relay in front of this channel.
 func (o *ChannelOpts) SetRelayOnly() *ChannelOpts {
 	o.OnlyRelay = true
+	return o
+}
+
+// SetDisableServer disables creation of the TChannel server.
+// This is typically only used in relay tests when a custom server is required.
+func (o *ChannelOpts) SetDisableServer() *ChannelOpts {
+	o.DisableServer = true
 	return o
 }
 


### PR DESCRIPTION
TestRelayBasedSweep verifies that the relay closes idle connections.
On CI, we saw failures where idle connections were not closed. It took
a while to repro (needed a strategically placed `time.Sleep` at the star
of `pollerLoop`), but it turned out to be a incorrect assumption in the
test.

The test assumes that `relayTicker` is only used by the relay to create
a ticker for the idle sweeper. However, `TestServer` actually
creates a server channel + relay channel with the same opts. In our
case, we don't use the server, but it's already been created.

This causes issues as when we do `relayTicker.Tick()`, it's a race
on which channel's idle sweeper will run, and if the server channel
wins the race, then the relay's idle sweeper doesn't run and doesn't
close connections as expected.

To fix this, add a new option to the TestServer to disable the server,
and do some refactorings to ensure that `ts.Server()` and `ts.Relay()`
work and are only used when they are actually enabled.

Fixes #689.