### PR TITLE
Replace manual "cur" pointer with typed.ReadBuffer

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -242,7 +242,13 @@ func (r *Relayer) Relay(f *Frame) error {
 		}
 		return err
 	}
-	return r.handleCallReq(newLazyCallReq(f))
+
+	cr, err := newLazyCallReq(f)
+	if err != nil {
+		return err
+	}
+
+	return r.handleCallReq(cr)
 }
 
 // Receive receives frames intended for this connection.

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/uber/tchannel-go/thrift/arg2"
+	"github.com/uber/tchannel-go/typed"
 )
 
 var (
@@ -96,6 +97,7 @@ type lazyCallReq struct {
 	caller, method, delegate, key, as []byte
 
 	arg2StartOffset, arg2EndOffset int
+	arg2                           []byte
 	isArg2Fragmented               bool
 }
 
@@ -110,19 +112,16 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 
 	serviceLen := f.Payload[_serviceLenIndex]
 	// nh:1 (hk~1 hv~1){nh}
-	headerStart := _serviceLenIndex + 1 /* length byte */ + serviceLen
-	numHeaders := int(f.Payload[headerStart])
-	cur := int(headerStart) + 1
-	for i := 0; i < numHeaders; i++ {
-		keyLen := int(f.Payload[cur])
-		cur++
-		key := f.Payload[cur : cur+keyLen]
-		cur += keyLen
+	headerStartIndex := _serviceLenIndex + 1 /* length byte */ + serviceLen
 
-		valLen := int(f.Payload[cur])
-		cur++
-		val := f.Payload[cur : cur+valLen]
-		cur += valLen
+	rbuf := typed.NewReadBuffer(f.SizedPayload()[headerStartIndex:])
+
+	numHeaders := int(rbuf.ReadSingleByte())
+	for i := 0; i < numHeaders; i++ {
+		keyLen := int(rbuf.ReadSingleByte())
+		key := rbuf.ReadBytes(keyLen)
+		valLen := int(rbuf.ReadSingleByte())
+		val := rbuf.ReadBytes(valLen)
 
 		if bytes.Equal(key, _argSchemeKeyBytes) {
 			cr.as = val
@@ -136,20 +135,21 @@ func newLazyCallReq(f *Frame) lazyCallReq {
 	}
 
 	// csumtype:1 (csum:4){0,1} arg1~2 arg2~2 arg3~2
-	checkSumType := ChecksumType(f.Payload[cur])
-	cur += 1 /* checksum */ + checkSumType.ChecksumSize()
+	checkSumType := ChecksumType(rbuf.ReadSingleByte())
+	rbuf.ReadBytes(checkSumType.ChecksumSize())
 
 	// arg1~2
-	arg1Len := int(binary.BigEndian.Uint16(f.Payload[cur : cur+2]))
-	cur += 2
-	cr.method = f.Payload[cur : cur+arg1Len]
+	arg1Len := int(rbuf.ReadUint16())
+	cr.method = rbuf.ReadBytes(arg1Len)
 
 	// arg2~2
-	cur += arg1Len
-	cr.arg2StartOffset = cur + 2
-	cr.arg2EndOffset = cr.arg2StartOffset + int(binary.BigEndian.Uint16(f.Payload[cur:cur+2]))
+	arg2Len := int(rbuf.ReadUint16())
+	cr.arg2StartOffset = int(headerStartIndex) + rbuf.BytesRead()
+	cr.arg2 = rbuf.ReadBytes(arg2Len)
+	cr.arg2EndOffset = cr.arg2StartOffset + arg2Len
 	// arg2 is fragmented if we don't see arg3 in this frame.
-	cr.isArg2Fragmented = int(cr.Header.PayloadSize()) <= cr.arg2EndOffset && cr.HasMoreFragments()
+	cr.isArg2Fragmented = rbuf.BytesRemaining() == 0 && cr.HasMoreFragments()
+
 	return cr
 }
 

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -136,25 +136,13 @@ func newLazyCallReq(f *Frame) (lazyCallReq, error) {
 		}
 	}
 
-	if rbuf.Err() != nil {
-		return lazyCallReq{}, errBadHeaderLen
-	}
-
 	// csumtype:1 (csum:4){0,1} arg1~2 arg2~2 arg3~2
 	checkSumType := ChecksumType(rbuf.ReadSingleByte())
 	rbuf.ReadBytes(checkSumType.ChecksumSize())
 
-	if rbuf.Err() != nil {
-		return lazyCallReq{}, errBadChecksumLen
-	}
-
 	// arg1~2
 	arg1Len := int(rbuf.ReadUint16())
 	cr.method = rbuf.ReadBytes(arg1Len)
-
-	if rbuf.Err() != nil {
-		return lazyCallReq{}, errBadArg1Len
-	}
 
 	// arg2~2
 	arg2Len := int(rbuf.ReadUint16())
@@ -167,7 +155,7 @@ func newLazyCallReq(f *Frame) (lazyCallReq, error) {
 	cr.isArg2Fragmented = rbuf.BytesRemaining() == 0 && cr.HasMoreFragments()
 
 	if rbuf.Err() != nil {
-		return lazyCallReq{}, errBadArg2Len
+		return lazyCallReq{}, rbuf.Err()
 	}
 
 	return cr, nil

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -100,7 +100,6 @@ type lazyCallReq struct {
 	caller, method, delegate, key, as []byte
 
 	arg2StartOffset, arg2EndOffset int
-	arg2                           []byte
 	isArg2Fragmented               bool
 }
 
@@ -160,7 +159,9 @@ func newLazyCallReq(f *Frame) (lazyCallReq, error) {
 	// arg2~2
 	arg2Len := int(rbuf.ReadUint16())
 	cr.arg2StartOffset = int(headerStartIndex) + rbuf.BytesRead()
-	cr.arg2 = rbuf.ReadBytes(arg2Len)
+	// TODO(echung): deprecate the arg2 offsets and store just the arg2 slice instead
+	// Read pass arg2
+	rbuf.ReadBytes(arg2Len)
 	cr.arg2EndOffset = cr.arg2StartOffset + arg2Len
 	// arg2 is fragmented if we don't see arg3 in this frame.
 	cr.isArg2Fragmented = rbuf.BytesRemaining() == 0 && cr.HasMoreFragments()

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -38,10 +38,7 @@ var (
 	_argSchemeKeyBytes       = []byte(ArgScheme)
 	_tchanThriftValueBytes   = []byte(Thrift)
 
-	errBadHeaderLen   = errors.New("bad header length")
-	errBadChecksumLen = errors.New("bad checksum length")
-	errBadArg1Len     = errors.New("bad Arg1 length")
-	errBadArg2Len     = errors.New("bad Arg2 length")
+	errBadArg2Len = errors.New("bad Arg2 length")
 )
 
 const (

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -145,7 +145,7 @@ func newLazyCallReq(f *Frame) (lazyCallReq, error) {
 	arg2Len := int(rbuf.ReadUint16())
 	cr.arg2StartOffset = int(headerStartIndex) + rbuf.BytesRead()
 	// TODO(echung): deprecate the arg2 offsets and store just the arg2 slice instead
-	// Read pass arg2
+	// Read past arg2
 	rbuf.ReadBytes(arg2Len)
 	cr.arg2EndOffset = cr.arg2StartOffset + arg2Len
 	// arg2 is fragmented if we don't see arg3 in this frame.

--- a/relay_messages_benchmark_test.go
+++ b/relay_messages_benchmark_test.go
@@ -24,17 +24,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkCallReqFrame(b *testing.B) {
-	cr := reqHasAll.req()
+	cr := reqHasAll.req(b)
 	f := cr.Frame
 
 	var service, caller, method []byte
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cr := newLazyCallReq(f)
+		cr, err := newLazyCallReq(f)
+		require.NoError(b, err)
 
 		// Multiple calls due to peer selection, stats, etc.
 		for i := 0; i < 3; i++ {

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -397,7 +397,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 				"key": "val",
 			},
 			overrideBufLen: 3, // 2 (nh) + 2 - 1
-			wantBadErr:     "invalid key offset 2 (arg2 len 3)",
+			wantBadErr:     "buffer is too small",
 		},
 		{
 			msg:       "length not enough to cover key",
@@ -406,7 +406,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 				"key": "val",
 			},
 			overrideBufLen: 6, // 2 (nh) + 2 + len(key) - 1
-			wantBadErr:     "key exceeds arg2 range (key offset 4, key len 3, arg2 len 6)",
+			wantBadErr:     "buffer is too small",
 		},
 		{
 			msg:       "length not enough to cover value len",
@@ -415,7 +415,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 				"key": "val",
 			},
 			overrideBufLen: 8, // 2 (nh) + 2 + len(key) + 2 - 1
-			wantBadErr:     "invalid value offset 7 (key offset 4, key len 3, arg2 len 8)",
+			wantBadErr:     "buffer is too small",
 		},
 		{
 			msg:       "length not enough to cover value",
@@ -424,7 +424,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 				"key": "val",
 			},
 			overrideBufLen: 10, // 2 (nh) + 2 + len(key) + 2 + len(val) - 2
-			wantBadErr:     "value exceeds arg2 range (offset 9, len 3, arg2 len 10)",
+			wantBadErr:     "buffer is too small",
 		},
 		{
 			msg:       "no key value pairs",

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -486,7 +486,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 				overrideArg2Len: leftSpace + 5, // Arg2 length extends beyond payload
 			})
 			_, err := newLazyCallReq(frm)
-			assert.Equal(t, errBadArg2Len, err)
+			assert.EqualError(t, err, "buffer is too small")
 		})
 	})
 }

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -399,7 +399,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 				"key": "val",
 			},
 			overrideBufLen: 6, // 2 (nh) + 2 + len(key) - 1
