### PR TITLE
relay: Add test framework to validate arg2 modification

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/uber/tchannel-go/testutils"
 	"github.com/uber/tchannel-go/testutils/testreader"
 	"github.com/uber/tchannel-go/testutils/thriftarg2test"
+	"github.com/uber/tchannel-go/thrift"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1360,4 +1361,208 @@ func inspectFrames(rh *relaytest.StubRelayHost) chan relay.CallFrame {
 		frameCh <- testutils.CopyCallFrame(f)
 	})
 	return frameCh
+}
+
+func TestRelayModifyArg2(t *testing.T) {
+	// largeKey := testutils.RandString(378)
+	// largeVal := testutils.RandString(65000)
+	largePayload := testutils.RandString(1024)
+
+	modifyTests := []struct {
+		msg         string
+		skip        string
+		modifyFrame func(relay.CallFrame, *relay.Conn)
+		modifyArg2  func(arg2 map[string]string)
+	}{
+		{
+			msg:         "no change",
+			modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {},
+			modifyArg2: func(arg2 map[string]string) {
+				// no change
+			},
+		},
+		// TODO(echung): Enable once we have frame modification.
+		// {
+		// 	msg: "add small key/value",
+		// 	modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {
+		// 		cf.Arg2Append([]byte("key"), []byte("value"))
+		// 	},
+		// 	modifyArg2: func(m map[string]string) {
+		// 		m["key"] = "value"
+		// 	},
+		// },
+		// {
+		// 	msg: "add large key/value",
+		// 	modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {
+		// 		cf.Arg2Append([]byte(largeKey), []byte(largeVal))
+		// 	},
+		// 	modifyArg2: func(m map[string]string) {
+		// 		m[largeKey] = largeVal
+		// 	},
+		// },
+	}
+
+	checksumTypes := []struct {
+		msg          string
+		checksumType ChecksumType
+	}{
+		{"none", ChecksumTypeNone},
+		{"crc32", ChecksumTypeCrc32},
+		{"farmhash", ChecksumTypeFarmhash},
+		{"crc32c", ChecksumTypeCrc32C},
+	}
+
+	payloadTests := []struct {
+		msg  string
+		arg2 map[string]string
+		arg3 []byte
+	}{
+		{
+			msg:  "no payload",
+			arg2: nil, // empty map
+			arg3: []byte{},
+		},
+		{
+			msg: "small payloads",
+			arg2: map[string]string{
+				"existingKey": "existingValue",
+			},
+			arg3: []byte("hello world"),
+		},
+		{
+			msg: "large payloads",
+			arg2: map[string]string{
+				"existingKey": "existingValue",
+			},
+			arg3: []byte(largePayload),
+		},
+	}
+
+	const (
+		format      = Thrift
+		noErrMethod = "EchoVerifyNoErr"
+		errMethod   = "EchoVerifyErr"
+	)
+
+	appErrTests := []struct {
+		msg        string
+		method     string
+		wantAppErr bool
+	}{
+		{
+			msg:        "no app error bit",
+			method:     noErrMethod,
+			wantAppErr: false,
+		},
+		{
+			msg:        "app error bit",
+			method:     errMethod,
+			wantAppErr: true,
+		},
+	}
+
+	for _, mt := range modifyTests {
+		for _, csTest := range checksumTypes {
+			t.Run(mt.msg+"/checksum="+csTest.msg, func(t *testing.T) {
+				// Create a relay that will modify the frame as per the test.
+				relayHost := relaytest.NewStubRelayHost()
+				relayHost.SetFrameFn(mt.modifyFrame)
+				opts := testutils.NewOpts().
+					SetRelayHost(relayHost).
+					SetRelayOnly()
+				testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
+					// Create a client that uses a specific checksumType.
+					clientOpts := testutils.NewOpts().SetChecksumType(csTest.checksumType)
+					client := ts.NewClient(clientOpts)
+					defer client.Close()
+
+					// Create a server echo verify endpoints (optionally returning an error).
+					for _, appErrTest := range appErrTests {
+						handler := echoVerifyHandler{
+							t:            t,
+							verifyFormat: format,
+							verifyCaller: client.ServiceName(),
+							verifyMethod: appErrTest.method,
+							appErr:       appErrTest.wantAppErr,
+						}
+						ts.Server().Register(raw.Wrap(handler), appErrTest.method)
+					}
+
+					ctx, cancel := NewContextBuilder(testutils.Timeout(time.Second)).
+						SetFormat(format).Build()
+					defer cancel()
+
+					// Make calls with different payloads and expected errors.
+					for _, aet := range appErrTests {
+						for _, tt := range payloadTests {
+							arg2Encoded := encodeThriftHeaders(t, tt.arg2)
+
+							resArg2, resArg3, resp, err := raw.Call(ctx, client, ts.HostPort(), ts.ServiceName(), aet.method, arg2Encoded, tt.arg3)
+							require.NoError(t, err, "%v: Received unexpected error", tt.msg)
+							assert.Equal(t, format, resp.Format(), "%v: Unexpected error format")
+							assert.Equal(t, aet.wantAppErr, resp.ApplicationError(), "%v: Unexpected app error")
+
+							wantArg2 := copyHeaders(tt.arg2)
+							mt.modifyArg2(wantArg2)
+
+							gotArg2Map := decodeThriftHeaders(t, resArg2)
+							assert.Equal(t, wantArg2, gotArg2Map, "%v: Unexpected arg2 headers", tt.msg)
+							assert.Equal(t, resArg3, tt.arg3, "%v: Unexpected arg3", tt.msg)
+						}
+					}
+				})
+			})
+		}
+	}
+}
+
+// echoVerifyHandler is an echo handler with some added verification of
+// the call metadata (e.g., caller, format).
+type echoVerifyHandler struct {
+	t testing.TB
+
+	appErr       bool
+	verifyFormat Format
+	verifyCaller string
+	verifyMethod string
+}
+
+func (h echoVerifyHandler) Handle(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+	assert.Equal(h.t, h.verifyFormat, args.Format, "Unexpected format")
+	assert.Equal(h.t, h.verifyCaller, args.Caller, "Unexpected caller")
+	assert.Equal(h.t, h.verifyMethod, args.Method, "Unexpected method")
+
+	return &raw.Res{
+		Arg2:  args.Arg2,
+		Arg3:  args.Arg3,
+		IsErr: h.appErr,
+	}, nil
+}
+
+func (h echoVerifyHandler) OnError(ctx context.Context, err error) {
+	h.t.Errorf("unexpected OnError: %v", err)
+}
+
+func encodeThriftHeaders(t testing.TB, m map[string]string) []byte {
+	var buf bytes.Buffer
+	require.NoError(t, thrift.WriteHeaders(&buf, m), "Failed to write headers")
+	return buf.Bytes()
+}
+
+func decodeThriftHeaders(t testing.TB, bs []byte) map[string]string {
+	m, err := thrift.ReadHeaders(bytes.NewReader(bs))
+	require.NoError(t, err, "Failed to read headers")
+	return m
+}
+
+func copyHeaders(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+
+	copied := make(map[string]string, len(m))
+	for k, v := range m {
+		copied[k] = v
+	}
+	return copied
 }

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -149,6 +149,12 @@ func (o *ChannelOpts) SetTosPriority(tosPriority tos.ToS) *ChannelOpts {
 	return o
 }
 
