### PR TITLE
Optimize KVIterator and typed.ReadBuffer for 25% improvement

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -146,9 +146,7 @@ func assertRoundTrip(t *testing.T, expected message, actual message) {
 	var b bytes.Buffer
 	w.FlushTo(&b)
 
-	r := typed.NewReadBufferWithSize(1024)
-	_, err := r.FillFrom(bytes.NewReader(b.Bytes()), len(b.Bytes()))
-	require.Nil(t, err)
+	r := typed.NewReadBuffer(b.Bytes())
 	require.Nil(t, actual.read(r), fmt.Sprintf("error reading message %v", expected.messageType()))
 
 	assert.Equal(t, expected, actual, fmt.Sprintf("pre- and post-marshal %v do not match", expected.messageType()))

--- a/thrift/arg2/kv_iterator.go
+++ b/thrift/arg2/kv_iterator.go
@@ -5,6 +5,7 @@
 package arg2
 
 import (
+	"encoding/binary"
 	"io"
 
 	"github.com/uber/tchannel-go/typed"
@@ -15,7 +16,6 @@ import (
 // NOTE: to be optimized for performance, we try to limit the allocation
 // done in the process of iteration.
 type KeyValIterator struct {
-	arg2Len       int
 	remaining     []byte
 	leftPairCount int
 	key           []byte
@@ -30,14 +30,10 @@ func NewKeyValIterator(arg2Payload []byte) (KeyValIterator, error) {
 		return KeyValIterator{}, io.EOF
 	}
 
-	// We don't hold on to rbuf to avoid the associated alloc
-	rbuf := typed.NewReadBuffer(arg2Payload)
-	leftPairCount := rbuf.ReadUint16()
-
+	leftPairCount := binary.BigEndian.Uint16(arg2Payload[0:2])
 	return KeyValIterator{
-		arg2Len:       len(arg2Payload),
 		leftPairCount: int(leftPairCount),
-		remaining:     arg2Payload[rbuf.BytesRead():],
+		remaining:     arg2Payload[2:],
 	}.Next()
 }
 
@@ -51,9 +47,17 @@ func (i KeyValIterator) Value() []byte {
 	return i.val
 }
 
+// Remaining returns whether there's any pairs left to consume.
+func (i KeyValIterator) Remaining() bool {
+	return i.leftPairCount > 0
+}
+
 // Next returns next iterator. Return io.EOF if no more key/value pair is
 // available.
-func (i KeyValIterator) Next() (KeyValIterator, error) {
+//
+// Note: We used named returns because of an unexpected performance improvement
+// See https://github.com/golang/go/issues/40638
+func (i KeyValIterator) Next() (kv KeyValIterator, _ error) {
 	if i.leftPairCount <= 0 {
 		return KeyValIterator{}, io.EOF
 	}
@@ -69,11 +73,11 @@ func (i KeyValIterator) Next() (KeyValIterator, error) {
 
 	leftPairCount := i.leftPairCount - 1
 
-	return KeyValIterator{
-		arg2Len:       i.arg2Len,
-		remaining:     i.remaining[rbuf.BytesRead():],
+	kv = KeyValIterator{
+		remaining:     rbuf.Remaining(),
 		leftPairCount: leftPairCount,
 		key:           key,
 		val:           val,
-	}, nil
+	}
+	return kv, nil
 }

--- a/thrift/arg2/kv_iterator_test.go
+++ b/thrift/arg2/kv_iterator_test.go
@@ -27,7 +27,11 @@ func TestKeyValIterator(t *testing.T) {
 	for i := 0; i < nh; i++ {
 		assert.NoError(t, err)
 		gotKV[fmt.Sprintf("key%v", i)] = fmt.Sprintf("value%v", i)
+
+		remaining := iter.Remaining()
 		iter, err = iter.Next()
+
+		assert.Equal(t, err == nil, remaining, "Expect remaining to be true if there's no errors")
 	}
 	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, kv, gotKV)
@@ -104,8 +108,15 @@ func BenchmarkKeyValIterator(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		iter, err := NewKeyValIterator(kvBuffer)
-		for err == nil {
+		if err != nil {
+			b.Fatalf("unexpected err %v", err)
+		}
+
+		for iter.Remaining() {
 			iter, err = iter.Next()
+			if err != nil {
+				b.Fatalf("unexpected err %v", err)
+			}
 		}
 	}
 }

--- a/typed/buffer_test.go
+++ b/typed/buffer_test.go
@@ -96,7 +96,7 @@ func TestReadBufferTracking(t *testing.T) {
 		t.Run("nothing read", func(t *testing.T) {
 			assert.Equal(t, len(bs), rbuf.BytesRemaining(), "BytesRemaining")
 			assert.Equal(t, bs, rbuf.Remaining(), "Remaining")
-			assert.Zero(t, rbuf.BytesRead()m "BytesRead")
+			assert.Zero(t, rbuf.BytesRead(), "BytesRead")
 		})
 
 		t.Run("partially consumed", func(t *testing.T) {

--- a/typed/buffer_test.go
+++ b/typed/buffer_test.go
@@ -88,8 +88,8 @@ func TestReadBufferTracking(t *testing.T) {
 
 	// Run twice, once on the original buffer, and once after wrapping.
 	rbuf := NewReadBuffer(bs)
-	for i := 0; i < 2; i++ {
-		if i == 1 {
+	for _, wrap := range []bool{false, true} {
+		if wrap {
 			rbuf.Wrap(bs)
 		}
 

--- a/typed/buffer_test.go
+++ b/typed/buffer_test.go
@@ -81,27 +81,44 @@ func TestReadWrite(t *testing.T) {
 	w.WriteLen8String("hello")
 	w.WriteLen16String("This is a much larger string")
 	require.NoError(t, w.Err())
+}
 
-	var b bytes.Buffer
-	w.FlushTo(&b)
+func TestReadBufferTracking(t *testing.T) {
+	bs := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
-	r := NewReadBufferWithSize(1024)
-	r.FillFrom(bytes.NewReader(b.Bytes()), len(b.Bytes()))
+	// Run twice, once on the original buffer, and once after wrapping.
+	rbuf := NewReadBuffer(bs)
+	for i := 0; i < 2; i++ {
+		if i == 1 {
+			rbuf.Wrap(bs)
+		}
 
-	assert.Equal(t, uint64(0x0123456789ABCDEF), r.ReadUint64())
-	assert.Equal(t, uint32(0xABCDEF01), r.ReadUint32())
-	assert.Equal(t, uint16(0x2345), r.ReadUint16())
-	assert.Equal(t, uint64(1), r.ReadUvarint())
-	assert.Equal(t, uint64(math.MaxInt16), r.ReadUvarint())
-	assert.Equal(t, uint64(math.MaxInt32), r.ReadUvarint())
-	assert.Equal(t, uint64(math.MaxInt64), r.ReadUvarint())
-	assert.Equal(t, byte(0xFF), r.ReadSingleByte())
-	assert.Equal(t, s, r.ReadString(len(s)))
-	assert.Equal(t, bslice, r.ReadBytes(len(bslice)))
-	assert.Equal(t, "hello", r.ReadLen8String())
-	assert.Equal(t, "This is a much larger string", r.ReadLen16String())
+		t.Run("nothing read", func(t *testing.T) {
+			assert.Equal(t, len(bs), rbuf.BytesRemaining(), "BytesRemaining")
+			assert.Equal(t, bs, rbuf.Remaining(), "Remaining")
+			assert.Zero(t, rbuf.BytesRead()m "BytesRead")
+		})
 
-	require.NoError(t, r.Err())
+		t.Run("partially consumed", func(t *testing.T) {
+			rbuf.ReadByte()
+			rbuf.ReadUint32()
+
+			assert.Equal(t, 5, rbuf.BytesRemaining(), "BytesRemaining")
+			assert.Equal(t, bs[5:], rbuf.Remaining(), "Remaining")
+			assert.Equal(t, 5, rbuf.BytesRead(), "BytesRead")
+		})
+
+		t.Run("fully consumed", func(t *testing.T) {
+			rbuf.ReadByte()
+			rbuf.ReadUint32()
+
+			assert.Zero(t, rbuf.BytesRemaining(), "BytesRemaining")
+			assert.Empty(t, rbuf.Remaining(), "Remaining")
+			assert.Equal(t, len(bs), rbuf.BytesRead(), "BytesRead")
+		})
+
+		require.NoError(t, rbuf.Err())
+	}
 }
 
 func TestDeferredWrites(t *testing.T) {


### PR DESCRIPTION
As part of #792, we moved to typed.ReadBuffer which is much more
readable than direct binary translations, but we lost a little
bit of performance on the KV iterator,

Original:
```
BenchmarkKeyValIterator-12      52558426                66.7 ns/op
```

With typed.ReadBuffer:
```
BenchmarkKeyValIterator-12      34918740               101 ns/op
```

WIth these optimizations, performance is close to the original:
```
BenchmarkKeyValIterator-12      46994628                76.1 ns/op
```

This change has the following optimizations:

 * Make ReadBuffer smaller by 2 words (replace []byte with int). This
   gets rid of the Fill functionality, which was never used in any
   production code anyway.
 * Don't create a read buffer for single Uint16 read when creating KeyValueIterator
 * Instead of using io.EOF to check for end of all headers, add a Remaining method
   which returns a bool (vs the Next method which returns > 10 words). We were
   spending time just copying the large struct values on the stack after the last
   header read.
 * Simplify how the KeyValueIterator.Next method creates remaining by adding method
   directly to the ReadBuffer.
 * Use named returns in KeyValueIterator.Next which give an unexpected ~6% performance
   improvement. Filed https://github.com/golang/go/issues/40638 as we'd like to avoid
   named returns here.