### PR TITLE
Prepare to release 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## [1.19.1] - 2020-08-03
+### Fixed
+ * Move OS-specific logic into OS-specific files to avoid compile issues on
+   non-Unix platforms.
+
 ## [1.19.0] - 2020-05-21
 ### Fixed
  * Internal API changes related to relaying.

--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ package tchannel
 // VersionInfo identifies the version of the TChannel library.
 // Due to lack of proper package management, this version string will
 // be maintained manually.
-const VersionInfo = "1.19.9-dev"
+const VersionInfo = "1.19.1"


### PR DESCRIPTION
This includes a OS-specific issue, and includes some relay changes.