+// SetChecksumType sets the ChecksumType in DefaultConnectionOptions.
+func (o *ChannelOpts) SetChecksumType(checksumType tchannel.ChecksumType) *ChannelOpts {
+	o.DefaultConnectionOptions.ChecksumType = checksumType
+	return o
+}
+
 // SetTimeNow sets TimeNow in ChannelOptions.
 func (o *ChannelOpts) SetTimeNow(timeNow func() time.Time) *ChannelOpts {
 	o.TimeNow = timeNow

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -270,6 +270,8 @@ func (ts *TestServer) NewClient(opts *ChannelOpts) *tchannel.Channel {
 }
 
 // NewServer returns a server with log and channel state verification.
+//
+// Note: The same default service name is used if one isn't specified.
 func (ts *TestServer) NewServer(opts *ChannelOpts) *tchannel.Channel {
 	ch := ts.addChannel(newServer, opts.Copy())
 	if ts.relayHost != nil {


### PR DESCRIPTION
This adds a test that can be used for arg2 modification tests for
different cases such as:
 * Payload sizes
 * Header sizes
 * Different checksum
 * Different header modifications
 * App error bit set

Enable the "no-op" test, which ensures that without modification, the
server/client validations work as expected (the body/payloads are as
expected, the transport headers such as format match, etc).