### PR TITLE
fragmenting relay 2/n: Update lazyCallReq to return header and args

### DIFF
--- a/relay_messages.go
+++ b/relay_messages.go
@@ -103,7 +103,6 @@ type lazyCallReq struct {
 
 	checksumTypeOffset             uint16
 	arg2StartOffset, arg2EndOffset uint16
-	arg2appends                    []keyVal
 	arg3StartOffset, arg3EndOffset uint16
 
 	checksumType     ChecksumType
@@ -171,7 +170,6 @@ func newLazyCallReq(f *Frame) (*lazyCallReq, error) {
 	if !cr.isArg2Fragmented {
 		// arg3~2
 		arg3Len := rbuf.ReadUint16()
-		fmt.Println("arg3Len=", arg3Len)
 		cr.arg3StartOffset = rbufOffset()
 
 		if uint16(rbuf.BytesRemaining()) < arg3Len {
@@ -269,10 +267,6 @@ func (f *lazyCallReq) Arg2Iterator() (arg2.KeyValIterator, error) {
 	}
 
 	return arg2.NewKeyValIterator(f.Payload[f.arg2StartOffset:f.arg2EndOffset])
-}
-
-func (f *lazyCallReq) Arg2Append(key, val []byte) {
-	f.arg2appends = append(f.arg2appends, keyVal{key, val})
 }
 
 // finishesCall checks whether this frame is the last one we should expect for

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -98,7 +98,7 @@ type lazyCallReq struct {
 
 	checksumTypeOffset             uint16
 	arg2StartOffset, arg2EndOffset uint16
-	arg3StartOffset, arg3EndOffset uint16
+	arg3StartOffset                uint16
 
 	checksumType     ChecksumType
 	isArg2Fragmented bool
@@ -155,12 +155,8 @@ func newLazyCallReq(f *Frame) (*lazyCallReq, error) {
 	cr.arg2EndOffset = cr.arg2StartOffset + arg2Len
 
 	// arg2 is fragmented if we don't see arg3 in this frame.
-	if uint16(rbuf.BytesRemaining()) <= arg2Len {
-		rbuf.SkipBytes(rbuf.BytesRemaining())
-		cr.isArg2Fragmented = cr.HasMoreFragments()
-	} else {
-		rbuf.SkipBytes(int(arg2Len))
-	}
+	rbuf.SkipBytes(int(arg2Len))
+	cr.isArg2Fragmented = rbuf.BytesRemaining() == 0 && cr.HasMoreFragments()
 
 	if !cr.isArg2Fragmented {
 		// arg3~2

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -246,12 +246,6 @@ func (f *lazyCallReq) Arg2Iterator() (arg2.KeyValIterator, error) {
 	if !bytes.Equal(f.as, _tchanThriftValueBytes) {
 		return arg2.KeyValIterator{}, fmt.Errorf("non thrift scheme %s", f.as)
 	}
-
-	// TODO(echung): drop this since we already do error checks in the constructor
-	if f.arg2EndOffset > f.Header.PayloadSize() {
-		return arg2.KeyValIterator{}, errBadArg2Len
-	}
-
 	return arg2.NewKeyValIterator(f.Payload[f.arg2StartOffset:f.arg2EndOffset])
 }
 

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -247,6 +247,7 @@ func (f *lazyCallReq) Arg2Iterator() (arg2.KeyValIterator, error) {
 		return arg2.KeyValIterator{}, fmt.Errorf("non thrift scheme %s", f.as)
 	}
 
+	// TODO(echung): drop this since we already do error checks in the constructor
 	if f.arg2EndOffset > f.Header.PayloadSize() {
 		return arg2.KeyValIterator{}, errBadArg2Len
 	}

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -121,8 +121,8 @@ func newLazyCallReq(f *Frame) (*lazyCallReq, error) {
 	rbuf.SkipBytes(int(serviceLen))
 
 	// nh:1 (hk~1 hv~1){nh}
-	numHeaders := rbuf.ReadSingleByte()
-	for i := byte(0); i < numHeaders; i++ {
+	numHeaders := int(rbuf.ReadSingleByte())
+	for i := 0; i < numHeaders; i++ {
 		keyLen := int(rbuf.ReadSingleByte())
 		key := rbuf.ReadBytes(keyLen)
 

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -164,14 +164,8 @@ func newLazyCallReq(f *Frame) (*lazyCallReq, error) {
 
 	if !cr.isArg2Fragmented {
 		// arg3~2
-		arg3Len := rbuf.ReadUint16()
+		rbuf.SkipBytes(2)
 		cr.arg3StartOffset = uint16(rbuf.BytesRead())
-
-		if uint16(rbuf.BytesRemaining()) < arg3Len {
-			cr.arg3EndOffset = cr.arg3StartOffset + uint16(rbuf.BytesRemaining())
-		} else {
-			cr.arg3EndOffset = cr.arg3StartOffset + arg3Len
-		}
 	}
 
 	if rbuf.Err() != nil {
@@ -247,7 +241,7 @@ func (f *lazyCallReq) arg2() []byte {
 }
 
 func (f *lazyCallReq) arg3() []byte {
-	return f.Payload[f.arg3StartOffset:f.arg3EndOffset]
+	return f.Payload[f.arg3StartOffset:f.Header.PayloadSize()]
 }
 
 // Arg2Iterator returns the iterator for reading Arg2 key value pair

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -91,11 +91,6 @@ func (cr lazyCallRes) OK() bool {
 	return cr.Payload[_resCodeIndex] == _resCodeOK
 }
 
-type keyVal struct {
-	key []byte
-	val []byte
-}
-
 type lazyCallReq struct {
 	*Frame
 

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -237,7 +237,7 @@ func (f *lazyCallReq) arg2() []byte {
 }
 
 func (f *lazyCallReq) arg3() []byte {
-	return f.Payload[f.arg3StartOffset:f.Header.PayloadSize()]
+	return f.SizedPayload()[f.arg3StartOffset:]
 }
 
 // Arg2Iterator returns the iterator for reading Arg2 key value pair

--- a/relay_messages_benchmark_test.go
+++ b/relay_messages_benchmark_test.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkCallReqFrame(b *testing.B) {
@@ -37,7 +35,9 @@ func BenchmarkCallReqFrame(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cr, err := newLazyCallReq(f)
-		require.NoError(b, err)
+		if err != nil {
+			b.Fatal("Unexpected error")
+		}
 
 		// Multiple calls due to peer selection, stats, etc.
 		for i := 0; i < 3; i++ {

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -45,6 +45,14 @@ const (
 	reqHasAll testCallReq = reqTotalCombinations - 1
 )
 
+var (
+	exampleArg2Map = map[string]string{
+		"foo": "bar",
+		"baz": "qux",
+	}
+	exampleArg3Data = "some arg3 data"
+)
+
 type testCallReqParams struct {
 	flags           byte
 	hasTChanThrift  bool
@@ -569,11 +577,8 @@ func uint16KeyValToMap(tb testing.TB, buffer []byte) map[string]string {
 
 func TestLazyCallReqContents(t *testing.T) {
 	cr := reqHasAll.reqWithParams(t, testCallReqParams{
-		arg2Buf: thriftarg2test.BuildKVBuffer(map[string]string{
-			"foo": "bar",
-			"baz": "qux",
-		}),
-		arg3Buf: []byte("some arg3 data"),
+		arg2Buf: thriftarg2test.BuildKVBuffer(exampleArg2Map),
+		arg3Buf: []byte(exampleArg3Data),
 	})
 
 	t.Run("checksum", func(t *testing.T) {
@@ -582,15 +587,11 @@ func TestLazyCallReqContents(t *testing.T) {
 	})
 
 	t.Run(".arg2()", func(t *testing.T) {
-		wantHeaders := map[string]string{
-			"baz": "qux",
-			"foo": "bar",
-		}
-		assert.Equal(t, wantHeaders, uint16KeyValToMap(t, cr.arg2()), "Got unexpected headers")
+		assert.Equal(t, exampleArg2Map, uint16KeyValToMap(t, cr.arg2()), "Got unexpected headers")
 	})
 
 	t.Run(".arg3()", func(t *testing.T) {
 		// TODO(echung): switch to assert.Equal once we have more robust test frame generation
-		assert.Contains(t, string(cr.arg3()), "some arg3 data", "Got unexpected headers")
+		assert.Contains(t, string(cr.arg3()), exampleArg3Data, "Got unexpected headers")
 	})
 }

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -588,4 +588,9 @@ func TestLazyCallReqContents(t *testing.T) {
 		}
 		assert.Equal(t, wantHeaders, uint16KeyValToMap(t, cr.arg2()), "Got unexpected headers")
 	})
+
+	t.Run(".arg3()", func(t *testing.T) {
+		// TODO(echung): switch to assert.Equal once we have more robust test frame generation
+		assert.Contains(t, string(cr.arg3()), "some arg3 data", "Got unexpected headers")
+	})
 }

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -114,7 +114,9 @@ func (cr testCallReq) frameWithParams(p testCallReqParams) *Frame {
 	}
 	payload.WriteUint16(uint16(arg2Len))
 	payload.WriteBytes(p.arg2Buf)
-	payload.WriteUint16(uint16(len(p.arg3Buf)))
+
+	arg3Len := len(p.arg3Buf)
+	payload.WriteUint16(uint16(arg3Len))
 	payload.WriteBytes(p.arg3Buf)
 
 	return f
@@ -307,56 +309,6 @@ func TestLazyCallReqSetTTL(t *testing.T) {
 		cr := crt.req(t)
 		cr.SetTTL(time.Second)
 		assert.Equal(t, time.Second, cr.TTL(), "Failed to write TTL to frame.")
-	})
-}
-
-// TODO(cinchurge): replace with e.g. decodeThriftHeader once we've resolved the import cycle
-func uint16KeyValToMap(tb testing.TB, buffer []byte) map[string]string {
-	rbuf := typed.NewReadBuffer(buffer)
-	nh := int(rbuf.ReadUint16())
-	retMap := make(map[string]string, nh)
-	for i := 0; i < nh; i++ {
-		keyLen := int(rbuf.ReadUint16())
-		key := rbuf.ReadBytes(keyLen)
-		valLen := int(rbuf.ReadUint16())
-		val := rbuf.ReadBytes(valLen)
-		retMap[string(key)] = string(val)
-	}
-	require.NoError(tb, rbuf.Err())
-	return retMap
-}
-
-func TestLazyCallReqContents(t *testing.T) {
-	cr := reqHasAll.reqWithParams(t, testCallReqParams{
-		arg2Buf: thriftarg2test.BuildKVBuffer(map[string]string{
-			"foo": "bar",
-			"baz": "qux",
-		}),
-		arg3Buf: []byte("some arg3 data"),
-	})
-
-	t.Run(".header()", func(t *testing.T) {
-		gotTP := make(transportHeaders)
-		gotTP.read(typed.NewReadBuffer(cr.transportHeader()))
-		assert.Equal(t, transportHeaders{
-			"cn":      "fake-caller",
-			"k1":      "v1",
-			"k222222": "",
-			"k3":      "thisisalonglongkey",
-			"rd":      "fake-delegate",
-			"rk":      "fake-routingkey",
-		}, gotTP)
-	})
-
-	t.Run(".arg2()", func(t *testing.T) {
-		assert.Equal(t, map[string]string{
-			"baz": "qux",
-			"foo": "bar",
-		}, uint16KeyValToMap(t, cr.arg2()))
-	})
-
-	t.Run(".arg3()", func(t *testing.T) {
-		assert.Equal(t, "some arg3 data", string(cr.arg3()))
 	})
 }
 
@@ -596,5 +548,49 @@ func TestLazyErrorCodes(t *testing.T) {
 	withLazyErrorCombinations(func(ec SystemErrCode) {
 		f := ec.fakeErrFrame()
 		assert.Equal(t, ec, f.Code(), "Mismatch between error code and lazy frame's Code() method.")
+	})
+}
+
+// TODO(cinchurge): replace with e.g. decodeThriftHeader once we've resolved the import cycle
+func uint16KeyValToMap(tb testing.TB, buffer []byte) map[string]string {
+	rbuf := typed.NewReadBuffer(buffer)
+	nh := int(rbuf.ReadUint16())
+	retMap := make(map[string]string, nh)
+	for i := 0; i < nh; i++ {
+		keyLen := int(rbuf.ReadUint16())
+		key := rbuf.ReadBytes(keyLen)
+		valLen := int(rbuf.ReadUint16())
+		val := rbuf.ReadBytes(valLen)
+		retMap[string(key)] = string(val)
+	}
+	require.NoError(tb, rbuf.Err())
+	return retMap
+}
+
+func TestLazyCallReqContents(t *testing.T) {
+	cr := reqHasAll.reqWithParams(t, testCallReqParams{
+		arg2Buf: thriftarg2test.BuildKVBuffer(map[string]string{
+			"foo": "bar",
+			"baz": "qux",
+		}),
+		arg3Buf: []byte("some arg3 data"),
+	})
+
+	t.Run("checksum", func(t *testing.T) {
+		assert.Equal(t, ChecksumType(0x3), cr.checksumType)
+		assert.Equal(t, uint16(0x80), cr.checksumTypeOffset)
+	})
+
+	t.Run(".arg2()", func(t *testing.T) {
+		assert.Equal(t, map[string]string{
+			"baz": "qux",
+			"foo": "bar",
+		}, uint16KeyValToMap(t, cr.arg2()))
+	})
+
+	fmt.Println(cr.isArg2Fragmented)
+
+	t.Run(".arg3()", func(t *testing.T) {
+		assert.Equal(t, "some arg3 data", string(cr.arg3()))
 	})
 }

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -587,10 +587,4 @@ func TestLazyCallReqContents(t *testing.T) {
 			"foo": "bar",
 		}, uint16KeyValToMap(t, cr.arg2()))
 	})
-
-	fmt.Println(cr.isArg2Fragmented)
-
-	t.Run(".arg3()", func(t *testing.T) {
-		assert.Equal(t, "some arg3 data", string(cr.arg3()))
-	})
 }

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -577,14 +577,15 @@ func TestLazyCallReqContents(t *testing.T) {
 	})
 
 	t.Run("checksum", func(t *testing.T) {
-		assert.Equal(t, ChecksumType(0x3), cr.checksumType)
-		assert.Equal(t, uint16(0x80), cr.checksumTypeOffset)
+		assert.Equal(t, ChecksumTypeCrc32C, cr.checksumType, "Got unexpected checksum type")
+		assert.Equal(t, byte(ChecksumTypeCrc32C), cr.Frame.Payload[cr.checksumTypeOffset], "Unexpected value read from checksum offset")
 	})
 
 	t.Run(".arg2()", func(t *testing.T) {
-		assert.Equal(t, map[string]string{
+		wantHeaders := map[string]string{
 			"baz": "qux",
 			"foo": "bar",
-		}, uint16KeyValToMap(t, cr.arg2()))
+		}
+		assert.Equal(t, wantHeaders, uint16KeyValToMap(t, cr.arg2()), "Got unexpected headers")
 	})
 }

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -92,6 +92,20 @@ func (r *ReadBuffer) ReadBytes(n int) []byte {
 	return b
 }
 
+func (r *ReadBuffer) SkipBytes(n int) {
+	if r.err != nil {
+		return
+	}
+
+	if len(r.remaining) < n {
+		r.err = ErrEOF
+		return
+	}
+
+	r.remaining = r.remaining[n:]
+	return
+}
+
 // ReadString returns a string of size n from the buffer
 func (r *ReadBuffer) ReadString(n int) string {
 	if b := r.ReadBytes(n); b != nil {

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -92,6 +92,7 @@ func (r *ReadBuffer) ReadBytes(n int) []byte {
 	return b
 }
 
+// SkipBytes skips the next n bytes from the buffer
 func (r *ReadBuffer) SkipBytes(n int) {
 	if r.err != nil {
 		return

--- a/typed/buffer.go
+++ b/typed/buffer.go
@@ -103,7 +103,6 @@ func (r *ReadBuffer) SkipBytes(n int) {
 	}
 
 	r.remaining = r.remaining[n:]
-	return
 }
 
 // ReadString returns a string of size n from the buffer

--- a/typed/buffer_test.go
+++ b/typed/buffer_test.go
@@ -57,6 +57,21 @@ func TestSimple(t *testing.T) {
 	}
 }
 
+func TestSkip(t *testing.T) {
+	buf := make([]byte, 128)
+	for i := 0; i < 128; i++ {
+		buf[i] = byte(i)
+	}
+
+	rbuf := NewReadBuffer(buf)
+	rbuf.SkipBytes(64)
+	gotByte := rbuf.ReadSingleByte()
+	assert.Equal(t, byte(64), gotByte)
+	rbuf.SkipBytes(3)
+	gotByte = rbuf.ReadSingleByte()
+	assert.Equal(t, byte(68), gotByte)
+}
+
 func TestShortBuffer(t *testing.T) {
 	r := NewReadBuffer([]byte{23})
 	assert.EqualValues(t, 0, r.ReadUint16())

--- a/typed/buffer_test.go
+++ b/typed/buffer_test.go
@@ -22,6 +22,7 @@ package typed
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"testing"
 
@@ -57,19 +58,58 @@ func TestSimple(t *testing.T) {
 	}
 }
 
-func TestSkip(t *testing.T) {
-	buf := make([]byte, 128)
-	for i := 0; i < 128; i++ {
-		buf[i] = byte(i)
+func TestReadBufferSkipBytes(t *testing.T) {
+	exampleBytes := make([]byte, 128)
+	tests := []struct {
+		msg           string
+		buf           *ReadBuffer
+		nSkip         int
+		wantError     string
+		wantRead      int
+		wantRemaining int
+	}{
+		{
+			msg:           "successful skip",
+			buf:           NewReadBuffer(exampleBytes),
+			nSkip:         64,
+			wantRead:      64,
+			wantRemaining: 64,
+		},
+		{
+			msg: "error occurred prior to skip",
+			buf: func() *ReadBuffer {
+				buf := NewReadBuffer(exampleBytes)
+				buf.err = errors.New("something bad happened")
+				return buf
+			}(),
+			nSkip:         64,
+			wantError:     "something bad happened",
+			wantRead:      0,
+			wantRemaining: 128,
+		},
+		{
+			msg: "not enough bytes remain",
+			buf: func() *ReadBuffer {
+				buf := NewReadBuffer(exampleBytes)
+				return buf
+			}(),
+			nSkip:         256,
+			wantError:     "buffer is too small",
+			wantRead:      0,
+			wantRemaining: 128,
+		},
 	}
 
-	rbuf := NewReadBuffer(buf)
-	rbuf.SkipBytes(64)
-	gotByte := rbuf.ReadSingleByte()
-	assert.Equal(t, byte(64), gotByte)
-	rbuf.SkipBytes(3)
-	gotByte = rbuf.ReadSingleByte()
-	assert.Equal(t, byte(68), gotByte)
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			tt.buf.SkipBytes(tt.nSkip)
+			if tt.wantError != "" {
+				require.EqualError(t, tt.buf.Err(), tt.wantError, "Didn't get exepcted error")
+			}
+			assert.Equal(t, tt.wantRead, tt.buf.BytesRead())
+			assert.Equal(t, tt.wantRemaining, tt.buf.BytesRemaining())
+		})
+	}
 }
 
 func TestShortBuffer(t *testing.T) {


### PR DESCRIPTION
In order to mutate a frame and potentially do a fragmenting send, we'll need access to the original content of the frame, specifically the header and arguments. This change refactors `newLazyCallReq` to keep track of the offsets of its contents, and adds some methods for exposing the data.