### PR TITLE
Update CHANGELOG and version in prep for 1.20.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Changelog
 
 ## [1.20.1] - 2020-09-24
 ### Fixed
- * Set ConnContext in the channel instead of the connection (#806)
+ * Set ConnContext in the channel instead of the connection to avoid serialization
+   errors since ConnectionOptions is sometimes embedded in configurations (#806)
 
 ## [1.20.0] - 2020-09-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## [1.20.1] - 2020-09-24
+### Fixed
+ * Set ConnContext in the channel instead of the connection (#806)
+
 ## [1.20.0] - 2020-09-23
 ### Added
  * Support per-connection base context propagation for inbound/outbound connections (#801)
@@ -302,6 +306,7 @@ Changelog
 * Thrift support, including includes.
 
 [//]: # (Version Links)
+[1.20.1]: https://github.com/uber/tchannel-go/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/uber/tchannel-go/compare/v1.19.1...v1.20.0
 [1.18.0]: https://github.com/uber/tchannel-go/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/uber/tchannel-go/compare/v1.16.0...v1.17.0

--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ package tchannel
 // VersionInfo identifies the version of the TChannel library.
 // Due to lack of proper package management, this version string will
 // be maintained manually.
-const VersionInfo = "1.20.0-dev"
+const VersionInfo = "1.20.1"


### PR DESCRIPTION
## [1.20.1] - 2020-09-24
### Fixed
 * Set ConnContext in the channel instead of the connection to avoid serialization
   errors since ConnectionOptions is sometimes embedded in configurations (#806)