### PR TITLE
Replace manual "cur" pointer with typed.ReadBuffer

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -242,7 +242,13 @@ func (r *Relayer) Relay(f *Frame) error {
 		}
 		return err
 	}
-	return r.handleCallReq(newLazyCallReq(f))
+
+	cr, err := newLazyCallReq(f)
+	if err != nil {
+		return err
+	}
+
+	return r.handleCallReq(cr)
 }
 
 // Receive receives frames intended for this connection.

--- a/relay_messages_benchmark_test.go
+++ b/relay_messages_benchmark_test.go
@@ -24,17 +24,20 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkCallReqFrame(b *testing.B) {
-	cr := reqHasAll.req()
+	cr := reqHasAll.req(b)
 	f := cr.Frame
 
 	var service, caller, method []byte
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cr := newLazyCallReq(f)
+		cr, err := newLazyCallReq(f)
+		require.NoError(b, err)
 
 		// Multiple calls due to peer selection, stats, etc.
 		for i := 0; i < 3; i++ {

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -5,9 +5,9 @@
 package arg2
 
 import (
-	"encoding/binary"
-	"fmt"
 	"io"
+
+	"github.com/uber/tchannel-go/typed"
 )
 
 // KeyValIterator is a iterator for reading tchannel-thrift Arg2 Scheme,
@@ -15,10 +15,11 @@ import (
 // NOTE: to be optimized for performance, we try to limit the allocation
 // done in the process of iteration.
 type KeyValIterator struct {
-	arg2Payload           []byte
-	leftPairCount         int
-	keyOffset             int
-	valueOffset, valueLen int
+	arg2Len       int
+	remaining     []byte
+	leftPairCount int
+	key           []byte
+	val           []byte
 }
 
 // NewKeyValIterator inits a KeyValIterator with the buffer pointing at
@@ -29,21 +30,25 @@ func NewKeyValIterator(arg2Payload []byte) (KeyValIterator, error) {
 		return KeyValIterator{}, io.EOF
 	}
 
+	// We don't hold on to rbuf to avoid the associated alloc
+	rbuf := typed.NewReadBuffer(arg2Payload)
+	leftPairCount := rbuf.ReadUint16()
+
 	return KeyValIterator{
-		valueOffset:   2, // nh has 2B offset
-		leftPairCount: int(binary.BigEndian.Uint16(arg2Payload[0:2])),
-		arg2Payload:   arg2Payload,
+		arg2Len:       len(arg2Payload),
+		leftPairCount: int(leftPairCount),
+		remaining:     arg2Payload[rbuf.BytesRead():],
 	}.Next()
 }
 
 // Key Returns the key.
 func (i KeyValIterator) Key() []byte {
-	return i.arg2Payload[i.keyOffset : i.valueOffset-2 /*2B length*/]
+	return i.key
 }
 
 // Value returns value.
 func (i KeyValIterator) Value() []byte {
-	return i.arg2Payload[i.valueOffset : i.valueOffset+i.valueLen]
+	return i.val
 }
 
 // Next returns next iterator. Return io.EOF if no more key/value pair is
@@ -53,32 +58,22 @@ func (i KeyValIterator) Next() (KeyValIterator, error) {
 		return KeyValIterator{}, io.EOF
 	}
 
-	arg2Len := len(i.arg2Payload)
-	cur := i.valueOffset + i.valueLen
-	if cur+2 > arg2Len {
-		return KeyValIterator{}, fmt.Errorf("invalid key offset %v (arg2 len %v)", cur, arg2Len)
+	rbuf := typed.NewReadBuffer(i.remaining)
+	keyLen := int(rbuf.ReadUint16())
+	key := rbuf.ReadBytes(keyLen)
+	valLen := int(rbuf.ReadUint16())
+	val := rbuf.ReadBytes(valLen)
+	if rbuf.Err() != nil {
+		return KeyValIterator{}, rbuf.Err()
 	}
-	keyLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
-	cur += 2
-	keyOffset := cur
-	cur += keyLen
 
-	if cur+2 > arg2Len {
-		return KeyValIterator{}, fmt.Errorf("invalid value offset %v (key offset %v, key len %v, arg2 len %v)", cur, keyOffset, keyLen, arg2Len)
-	}
-	valueLen := int(binary.BigEndian.Uint16(i.arg2Payload[cur : cur+2]))
-	cur += 2
-	valueOffset := cur
-
-	if valueOffset+valueLen > arg2Len {
-		return KeyValIterator{}, fmt.Errorf("value exceeds arg2 range (offset %v, len %v, arg2 len %v)", valueOffset, valueLen, arg2Len)
-	}
+	leftPairCount := i.leftPairCount - 1
 
 	return KeyValIterator{
-		arg2Payload:   i.arg2Payload,
-		leftPairCount: i.leftPairCount - 1,
-		keyOffset:     keyOffset,
-		valueOffset:   valueOffset,
-		valueLen:      valueLen,
+		arg2Len:       i.arg2Len,
+		remaining:     i.remaining[rbuf.BytesRead():],
+		leftPairCount: leftPairCount,
+		key:           key,
+		val:           val,
 	}, nil
 }

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -59,22 +59,22 @@ func TestKeyValIterator(t *testing.T) {
 			{
 				msg:     "not enough to read key len",
 				arg2Len: 3, // nh (2) + 1
-				wantErr: "invalid key offset 2 (arg2 len 3)",
+				wantErr: "buffer is too small",
 			},
 			{
 				msg:     "not enough to hold key value",
 				arg2Len: 6, // nh (2) + 2 + len(key) - 1
-				wantErr: "invalid value offset 7 (key offset 4, key len 3, arg2 len 6)",
+				wantErr: "buffer is too small",
 			},
 			{
 				msg:     "not enough to read value len",
 				arg2Len: 8, // nh (2) + 2 + len(key) + 1
-				wantErr: "invalid value offset 7 (key offset 4, key len 3, arg2 len 8)",
+				wantErr: "buffer is too small",
 			},
 			{
 				msg:     "not enough to iterate value",
 				arg2Len: 13, // nh (2) + 2 + len(key) + 2 + len(value) = 14
-				wantErr: "value exceeds arg2 range (offset 9, len 5, arg2 len 13)",
+				wantErr: "buffer is too small",
 			},
 		}
 
@@ -93,4 +93,19 @@ func TestKeyValIterator(t *testing.T) {
 			})
 		}
 	})
