### PR TITLE
Avoid unnecessary frame interface field

### DIFF
--- a/fragmenting_writer.go
+++ b/fragmenting_writer.go
@@ -46,7 +46,7 @@ type writableFragment struct {
 	checksumRef typed.BytesRef
 	checksum    Checksum
 	contents    *typed.WriteBuffer
-	frame       interface{}
+	frame       *Frame
 }
 
 // finish finishes the fragment, updating the final checksum and fragment flags

--- a/reqres.go
+++ b/reqres.go
@@ -141,7 +141,7 @@ func (w *reqResWriter) flushFragment(fragment *writableFragment) error {
 		return w.err
 	}
 
-	frame := fragment.frame.(*Frame)
+	frame := fragment.frame
 	frame.Header.SetPayloadSize(uint16(fragment.contents.BytesWritten()))
 
 	if err := w.mex.checkError(); err != nil {


### PR DESCRIPTION
The writableFragment is only used with a `*Frame`, so there's no need to
use an `interface{}` for the `frame` field.