### PR TITLE
testutils: Use defer to ensure CloseAndVerify on t.Fatal

### DIFF
--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -477,10 +477,10 @@ func withServer(t testing.TB, chanOpts *ChannelOpts, f func(testing.TB, *TestSer
 	// Note: We use defer, as we want the postFns to run even if the test
 	// goroutine exits (e.g. user calls t.Fatalf).
 	defer ts.post()
+	defer ts.CloseAndVerify()
 
 	f(t, ts)
 	if ts.HasServer() {
 		ts.Server().Logger().Debugf("TEST: Test function complete")
 	}
-	ts.CloseAndVerify()
 }


### PR DESCRIPTION
This avoids the issue in #787 where a test using t.Fatal ends up exiting
the goroutine which causes `CloseAndVerify` to be skipped:
 * Leaves any channels created running (causing leaks)
 * Skips the goroutine leak checker, which marks that a leak
   occurred due to a failed test, so other tests don't report
   the leak.

This causes leaks to be reported after a failed test, but the reported
leaks are attributed to other tests (E.g., in #787, we see the leak is
caused by TestLargeTimeoutsAreClamped but the leak is reported in
TestRelayConcurrentCalls).

Using `defer` ensures that we try and close channels (to avoid leaks in
the first place), but also run the leak detector which will skip any
leak checks in future caused by the failed test. Since `defer` is run even
when `runtime.Goexit` is called (which is used by `t.Fatal`), this will ensure
that we run `CloseAndVerify`.