-			wantBadErr:     "invalid value offset 7 (key offset 4, key len 3, arg2 len 6)",
+			wantBadErr:     "key exceeds arg2 range (key offset 4, key len 3, arg2 len 6)",
 		},
 		{
 			msg:       "length not enough to cover value len",

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -53,11 +53,17 @@ type testCallReqParams struct {
 	overrideArg2Len int
 }
 
-func (cr testCallReq) req() lazyCallReq {
-	return cr.reqWithParams(testCallReqParams{})
+func (cr testCallReq) req(tb testing.TB) lazyCallReq {
+	return cr.reqWithParams(tb, testCallReqParams{})
 }
 
-func (cr testCallReq) reqWithParams(p testCallReqParams) lazyCallReq {
+func (cr testCallReq) reqWithParams(tb testing.TB, p testCallReqParams) lazyCallReq {
+	lcr, err := newLazyCallReq(cr.frameWithParams(p))
+	require.NoError(tb, err)
+	return lcr
+}
+
+func (cr testCallReq) frameWithParams(p testCallReqParams) *Frame {
 	// TODO: Constructing a frame is ugly because the initial flags byte is
 	// written in reqResWriter instead of callReq. We should instead handle that
 	// in callReq, which will allow our tests to be sane.
@@ -107,7 +113,8 @@ func (cr testCallReq) reqWithParams(p testCallReqParams) lazyCallReq {
 	}
 	payload.WriteUint16(uint16(arg2Len))
 	payload.WriteBytes(p.arg2Buf)
-	return newLazyCallReq(f)
+
+	return f
 }
 
 func withLazyCallReqCombinations(f func(cr testCallReq)) {
@@ -240,14 +247,14 @@ func TestLazyCallReqRejectsOtherFrames(t *testing.T) {
 
 func TestLazyCallReqService(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
+		cr := crt.req(t)
 		assert.Equal(t, "bankmoji", string(cr.Service()), "Service name mismatch")
 	})
 }
 
 func TestLazyCallReqCaller(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
+		cr := crt.req(t)
 		if crt&reqHasCaller == 0 {
 			assert.Equal(t, []byte(nil), cr.Caller(), "Unexpected caller name.")
 		} else {
@@ -258,7 +265,7 @@ func TestLazyCallReqCaller(t *testing.T) {
 
 func TestLazyCallReqRoutingDelegate(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
+		cr := crt.req(t)
 		if crt&reqHasDelegate == 0 {
 			assert.Equal(t, []byte(nil), cr.RoutingDelegate(), "Unexpected routing delegate.")
 		} else {
@@ -269,7 +276,7 @@ func TestLazyCallReqRoutingDelegate(t *testing.T) {
 
 func TestLazyCallReqRoutingKey(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
+		cr := crt.req(t)
 		if crt&reqHasRoutingKey == 0 {
 			assert.Equal(t, []byte(nil), cr.RoutingKey(), "Unexpected routing key.")
 		} else {
@@ -280,21 +287,21 @@ func TestLazyCallReqRoutingKey(t *testing.T) {
 
 func TestLazyCallReqMethod(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
+		cr := crt.req(t)
 		assert.Equal(t, "moneys", string(cr.Method()), "Method name mismatch")
 	})
 }
 
 func TestLazyCallReqTTL(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
+		cr := crt.req(t)
 		assert.Equal(t, 42*time.Millisecond, cr.TTL(), "Failed to parse TTL from frame.")
 	})
 }
 
 func TestLazyCallReqSetTTL(t *testing.T) {
 	withLazyCallReqCombinations(func(crt testCallReq) {
-		cr := crt.req()
+		cr := crt.req(t)
 		cr.SetTTL(time.Second)
 		assert.Equal(t, time.Second, cr.TTL(), "Failed to write TTL to frame.")
 	})
@@ -324,7 +331,7 @@ func TestLazyCallArg2Offset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
 			withLazyCallReqCombinations(func(crt testCallReq) {
-				cr := crt.reqWithParams(testCallReqParams{
+				cr := crt.reqWithParams(t, testCallReqParams{
 					flags:   tt.flags,
 					arg2Buf: tt.arg2Buf,
 				})
@@ -347,13 +354,13 @@ func TestLazyCallArg2Offset(t *testing.T) {
 				withLazyCallReqCombinations(func(crt testCallReq) {
 					// For each CallReq, we first get the remaining space left, and
 					// fill up the remaining space with arg2.
-					crNoArg2 := crt.req()
+					crNoArg2 := crt.req(t)
 					arg2Size := int(crNoArg2.Header.PayloadSize()) - crNoArg2.Arg2StartOffset()
 					var flags byte
 					if testHasMore {
 						flags |= hasMoreFragmentsFlag
 					}
-					cr := crt.reqWithParams(testCallReqParams{
+					cr := crt.reqWithParams(t, testCallReqParams{
 						flags:   flags,
 						arg2Buf: make([]byte, arg2Size),
 					})
@@ -444,7 +451,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 				if tt.overrideBufLen > 0 {
 					arg2Buf = arg2Buf[:tt.overrideBufLen]
 				}
-				cr := crt.reqWithParams(testCallReqParams{
+				cr := crt.reqWithParams(t, testCallReqParams{
 					arg2Buf:   arg2Buf,
 					argScheme: tt.argScheme,
 				})
@@ -471,14 +478,14 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 
 	t.Run("bad Arg2 length", func(t *testing.T) {
 		withLazyCallReqCombinations(func(crt testCallReq) {
-			crNoArg2 := crt.req()
+			crNoArg2 := crt.req(t)
 			leftSpace := int(crNoArg2.Header.PayloadSize()) - crNoArg2.Arg2StartOffset()
-			cr := crt.reqWithParams(testCallReqParams{
+			frm := crt.frameWithParams(testCallReqParams{
 				arg2Buf:         make([]byte, leftSpace),
 				argScheme:       Thrift,
 				overrideArg2Len: leftSpace + 5, // Arg2 length extends beyond payload
 			})
-			_, err := cr.Arg2Iterator()
+			_, err := newLazyCallReq(frm)
 			assert.Equal(t, errBadArg2Len, err)
 		})
 	})
@@ -487,7 +494,7 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 func TestLazyCallResRejectsOtherFrames(t *testing.T) {
 	assertWrappingPanics(
 		t,
-		reqHasHeaders.req().Frame,
+		reqHasHeaders.req(t).Frame,
 		func(f *Frame) { newLazyCallRes(f) },
 	)
 }
@@ -506,7 +513,7 @@ func TestLazyCallResOK(t *testing.T) {
 func TestLazyErrorRejectsOtherFrames(t *testing.T) {
 	assertWrappingPanics(
 		t,
-		reqHasHeaders.req().Frame,
+		reqHasHeaders.req(t).Frame,
 		func(f *Frame) { newLazyError(f) },
 	)
 }

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -5,7 +5,6 @@
 package arg2
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/uber/tchannel-go/typed"
@@ -58,27 +57,13 @@ func (i KeyValIterator) Next() (KeyValIterator, error) {
 		return KeyValIterator{}, io.EOF
 	}
 
-	if i.rbuf.BytesRemaining() < 2 {
-		return KeyValIterator{}, fmt.Errorf("invalid key offset %v (arg2 len %v)", i.rbuf.BytesRead(), i.arg2Len)
-	}
 	keyLen := int(i.rbuf.ReadUint16())
-
-	keyOffset := i.rbuf.BytesRead()
-	if i.rbuf.BytesRemaining() < keyLen {
-		return KeyValIterator{}, fmt.Errorf("key exceeds arg2 range (key offset %v, key len %v, arg2 len %v)", keyOffset, keyLen, i.arg2Len)
-	}
 	key := i.rbuf.ReadBytes(keyLen)
-
-	if i.rbuf.BytesRemaining() < 2 {
-		return KeyValIterator{}, fmt.Errorf("invalid value offset %v (key offset %v, key len %v, arg2 len %v)", i.rbuf.BytesRead(), keyOffset, keyLen, i.arg2Len)
-	}
 	valLen := int(i.rbuf.ReadUint16())
-
-	valOffset := i.rbuf.BytesRead()
-	if i.rbuf.BytesRemaining() < valLen {
-		return KeyValIterator{}, fmt.Errorf("value exceeds arg2 range (offset %v, len %v, arg2 len %v)", valOffset, valLen, i.arg2Len)
-	}
 	val := i.rbuf.ReadBytes(valLen)
+	if i.rbuf.Err() != nil {
+		return KeyValIterator{}, i.rbuf.Err()
+	}
 
 	leftPairCount := i.leftPairCount - 1
 

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -62,23 +62,24 @@ func (i KeyValIterator) Next() (KeyValIterator, error) {
 		return KeyValIterator{}, fmt.Errorf("invalid key offset %v (arg2 len %v)", i.rbuf.BytesRead(), i.arg2Len)
 	}
 	keyLen := int(i.rbuf.ReadUint16())
+
 	keyOffset := i.rbuf.BytesRead()
 	if i.rbuf.BytesRemaining() < keyLen {
 		return KeyValIterator{}, fmt.Errorf("key exceeds arg2 range (key offset %v, key len %v, arg2 len %v)", keyOffset, keyLen, i.arg2Len)
 	}
-
 	key := i.rbuf.ReadBytes(keyLen)
 
 	if i.rbuf.BytesRemaining() < 2 {
 		return KeyValIterator{}, fmt.Errorf("invalid value offset %v (key offset %v, key len %v, arg2 len %v)", i.rbuf.BytesRead(), keyOffset, keyLen, i.arg2Len)
 	}
 	valLen := int(i.rbuf.ReadUint16())
+
 	valOffset := i.rbuf.BytesRead()
 	if i.rbuf.BytesRemaining() < valLen {
 		return KeyValIterator{}, fmt.Errorf("value exceeds arg2 range (offset %v, len %v, arg2 len %v)", valOffset, valLen, i.arg2Len)
 	}
-
 	val := i.rbuf.ReadBytes(valLen)
+
 	leftPairCount := i.leftPairCount - 1
 
 	return KeyValIterator{

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -94,3 +94,18 @@ func TestKeyValIterator(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkKeyValIterator(b *testing.B) {
+	kvBuffer := thriftarg2test.BuildKVBuffer(map[string]string{
+		"foo":  "bar",
+		"baz":  "qux",
+		"quux": "corge",
+	})
+
+	for i := 0; i < b.N; i++ {
+		iter, err := NewKeyValIterator(kvBuffer)
+		for err == nil {
+			iter, err = iter.Next()
+		}
+	}
+}

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -64,7 +64,7 @@ func TestKeyValIterator(t *testing.T) {
 			{
 				msg:     "not enough to hold key value",
 				arg2Len: 6, // nh (2) + 2 + len(key) - 1
-				wantErr: "invalid value offset 7 (key offset 4, key len 3, arg2 len 6)",
+				wantErr: "key exceeds arg2 range (key offset 4, key len 3, arg2 len 6)",
 			},
 			{
 				msg:     "not enough to read value len",

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -59,22 +59,22 @@ func TestKeyValIterator(t *testing.T) {
 			{
 				msg:     "not enough to read key len",
 				arg2Len: 3, // nh (2) + 1
-				wantErr: "invalid key offset 2 (arg2 len 3)",
+				wantErr: "buffer is too small",
 			},
 			{
 				msg:     "not enough to hold key value",
 				arg2Len: 6, // nh (2) + 2 + len(key) - 1
-				wantErr: "key exceeds arg2 range (key offset 4, key len 3, arg2 len 6)",
+				wantErr: "buffer is too small",
 			},
 			{
 				msg:     "not enough to read value len",
 				arg2Len: 8, // nh (2) + 2 + len(key) + 1
-				wantErr: "invalid value offset 7 (key offset 4, key len 3, arg2 len 8)",
+				wantErr: "buffer is too small",
 			},
 			{
 				msg:     "not enough to iterate value",
 				arg2Len: 13, // nh (2) + 2 + len(key) + 2 + len(value) = 14
-				wantErr: "value exceeds arg2 range (offset 9, len 5, arg2 len 13)",
+				wantErr: "buffer is too small",
 			},
 		}
 

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -155,6 +155,11 @@ func (r *ReadBuffer) BytesRemaining() int {
 	return len(r.remaining)
 }
 
+// BytesRead returns the number of bytes consumed
+func (r *ReadBuffer) BytesRead() int {
+	return len(r.buffer) - len(r.remaining)
+}
+
 // FillFrom fills the buffer from a reader
 func (r *ReadBuffer) FillFrom(ior io.Reader, n int) (int, error) {
 	if len(r.buffer) < n {


### PR DESCRIPTION
The "cur" pointer approach has made the code very difficult to follow and has likely resulted in a missed error check in `KeyValIterator.Next()`.

This change migrates `newLazyCallReq()` and `KeyValIterator.Next()` to `typed.ReadBuffer` instead for better readability.

Benchmarks indicate that there are no additional allocs resulting from this change.

`BenchmarkRelay*` benchmarks:
```
$ cat baseline.log | grep allocs/op
   17408	     71408 ns/op	  14.34 MB/s	     446 B/op	      12 allocs/op
   21661	     55907 ns/op	  18.32 MB/s	     506 B/op	      12 allocs/op
   13016	     86108 ns/op	  47.57 MB/s	     497 B/op	      12 allocs/op
$ cat benchmark.log | grep allocs/op
   15798	     75712 ns/op	  13.52 MB/s	     453 B/op	      12 allocs/op
   24147	     48498 ns/op	  21.11 MB/s	     496 B/op	      12 allocs/op
   14484	     81832 ns/op	  50.05 MB/s	     499 B/op	      12 allocs/op
```