### PR TITLE
relay: Add repro for race between timeout/call completion

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -83,6 +83,12 @@ type ChannelOptions struct {
 	// the max connection timeout used.
 	RelayMaxConnectionTimeout time.Duration
 
+	// RelayMaxTombs is the maximum number of timed-out calls that the relay
+	// will keep track of per-connection to avoid spurious logs
+	// for late-arriving frames.
+	// This is an unstable API - breaking changes are likely.
+	RelayMaxTombs uint64
+
 	// RelayTimerVerification will disable pooling of relay timers, and instead
 	// verify that timers are not used once they are released.
 	// This is an unstable API - breaking changes are likely.
@@ -168,6 +174,7 @@ type Channel struct {
 	relayHost           RelayHost
 	relayMaxTimeout     time.Duration
 	relayMaxConnTimeout time.Duration
+	relayMaxTombs       uint64
 	relayTimerVerify    bool
 	internalHandlers    *handlerMap
 	handler             Handler
@@ -289,6 +296,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		relayHost:           opts.RelayHost,
 		relayMaxTimeout:     validateRelayMaxTimeout(opts.RelayMaxTimeout, logger),
 		relayMaxConnTimeout: opts.RelayMaxConnectionTimeout,
+		relayMaxTombs:       opts.RelayMaxTombs,
 		relayTimerVerify:    opts.RelayTimerVerification,
 		dialer:              dialCtx,
 		connContext:         opts.ConnContext,

--- a/relay_test.go
+++ b/relay_test.go
@@ -1056,7 +1056,6 @@ func TestRelayRaceCompletionAndTimeout(t *testing.T) {
 		AddLogFilter("Too many tombstones, deleting relay item immediately.", numCalls).
 		AddLogFilter("Received a frame without a RelayItem.", numCalls).
 		SetRelayOnly()
-	opts.RelayMaxTombs = numCalls / 2
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -1046,11 +1046,17 @@ func TestRelayRaceTimerCausesStuckConnectionOnClose(t *testing.T) {
 }
 
 func TestRelayRaceCompletionAndTimeout(t *testing.T) {
-	const numCalls = 10
+	const numCalls = 100
 
 	opts := testutils.NewOpts().
 		AddLogFilter("simpleHandler OnError.", numCalls).
+		// Trigger deletion on timeout, see https://github.com/uber/tchannel-go/issues/808.
+		SetRelayMaxTombs(numCalls/2).
+		// Hitting max tombs will cause the following logs:
+		AddLogFilter("Too many tombstones, deleting relay item immediately.", numCalls).
+		AddLogFilter("Received a frame without a RelayItem.", numCalls).
 		SetRelayOnly()
+	opts.RelayMaxTombs = numCalls / 2
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
 

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -243,6 +243,12 @@ func (o *ChannelOpts) SetRelayMaxConnectionTimeout(d time.Duration) *ChannelOpts
 	return o
 }
 
+// SetRelayMaxTombs sets the maximum number of tombs tracked in the relayer.
+func (o *ChannelOpts) SetRelayMaxTombs(maxTombs uint64) *ChannelOpts {
+	o.ChannelOptions.RelayMaxTombs = maxTombs
+	return o
+}
+
 // SetOnPeerStatusChanged sets the callback for channel status change
 // noficiations.
 func (o *ChannelOpts) SetOnPeerStatusChanged(f func(*tchannel.Peer)) *ChannelOpts {


### PR DESCRIPTION
Reproduces #808.

To reproduce the race, the relayer needs to hit max tombs. Add a configuration
to the Relayer to set the max tombs so we can drop it for the test.

While the race is not triggered on every run, in 10 runs, the race
detector will flag the issue:
```
=== RUN   TestRelayRaceCompletionAndTimeout/with_relay
==================                                                                                                                                                                                                                                                                                                            WARNING: DATA RACE                                                                                                                                                                                                                                                                                                            Write at 0x00c000520ee2 by goroutine 12:                                                                                                                                                                                                                                                                                        github.com/uber/tchannel-go.(*relayTimer).Release()                                                                                                                                                                                                                                                                               /home/prashant/go/src/github.com/uber/tchannel-go/relay_timer_pool.go:150 +0x7d
  github.com/uber/tchannel-go.(*relayItems).Delete()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay.go:155 +0x21c
  github.com/uber/tchannel-go.(*relayItems).Entomb()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay.go:167 +0x22a
  github.com/uber/tchannel-go.(*Relayer).timeoutRelayItem()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay.go:577 +0x65
  github.com/uber/tchannel-go.(*Relayer).timeoutRelayItem-fm()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay.go:576 +0x5c
  github.com/uber/tchannel-go.(*relayTimer).OnTimer()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay_timer_pool.go:55 +0x194
  github.com/uber/tchannel-go.(*relayTimer).OnTimer-fm()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay_timer_pool.go:51 +0x41

Previous read at 0x00c000520ee2 by goroutine 106:
  github.com/uber/tchannel-go.(*relayTimer).verifyNotReleased()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay_timer_pool.go:155 +0x43
  github.com/uber/tchannel-go.(*relayTimer).Stop()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay_timer_pool.go:128 +0x36
  github.com/uber/tchannel-go.(*Relayer).handleNonCallReq()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay.go:532 +0x362
  github.com/uber/tchannel-go.(*Relayer).Relay()
      /home/prashant/go/src/github.com/uber/tchannel-go/relay.go:255 +0x6a
  github.com/uber/tchannel-go.(*Connection).handleFrameRelay()
      /home/prashant/go/src/github.com/uber/tchannel-go/connection.go:689 +0x96
  github.com/uber/tchannel-go.(*Connection).readFrames()
      /home/prashant/go/src/github.com/uber/tchannel-go/connection.go:678 +0x244
```