### PR TITLE
Move OS-specific logic into separate files

### DIFF
--- a/sockio_darwin.go
+++ b/sockio_darwin.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// +build darwin amd64
+// +build darwin
 
 package tchannel
 

--- a/sockio_non_unix.go
+++ b/sockio_non_unix.go
@@ -18,13 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// +build linux
+// Opposite of sockio_unix.go
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package tchannel
 
-import "golang.org/x/sys/unix"
-
-func getSendQueueLen(fd uintptr) (int, error) {
-	// https://linux.die.net/man/7/tcp
-	return unix.IoctlGetInt(int(fd), unix.SIOCOUTQ)
+func (c *Connection) sendBufSize() (sendBufUsage int, sendBufSize int, _ error) {
+	return -1, -1, errNoSyscallConn
 }


### PR DESCRIPTION
While we don't officially support non-Linux/Darwin builds
we should still keep the OS-specific logic in separate files
and follow best practices.

Fixes #780.