### PR TITLE
Switch to pointer receivers for CallFrame implementations

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -398,7 +398,7 @@ func (r *Relayer) handleCallReq(f lazyCallReq) error {
 		return nil
 	}
 
-	call, err := r.relayHost.Start(f, r.relayConn)
+	call, err := r.relayHost.Start(&f, r.relayConn)
 	if err != nil {
 		// If we have a RateLimitDropError we record the statistic, but
 		// we *don't* send an error frame back to the client.

--- a/relay.go
+++ b/relay.go
@@ -355,7 +355,7 @@ func (r *Relayer) canHandleNewCall() (bool, connectionState) {
 	return canHandle, curState
 }
 
-func (r *Relayer) getDestination(f lazyCallReq, call RelayCall) (*Connection, bool, error) {
+func (r *Relayer) getDestination(f *lazyCallReq, call RelayCall) (*Connection, bool, error) {
 	if _, ok := r.outbound.Get(f.Header.ID); ok {
 		r.logger.WithFields(
 			LogField{"id", f.Header.ID},
@@ -393,12 +393,12 @@ func (r *Relayer) getDestination(f lazyCallReq, call RelayCall) (*Connection, bo
 	return remoteConn, true, nil
 }
 
-func (r *Relayer) handleCallReq(f lazyCallReq) error {
+func (r *Relayer) handleCallReq(f *lazyCallReq) error {
 	if handled := r.handleLocalCallReq(f); handled {
 		return nil
 	}
 
-	call, err := r.relayHost.Start(&f, r.relayConn)
+	call, err := r.relayHost.Start(f, r.relayConn)
 	if err != nil {
 		// If we have a RateLimitDropError we record the statistic, but
 		// we *don't* send an error frame back to the client.
@@ -625,7 +625,7 @@ func (r *Relayer) receiverItems(fType frameType) *relayItems {
 	return r.outbound
 }
 
-func (r *Relayer) handleLocalCallReq(cr lazyCallReq) bool {
+func (r *Relayer) handleLocalCallReq(cr *lazyCallReq) bool {
 	// Check whether this is a service we want to handle locally.
 	if _, ok := r.localHandler[string(cr.Service())]; !ok {
 		return false

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -102,12 +102,12 @@ type lazyCallReq struct {
 
 // TODO: Consider pooling lazyCallReq and using pointers to the struct.
 
-func newLazyCallReq(f *Frame) (lazyCallReq, error) {
+func newLazyCallReq(f *Frame) (*lazyCallReq, error) {
 	if msgType := f.Header.messageType; msgType != messageTypeCallReq {
 		panic(fmt.Errorf("newLazyCallReq called for wrong messageType: %v", msgType))
 	}
 
-	cr := lazyCallReq{Frame: f}
+	cr := &lazyCallReq{Frame: f}
 
 	serviceLen := f.Payload[_serviceLenIndex]
 	// nh:1 (hk~1 hv~1){nh}
@@ -152,7 +152,7 @@ func newLazyCallReq(f *Frame) (lazyCallReq, error) {
 	cr.isArg2Fragmented = rbuf.BytesRemaining() == 0 && cr.HasMoreFragments()
 
 	if rbuf.Err() != nil {
-		return lazyCallReq{}, rbuf.Err()
+		return nil, rbuf.Err()
 	}
 
 	return cr, nil

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -159,69 +159,69 @@ func newLazyCallReq(f *Frame) (lazyCallReq, error) {
 }
 
 // Caller returns the name of the originator of this callReq.
-func (f lazyCallReq) Caller() []byte {
+func (f *lazyCallReq) Caller() []byte {
 	return f.caller
 }
 
 // Service returns the name of the destination service for this callReq.
-func (f lazyCallReq) Service() []byte {
+func (f *lazyCallReq) Service() []byte {
 	l := f.Payload[_serviceLenIndex]
 	return f.Payload[_serviceNameIndex : _serviceNameIndex+l]
 }
 
 // Method returns the name of the method being called.
-func (f lazyCallReq) Method() []byte {
+func (f *lazyCallReq) Method() []byte {
 	return f.method
 }
 
 // RoutingDelegate returns the routing delegate for this call req, if any.
-func (f lazyCallReq) RoutingDelegate() []byte {
+func (f *lazyCallReq) RoutingDelegate() []byte {
 	return f.delegate
 }
 
 // RoutingKey returns the routing delegate for this call req, if any.
-func (f lazyCallReq) RoutingKey() []byte {
+func (f *lazyCallReq) RoutingKey() []byte {
 	return f.key
 }
 
 // TTL returns the time to live for this callReq.
-func (f lazyCallReq) TTL() time.Duration {
+func (f *lazyCallReq) TTL() time.Duration {
 	ttl := binary.BigEndian.Uint32(f.Payload[_ttlIndex : _ttlIndex+_ttlLen])
 	return time.Duration(ttl) * time.Millisecond
 }
 
 // SetTTL overwrites the frame's TTL.
-func (f lazyCallReq) SetTTL(d time.Duration) {
+func (f *lazyCallReq) SetTTL(d time.Duration) {
 	ttl := uint32(d / time.Millisecond)
 	binary.BigEndian.PutUint32(f.Payload[_ttlIndex:_ttlIndex+_ttlLen], ttl)
 }
 
 // Span returns the Span
-func (f lazyCallReq) Span() Span {
+func (f *lazyCallReq) Span() Span {
 	return callReqSpan(f.Frame)
 }
 
 // HasMoreFragments returns whether the callReq has more fragments.
-func (f lazyCallReq) HasMoreFragments() bool {
+func (f *lazyCallReq) HasMoreFragments() bool {
 	return f.Payload[_flagsIndex]&hasMoreFragmentsFlag != 0
 }
 
 // Arg2EndOffset returns the offset from start of payload to the end of Arg2
 // in bytes, and hasMore to be true if there are more frames and arg3 has
 // not started.
-func (f lazyCallReq) Arg2EndOffset() (_ int, hasMore bool) {
+func (f *lazyCallReq) Arg2EndOffset() (_ int, hasMore bool) {
 	return f.arg2EndOffset, f.isArg2Fragmented
 }
 
 // Arg2StartOffset returns the offset from start of payload to the beginning
 // of Arg2 in bytes.
-func (f lazyCallReq) Arg2StartOffset() int {
+func (f *lazyCallReq) Arg2StartOffset() int {
 	return f.arg2StartOffset
 }
 
 // Arg2Iterator returns the iterator for reading Arg2 key value pair
 // of TChannel-Thrift Arg Scheme.
-func (f lazyCallReq) Arg2Iterator() (arg2.KeyValIterator, error) {
+func (f *lazyCallReq) Arg2Iterator() (arg2.KeyValIterator, error) {
 	if !bytes.Equal(f.as, _tchanThriftValueBytes) {
 		return arg2.KeyValIterator{}, fmt.Errorf("non thrift scheme %s", f.as)
 	}

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -60,7 +60,7 @@ func (cr testCallReq) req(tb testing.TB) lazyCallReq {
 func (cr testCallReq) reqWithParams(tb testing.TB, p testCallReqParams) lazyCallReq {
 	lcr, err := newLazyCallReq(cr.frameWithParams(p))
 	require.NoError(tb, err)
-	return lcr
+	return *lcr
 }
 
 func (cr testCallReq) frameWithParams(p testCallReqParams) *Frame {

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -108,62 +108,62 @@ type FakeCallFrame struct {
 	hasArg2KVIterator error
 }
 
-var _ relay.CallFrame = FakeCallFrame{}
+var _ relay.CallFrame = &FakeCallFrame{}
 
 // TTL returns the TTL field.
-func (f FakeCallFrame) TTL() time.Duration {
+func (f *FakeCallFrame) TTL() time.Duration {
 	return f.TTLF
 }
 
 // Service returns the service name field.
-func (f FakeCallFrame) Service() []byte {
+func (f *FakeCallFrame) Service() []byte {
 	return []byte(f.ServiceF)
 }
 
 // Method returns the method field.
-func (f FakeCallFrame) Method() []byte {
+func (f *FakeCallFrame) Method() []byte {
 	return []byte(f.MethodF)
 }
 
 // Caller returns the caller field.
-func (f FakeCallFrame) Caller() []byte {
+func (f *FakeCallFrame) Caller() []byte {
 	return []byte(f.CallerF)
 }
 
 // RoutingKey returns the routing delegate field.
-func (f FakeCallFrame) RoutingKey() []byte {
+func (f *FakeCallFrame) RoutingKey() []byte {
 	return []byte(f.RoutingKeyF)
 }
 
 // RoutingDelegate returns the routing delegate field.
-func (f FakeCallFrame) RoutingDelegate() []byte {
+func (f *FakeCallFrame) RoutingDelegate() []byte {
 	return []byte(f.RoutingDelegateF)
 }
 
 // Arg2StartOffset returns the offset from start of payload to
 // the beginning of Arg2.
-func (f FakeCallFrame) Arg2StartOffset() int {
+func (f *FakeCallFrame) Arg2StartOffset() int {
 	return f.Arg2StartOffsetVal
 }
 
 // Arg2EndOffset returns the offset from start of payload to the end
 // of Arg2 and whether Arg2 is fragmented.
-func (f FakeCallFrame) Arg2EndOffset() (int, bool) {
+func (f *FakeCallFrame) Arg2EndOffset() (int, bool) {
 	return f.Arg2EndOffsetVal, f.IsArg2Fragmented
 }
 
 // Arg2Iterator returns the iterator for reading Arg2 key value pair
 // of TChannel-Thrift Arg Scheme.
-func (f FakeCallFrame) Arg2Iterator() (arg2.KeyValIterator, error) {
+func (f *FakeCallFrame) Arg2Iterator() (arg2.KeyValIterator, error) {
 	return f.arg2KVIterator, f.hasArg2KVIterator
 }
 
 // CopyCallFrame copies the relay.CallFrame and returns a FakeCallFrame with
 // corresponding values
-func CopyCallFrame(f relay.CallFrame) FakeCallFrame {
+func CopyCallFrame(f relay.CallFrame) *FakeCallFrame {
 	endOffset, hasMore := f.Arg2EndOffset()
 	copyIterator, err := copyThriftArg2KVIterator(f)
-	return FakeCallFrame{
+	return &FakeCallFrame{
 		TTLF:               f.TTL(),
 		ServiceF:           string(f.Service()),
 		MethodF:            string(f.Method()),


### PR DESCRIPTION
In order to support arg2 appends in the relayer, we must allow mutations to implementations of the `relay.CallFrame` interface so that we are able to allow mutations in `RelayHost.Start()`.

This change changes the method receivers of `lazyCallReq` and `FakeCallFrame` to pointers, so that we may extend the `CallFrame` interface with methods such as `Arg2Append()` later.