### PR TITLE
relay: Report bytes sent/received via Call

### DIFF
--- a/relay_api.go
+++ b/relay_api.go
@@ -43,6 +43,12 @@ type RelayCall interface {
 	// Destination returns the selected peer (if there was no error from Start).
 	Destination() (peer *Peer, ok bool)
 
+	// SentBytes is called when a frame is sent to the destination peer.
+	SentBytes(uint16)
+
+	// ReceivedBytes is called when a frame is received from the destination peer.
+	ReceivedBytes(uint16)
+
 	// The call succeeded (possibly after retrying).
 	Succeeded()
 


### PR DESCRIPTION
Ref T6369485

Track the number of bytes sent/received on a per-call basis by
reporting the frame sizes in the relay path.

For a call, the flow is:

```
   S1 (caller)            S2 (callee)
  ------------------------------------
   Relay(callReq)
                     ->   Receive(callReq)

                          // Request sent to backend, receive response.

                          Relay(callRes)
   Receive(callRes)  <-
```

We could track outbound frames either at caller.Relay or callee.Receive
Inbound frames could similary by tracked in either callee.Relay or
caller.Receive.

If we track metrics only at the caller (Relay and Receive), we can
end up missing frames that are received, but dropped because the call
has timed out.

Instead, we choose to always track metrics in Relay, but we need to take
into account whether it's a request or response frame to determine
whether these are received or sent bytes.

We also need the call to be tracked as part of the relayItem on both
the caller and callee side, as we emit metrics from both sides.

This is not going to be 100% accurate, as there are other paths were
frames may be dropped (E.g., sendCh queue full), but this should work
well for the majority of use-cases.