+}
+
+func BenchmarkKeyValIterator(b *testing.B) {
+	kvBuffer := thriftarg2test.BuildKVBuffer(map[string]string{
+		"foo":  "bar",
+		"baz":  "qux",
+		"quux": "corge",
+	})
+
+	for i := 0; i < b.N; i++ {
+		iter, err := NewKeyValIterator(kvBuffer)
+		for err == nil {
+			iter, err = iter.Next()
+		}
+	}
 }

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -155,6 +155,11 @@ func (r *ReadBuffer) BytesRemaining() int {
 	return len(r.remaining)
 }
 
+// BytesRead returns the number of bytes consumed
+func (r *ReadBuffer) BytesRead() int {
+	return len(r.buffer) - len(r.remaining)
+}
+
 // FillFrom fills the buffer from a reader
 func (r *ReadBuffer) FillFrom(ior io.Reader, n int) (int, error) {
 	if len(r.buffer) < n {


### PR DESCRIPTION
The "cur" pointer approach has made the code very difficult to follow and has likely resulted in a missed error check in `KeyValIterator.Next()`.

This change migrates `newLazyCallReq()` and `KeyValIterator.Next()` to `typed.ReadBuffer` instead for better readability.

Benchmarks indicate that there are no additional allocs resulting from this change.

`BenchmarkRelay*` benchmarks:
```
$ cat baseline.log | grep allocs/op
   17408	     71408 ns/op	  14.34 MB/s	     446 B/op	      12 allocs/op
   21661	     55907 ns/op	  18.32 MB/s	     506 B/op	      12 allocs/op
   13016	     86108 ns/op	  47.57 MB/s	     497 B/op	      12 allocs/op
$ cat benchmark.log | grep allocs/op
   15798	     75712 ns/op	  13.52 MB/s	     453 B/op	      12 allocs/op
   24147	     48498 ns/op	  21.11 MB/s	     496 B/op	      12 allocs/op
   14484	     81832 ns/op	  50.05 MB/s	     499 B/op	      12 allocs/op
```

This is the same as https://github.com/uber/tchannel-go/pull/792 which has history, but the previous change was reverted.