### PR TITLE
Fix goroutine leak in TestLargeTimeoutsAreClamped

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -385,7 +385,8 @@ func TestLargeTimeoutsAreClamped(t *testing.T) {
 
 		select {
 		case <-time.After(testutils.Timeout(10 * clampTTL)):
-			t.Fatal("Failed to clamp timeout.")
+			assert.Fail(t, "Failed to clamp timeout.")
+			return
 		case <-done:
 		}
 	})


### PR DESCRIPTION
`t.Fatal()` from failures in `TestLargeTimeoutsAreClamped` caused the test to exit without cleanup. Do `assert.Fail()` and `return` instead so we don't trigger the goroutine detector (which is super noisy). 