### PR TITLE
Update checksum for all frames when calls are mutated by the relayer

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -173,3 +173,12 @@ func (h *hashChecksum) Release() { h.TypeCode().Release(h) }
 
 // Reset resets the checksum state to the default 0 value.
 func (h *hashChecksum) Reset() { h.hash.Reset() }
+
+// noReleaseChecksum overrides .Release() with a NOOP so that the checksum won't
+// be released by the fragmentingWriter when it is managed externally, e.g. by the
+// relayer
+type noReleaseChecksum struct {
+	Checksum
+}
+
+func (n *noReleaseChecksum) Release() {}

--- a/fragmenting_writer.go
+++ b/fragmenting_writer.go
@@ -54,6 +54,9 @@ type writableFragment struct {
 func (f *writableFragment) finish(hasMoreFragments bool) {
 	f.checksumRef.Update(f.checksum.Sum())
 	if hasMoreFragments {
+		// Important: hasMoreFragmentsFlag is set if there are more fragments, but NOT CLEARED if there aren't.
+		// This allows for callReqContinue frames to follow a fragmented callReq frame e.g. when arg2 is modified
+		// by the relayer
 		f.flagsRef.Update(hasMoreFragmentsFlag)
 	} else if !f.dontReleaseChecksum {
 		f.checksum.Release()

--- a/fragmenting_writer.go
+++ b/fragmenting_writer.go
@@ -42,11 +42,12 @@ const (
 // for contents, a running checksum, and placeholders for the fragment flags
 // and final checksum value
 type writableFragment struct {
-	flagsRef    typed.ByteRef
-	checksumRef typed.BytesRef
-	checksum    Checksum
-	contents    *typed.WriteBuffer
-	frame       *Frame
+	flagsRef            typed.ByteRef
+	checksumRef         typed.BytesRef
+	checksum            Checksum
+	contents            *typed.WriteBuffer
+	frame               *Frame
+	dontReleaseChecksum bool
 }
 
 // finish finishes the fragment, updating the final checksum and fragment flags
@@ -54,7 +55,7 @@ func (f *writableFragment) finish(hasMoreFragments bool) {
 	f.checksumRef.Update(f.checksum.Sum())
 	if hasMoreFragments {
 		f.flagsRef.Update(hasMoreFragmentsFlag)
-	} else {
+	} else if !f.dontReleaseChecksum {
 		f.checksum.Release()
 	}
 }

--- a/fragmenting_writer.go
+++ b/fragmenting_writer.go
@@ -42,12 +42,11 @@ const (
 // for contents, a running checksum, and placeholders for the fragment flags
 // and final checksum value
 type writableFragment struct {
-	flagsRef            typed.ByteRef
-	checksumRef         typed.BytesRef
-	checksum            Checksum
-	contents            *typed.WriteBuffer
-	frame               *Frame
-	dontReleaseChecksum bool
+	flagsRef    typed.ByteRef
+	checksumRef typed.BytesRef
+	checksum    Checksum
+	contents    *typed.WriteBuffer
+	frame       *Frame
 }
 
 // finish finishes the fragment, updating the final checksum and fragment flags
@@ -58,7 +57,7 @@ func (f *writableFragment) finish(hasMoreFragments bool) {
 		// This allows for callReqContinue frames to follow a fragmented callReq frame e.g. when arg2 is modified
 		// by the relayer
 		f.flagsRef.Update(hasMoreFragmentsFlag)
-	} else if !f.dontReleaseChecksum {
+	} else {
 		f.checksum.Release()
 	}
 }

--- a/relay.go
+++ b/relay.go
@@ -511,7 +511,7 @@ func (r *Relayer) handleCallReq(f *lazyCallReq) (shouldRelease bool, _ error) {
 	}
 
 	// The remote side of the relay doesn't need to track stats or call state.
-	remoteConn.relay.addRelayItem(false /* isOriginator */, destinationID, f.Header.ID, r, ttl, span, call, nil)
+	remoteConn.relay.addRelayItem(false /* isOriginator */, destinationID, f.Header.ID, r, ttl, span, call, nil /* mutatedChecksum */)
 	relayToDest := r.addRelayItem(true /* isOriginator */, f.Header.ID, destinationID, remoteConn.relay, ttl, span, call, mutatedChecksum)
 
 	f.Header.ID = destinationID

--- a/relay.go
+++ b/relay.go
@@ -79,6 +79,7 @@ type relayItem struct {
 	destination  *Relayer
 	span         Span
 	timeout      *relayTimer
+	callState    *mutatedCallState
 }
 
 type relayItems struct {
@@ -260,8 +261,6 @@ type Relayer struct {
 	relayConn *relay.Conn
 	logger    Logger
 	pending   atomic.Uint32
-
-	mutatedCalls map[uint32]*mutatedCallState
 }
 
 // NewRelayer constructs a Relayer.
@@ -281,8 +280,7 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 			IsOutbound:        conn.connDirection == outbound,
 			Context:           conn.baseContext,
 		},
-		logger:       conn.log,
-		mutatedCalls: make(map[uint32]*mutatedCallState),
+		logger: conn.log,
 	}
 	r.timeouts = newRelayTimerPool(r.timeoutRelayItem, ch.relayTimerVerify)
 	return r
@@ -311,12 +309,7 @@ func (r *Relayer) Relay(f *Frame) (shouldRelease bool, _ error) {
 	return r.handleCallReq(cr)
 }
 
-func (r *Relayer) updateChecksumIfCallIsMutated(f *Frame) {
-	cs, ok := r.mutatedCalls[f.Header.ID]
-	if !ok {
-		return
-	}
-
+func (r *Relayer) updateChecksumIfCallIsMutated(f *Frame, cs *mutatedCallState) {
 	rbuf := typed.NewReadBuffer(f.SizedPayload())
 	rbuf.SkipBytes(1) // flags
 	rbuf.SkipBytes(1) // checksum type
@@ -325,11 +318,6 @@ func (r *Relayer) updateChecksumIfCallIsMutated(f *Frame) {
 	cs.updateChecksumFromArg(rbuf, &cs.arg2Complete)
 	cs.updateChecksumFromArg(rbuf, &cs.arg3Complete)
 	checksumRef.Update(cs.checksum.Sum())
-
-	if finishesCall(f) {
-		cs.checksum.Release()
-		delete(r.mutatedCalls, f.Header.ID)
-	}
 }
 
 // Receive receives frames intended for this connection.
@@ -534,9 +522,15 @@ func (r *Relayer) handleCallReq(f *lazyCallReq) (shouldRelease bool, _ error) {
 		f.SetTTL(r.maxTimeout)
 	}
 	span := f.Span()
-	// The remote side of the relay doesn't need to track stats.
-	remoteConn.relay.addRelayItem(false /* isOriginator */, destinationID, f.Header.ID, r, ttl, span, call)
-	relayToDest := r.addRelayItem(true /* isOriginator */, f.Header.ID, destinationID, remoteConn.relay, ttl, span, call)
+
+	var cs *mutatedCallState
+	if len(f.arg2Appends) > 0 {
+		cs = &mutatedCallState{checksum: f.checksumType.New()}
+	}
+
+	// The remote side of the relay doesn't need to track stats or call state.
+	remoteConn.relay.addRelayItem(false /* isOriginator */, destinationID, f.Header.ID, r, ttl, span, call, nil)
+	relayToDest := r.addRelayItem(true /* isOriginator */, f.Header.ID, destinationID, remoteConn.relay, ttl, span, call, cs)
 
 	f.Header.ID = destinationID
 
@@ -574,10 +568,6 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	frameType := frameTypeFor(f)
 	finished := finishesCall(f)
 
-	if f.messageType() == messageTypeCallReqContinue {
-		r.updateChecksumIfCallIsMutated(f)
-	}
-
 	// If we read a request frame, we need to use the outbound map to decide
 	// the destination. Otherwise, we use the inbound map.
 	items := r.outbound
@@ -590,10 +580,15 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	if !ok {
 		return errUnknownID
 	}
+
 	if item.tomb || (finished && !stopped) {
 		// Item has previously timed out, or is in the process of timing out.
 		// TODO: metrics for late-arriving frames.
 		return nil
+	}
+
+	if f.messageType() == messageTypeCallReqContinue && item.callState != nil {
+		r.updateChecksumIfCallIsMutated(f, item.callState)
 	}
 
 	// Track sent/received bytes. We don't do this before we check
@@ -616,7 +611,7 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 }
 
 // addRelayItem adds a relay item to either outbound or inbound.
-func (r *Relayer) addRelayItem(isOriginator bool, id, remapID uint32, destination *Relayer, ttl time.Duration, span Span, call RelayCall) relayItem {
+func (r *Relayer) addRelayItem(isOriginator bool, id, remapID uint32, destination *Relayer, ttl time.Duration, span Span, call RelayCall, cs *mutatedCallState) relayItem {
 	item := relayItem{
 		isOriginator: isOriginator,
 		call:         call,
@@ -628,6 +623,7 @@ func (r *Relayer) addRelayItem(isOriginator bool, id, remapID uint32, destinatio
 	items := r.inbound
 	if isOriginator {
 		items = r.outbound
+		item.callState = cs
 	}
 	item.timeout = r.timeouts.Get()
 	items.Add(id, item)
@@ -688,6 +684,9 @@ func (r *Relayer) finishRelayItem(items *relayItems, id uint32) {
 	}
 	if item.isOriginator {
 		item.call.End()
+		if item.callState != nil {
+			item.callState.checksum.Release()
+		}
 	}
 	r.decrementPending()
 }
@@ -751,10 +750,7 @@ func (r *Relayer) fragmentingSend(call RelayCall, f *lazyCallReq, relayToDest re
 		return fmt.Errorf("%v: got %s", errArg2ThriftOnly, f.as)
 	}
 
-	cs := &mutatedCallState{
-		checksum: f.checksumType.New(),
-	}
-	r.mutatedCalls[f.Header.ID] = cs
+	cs := relayToDest.callState
 
 	// TODO(echung): should we pool the writers?
 	fragWriter := newFragmentingWriter(

--- a/relay.go
+++ b/relay.go
@@ -721,7 +721,7 @@ func (r *Relayer) fragmentingSend(call RelayCall, f *lazyCallReq, relayToDest re
 
 	// TODO(echung): should we pool the writers?
 	fragWriter := newFragmentingWriter(
-		r.logger, r.newFragmentSender(relayToDest.destination, f, origID, call, cs),
+		r.logger, r.newFragmentSender(relayToDest.destination, f, origID, call),
 		cs,
 	)
 
@@ -850,7 +850,7 @@ type relayFragmentSender struct {
 	sentReporter       sentBytesReporter
 }
 
-func (r *Relayer) newFragmentSender(dstRelay frameReceiver, cr *lazyCallReq, origID uint32, sentReporter sentBytesReporter, mutatedChecksum Checksum) *relayFragmentSender {
+func (r *Relayer) newFragmentSender(dstRelay frameReceiver, cr *lazyCallReq, origID uint32, sentReporter sentBytesReporter) *relayFragmentSender {
 	// TODO(cinchurge): pool fragment senders
 	return &relayFragmentSender{
 		callReq:            cr,

--- a/relay.go
+++ b/relay.go
@@ -897,12 +897,12 @@ func (rfs *relayFragmentSender) newFragment(initial bool, checksum Checksum) (*w
 
 	// TODO(cinchurge): pool writableFragment
 	return &writableFragment{
-		flagsRef:            flagsRef,
-		checksumRef:         checksumRef,
-		checksum:            checksum,
-		contents:            contents,
-		frame:               frame,
-		dontReleaseChecksum: true, // checksum will be released when the call is finished
+		flagsRef:    flagsRef,
+		checksumRef: checksumRef,
+		// checksum will be released by the relayer when the call is finished
+		checksum: &noReleaseChecksum{Checksum: checksum},
+		contents: contents,
+		frame:    frame,
 	}, contents.Err()
 }
 

--- a/relay.go
+++ b/relay.go
@@ -210,26 +210,8 @@ const (
 )
 
 type mutatedCallState struct {
-	arg2Complete bool
 	arg3Complete bool
 	checksum     Checksum
-}
-
-func (cs *mutatedCallState) updateChecksumFromArg(rbuf *typed.ReadBuffer, complete *bool) {
-	if *complete {
-		return
-	}
-
-	n := rbuf.ReadUint16()
-	if n == 0 {
-		*complete = true
-		return
-	}
-
-	cs.checksum.Add(rbuf.ReadBytes(int(n)))
-	if rbuf.BytesRemaining() > 0 {
-		*complete = true
-	}
 }
 
 // A Relayer forwards frames.
@@ -310,13 +292,27 @@ func (r *Relayer) Relay(f *Frame) (shouldRelease bool, _ error) {
 }
 
 func (r *Relayer) updateChecksumIfCallIsMutated(f *Frame, cs *mutatedCallState) {
+	if cs.arg3Complete {
+		return
+	}
+
 	rbuf := typed.NewReadBuffer(f.SizedPayload())
 	rbuf.SkipBytes(1) // flags
 	rbuf.SkipBytes(1) // checksum type
 
 	checksumRef := typed.BytesRef(rbuf.ReadBytes(cs.checksum.Size()))
-	cs.updateChecksumFromArg(rbuf, &cs.arg2Complete)
-	cs.updateChecksumFromArg(rbuf, &cs.arg3Complete)
+
+	n := rbuf.ReadUint16()
+	if n == 0 {
+		cs.arg3Complete = true
+		return
+	}
+
+	cs.checksum.Add(rbuf.ReadBytes(int(n)))
+	if rbuf.BytesRemaining() > 0 {
+		cs.arg3Complete = true
+	}
+
 	checksumRef.Update(cs.checksum.Sum())
 }
 
@@ -769,7 +765,6 @@ func (r *Relayer) fragmentingSend(call RelayCall, f *lazyCallReq, relayToDest re
 	if err := arg2Writer.Close(); err != nil {
 		return fmt.Errorf("close arg2 writer: %v", err)
 	}
-	cs.arg2Complete = true
 
 	if err := NewArgWriter(fragWriter.ArgWriter(true /* last */)).Write(f.arg3()); err != nil {
 		return errors.New("arg3 write failed")

--- a/relay.go
+++ b/relay.go
@@ -866,6 +866,9 @@ func (rfs *relayFragmentSender) newFragment(initial bool, checksum Checksum) (*w
 	contents := typed.NewWriteBuffer(frame.Payload[:])
 
 	// flags:1
+	// Flags MUST be copied over from the callReq frame to all new fragments since if there are more
+	// fragments to follow the callReq, the destination needs to know about this or those frames will
+	// be dropped from the call
 	flagsRef := contents.DeferByte()
 	flagsRef.Update(rfs.callReq.Payload[_flagsIndex])
 

--- a/relay.go
+++ b/relay.go
@@ -576,7 +576,6 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	if !ok {
 		return errUnknownID
 	}
-
 	if item.tomb || (finished && !stopped) {
 		// Item has previously timed out, or is in the process of timing out.
 		// TODO: metrics for late-arriving frames.

--- a/relay.go
+++ b/relay.go
@@ -305,6 +305,7 @@ func (r *Relayer) updateMutatedCallReqContinueChecksum(f *Frame, cs Checksum) {
 	//
 	// Additionally, if the checksum type results in a 0-length checksum, the .Update() would
 	// become a copy between empty slices, which correctly becomes a noop.
+	// TODO(cinchurge): include a test for len(arg3)==0 in the unit tests
 	n := rbuf.ReadUint16()
 	cs.Add(rbuf.ReadBytes(int(n)))
 	checksumRef.Update(cs.Sum())

--- a/relay.go
+++ b/relay.go
@@ -848,7 +848,6 @@ type relayFragmentSender struct {
 	outboundRelayItems *relayItems
 	origID             uint32
 	sentReporter       sentBytesReporter
-	mutatedChecksum    Checksum
 }
 
 func (r *Relayer) newFragmentSender(dstRelay frameReceiver, cr *lazyCallReq, origID uint32, sentReporter sentBytesReporter, mutatedChecksum Checksum) *relayFragmentSender {
@@ -861,7 +860,6 @@ func (r *Relayer) newFragmentSender(dstRelay frameReceiver, cr *lazyCallReq, ori
 		outboundRelayItems: r.outbound,
 		origID:             origID,
 		sentReporter:       sentReporter,
-		mutatedChecksum:    mutatedChecksum,
 	}
 }
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -1662,6 +1662,10 @@ func TestRelayModifyArg2(t *testing.T) {
 		},
 	}
 
+	// TODO(cinchurge): we need to cover a combination of the following for the payloads:
+	//   - no arg2, small arg2, large arg2 (3 or 4 cases that are close/on the boundary)
+	//   - no arg3, small arg3, 16kb arg3, 32kb arg3, 64kb arg3, 128kb arg3, 1mb arg3
+	//   - 2 bytes, 1 byte, and 0 bytes from the frame boundary for both arg2 and arg3
 	payloadTests := []struct {
 		msg  string
 		arg2 map[string]string

--- a/relay_test.go
+++ b/relay_test.go
@@ -1498,74 +1498,80 @@ func inspectFrames(rh *relaytest.StubRelayHost) chan relay.CallFrame {
 	return frameCh
 }
 
+type relayModifier interface {
+	frameFn(cf relay.CallFrame, _ *relay.Conn)
+	modifyArg2(m map[string]string) map[string]string
+}
+
+type noopRelayModifer struct{}
+
+func (nrm *noopRelayModifer) frameFn(_ relay.CallFrame, _ *relay.Conn) {}
+
+func (nrm *noopRelayModifer) modifyArg2(m map[string]string) map[string]string { return m }
+
+type keyVal struct {
+	key, val string
+}
+
+type arg2KeyValRelayModifier struct {
+	keyValPairs []keyVal
+}
+
+func addFixedKeyVal(kvPairs []keyVal) *arg2KeyValRelayModifier {
+	return &arg2KeyValRelayModifier{
+		keyValPairs: kvPairs,
+	}
+}
+
+func fillFrameWithArg2(t *testing.T, checksumType ChecksumType, arg1 string, arg2 map[string]string, bytePosFromBoundary int) *arg2KeyValRelayModifier {
+	arg2Key := "foo"
+
+	fmt.Println("method=", arg1)
+
+	arg2Len := 2 // nh
+	for k, v := range arg2 {
+		arg2Len += 2 + len(k) + 2 + len(v)
+	}
+
+	// Writing an arg adds nh+nk+len(key)+nv+len(val) bytes. calculate the size of val
+	// so that we end at bytePosFromBoundary in the frame. remainingSpaceBeforeChecksum
+	// is the number of bytes from the start of the frame up until the checkumType byte,
+	// just before the checksum itself.
+	const remainingSpaceBeforeChecksum = 65441
+	valSize := remainingSpaceBeforeChecksum + bytePosFromBoundary - (checksumType.ChecksumSize() + 2 /* nArg1 */ + len(arg1) + arg2Len + 2 /* nk */ + len(arg2Key) + 2 /* nv */)
+	if valSize < 0 {
+		t.Fatalf("can't fill arg2 with key %q and %d bytes remaining", arg2Key, bytePosFromBoundary)
+	}
+
+	return &arg2KeyValRelayModifier{
+		keyValPairs: []keyVal{
+			{key: arg2Key, val: testutils.RandString(valSize)},
+		},
+	}
+}
+
+func (rm *arg2KeyValRelayModifier) frameFn(cf relay.CallFrame, _ *relay.Conn) {
+	for _, kv := range rm.keyValPairs {
+		cf.Arg2Append([]byte(kv.key), []byte(kv.val))
+	}
+}
+
+func (rm *arg2KeyValRelayModifier) modifyArg2(m map[string]string) map[string]string {
+	if m == nil {
+		m = make(map[string]string)
+	}
+	for _, kv := range rm.keyValPairs {
+		m[kv.key] = kv.val
+	}
+	return m
+}
+
 func TestRelayModifyArg2(t *testing.T) {
 	const kb = 1024
 	largeVal1 := testutils.RandString(16 * 1024)
 	largeVal2 := testutils.RandString(16 * 1024)
 	largeVal3 := testutils.RandString(16 * 1024)
 	largeVal4 := testutils.RandString(16 * 1024)
-
-	modifyTests := []struct {
-		msg         string
-		skip        string
-		modifyFrame func(relay.CallFrame, *relay.Conn)
-		modifyArg2  func(arg2 map[string]string) map[string]string
-	}{
-		{
-			msg:         "no change",
-			modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {},
-		},
-		{
-			msg: "add zero-length key/value",
-			modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {
-				cf.Arg2Append(nil, nil)
-			},
-			modifyArg2: func(m map[string]string) map[string]string {
-				m[""] = ""
-				return m
-			},
-		},
-		{
-			msg: "add multiple zero-length key/value",
-			modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {
-				cf.Arg2Append(nil, nil)
-				cf.Arg2Append(nil, nil)
-				cf.Arg2Append(nil, nil)
-			},
-			modifyArg2: func(m map[string]string) map[string]string {
-				m[""] = ""
-				return m
-			},
-		},
-		{
-			msg: "add small key/value",
-			modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {
-				cf.Arg2Append([]byte("foo"), []byte("bar"))
-				cf.Arg2Append([]byte("baz"), []byte("qux"))
-			},
-			modifyArg2: func(m map[string]string) map[string]string {
-				m["foo"] = "bar"
-				m["baz"] = "qux"
-				return m
-			},
-		},
-		{
-			msg: "add large key/value",
-			modifyFrame: func(cf relay.CallFrame, _ *relay.Conn) {
-				cf.Arg2Append([]byte("fee"), []byte(largeVal1))
-				cf.Arg2Append([]byte("fi"), []byte(largeVal2))
-				cf.Arg2Append([]byte("fo"), []byte(largeVal3))
-				cf.Arg2Append([]byte("fum"), []byte(largeVal4))
-			},
-			modifyArg2: func(m map[string]string) map[string]string {
-				m["fee"] = largeVal1
-				m["fi"] = largeVal2
-				m["fo"] = largeVal3
-				m["fum"] = largeVal4
-				return m
-			},
-		},
-	}
 
 	checksumTypes := []struct {
 		msg          string
@@ -1575,6 +1581,85 @@ func TestRelayModifyArg2(t *testing.T) {
 		{"crc32", ChecksumTypeCrc32},
 		{"farmhash", ChecksumTypeFarmhash},
 		{"crc32c", ChecksumTypeCrc32C},
+	}
+
+	modifyTests := []struct {
+		msg      string
+		skip     string
+		modifier func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier
+	}{
+		{
+			msg: "no change",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return &noopRelayModifer{}
+			},
+		},
+		{
+			msg: "add zero-length key/value",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return addFixedKeyVal([]keyVal{{key: "", val: ""}})
+			},
+		},
+		{
+			msg: "add multiple zero-length key/value",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return addFixedKeyVal([]keyVal{
+					{"", ""},
+					{"", ""},
+					{"", ""},
+				})
+			},
+		},
+		{
+			msg: "add small key/value",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return addFixedKeyVal([]keyVal{
+					{"foo", "bar"},
+					{"baz", "qux"},
+				})
+			},
+		},
+		{
+			msg: "fill the first frame until 2 bytes remain",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return fillFrameWithArg2(t, cst, arg1, arg2, -2)
+			},
+		},
+		{
+			msg: "fill the first frame until 1 byte remain",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return fillFrameWithArg2(t, cst, arg1, arg2, -1)
+			},
+		},
+		{
+			msg: "fill the first frame to its boundary",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return fillFrameWithArg2(t, cst, arg1, arg2, 0)
+			},
+		},
+		{
+			msg: "fill the first frame to 1 byte over its boundary",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return fillFrameWithArg2(t, cst, arg1, arg2, 1)
+			},
+		},
+		{
+			msg: "fill the first frame to 2 bytes over its boundary",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return fillFrameWithArg2(t, cst, arg1, arg2, 2)
+			},
+		},
+		{
+			msg: "add large key/value",
+			modifier: func(t *testing.T, cst ChecksumType, arg1 string, arg2 map[string]string) relayModifier {
+				return addFixedKeyVal([]keyVal{
+					{"fee", largeVal1},
+					{"fi", largeVal2},
+					{"fo", largeVal3},
+					{"fum", largeVal4},
+				})
+			},
+		},
 	}
 
 	payloadTests := []struct {
@@ -1623,11 +1708,11 @@ func TestRelayModifyArg2(t *testing.T) {
 			arg3: testutils.RandBytes(128 * kb),
 		},
 		{
-			msg: "512kB payloads",
+			msg: "1MB payloads",
 			arg2: map[string]string{
 				"existingKey": "existingValue",
 			},
-			arg3: testutils.RandBytes(512 * kb),
+			arg3: testutils.RandBytes(1024 * kb),
 		},
 	}
 
@@ -1656,62 +1741,56 @@ func TestRelayModifyArg2(t *testing.T) {
 
 	for _, mt := range modifyTests {
 		for _, csTest := range checksumTypes {
-			t.Run(mt.msg+"/checksum="+csTest.msg, func(t *testing.T) {
-				// Create a relay that will modify the frame as per the test.
-				relayHost := relaytest.NewStubRelayHost()
-				relayHost.SetFrameFn(mt.modifyFrame)
-				opts := testutils.NewOpts().
-					SetRelayHost(relayHost).
-					SetRelayOnly()
-				testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
-					// Create a client that uses a specific checksumType.
-					clientOpts := testutils.NewOpts().SetChecksumType(csTest.checksumType)
-					client := ts.NewClient(clientOpts)
-					defer client.Close()
+			// Make calls with different payloads and expected errors.
+			for _, aet := range appErrTests {
+				for _, tt := range payloadTests {
+					t.Run(fmt.Sprintf("%s,checksum=%s,%s,%s", mt.msg, csTest.msg, aet.msg, tt.msg), func(t *testing.T) {
+						modifier := mt.modifier(t, csTest.checksumType, aet.method, tt.arg2)
 
-					// Create a server echo verify endpoints (optionally returning an error).
-					for _, appErrTest := range appErrTests {
-						handler := echoVerifyHandler{
-							t:            t,
-							verifyFormat: format,
-							verifyCaller: client.ServiceName(),
-							verifyMethod: appErrTest.method,
-							appErr:       appErrTest.wantAppErr,
-						}
-						ts.Server().Register(raw.Wrap(handler), appErrTest.method)
-					}
+						// Create a relay that will modify the frame as per the test.
+						relayHost := relaytest.NewStubRelayHost()
+						relayHost.SetFrameFn(modifier.frameFn)
+						opts := testutils.NewOpts().
+							SetRelayHost(relayHost).
+							SetRelayOnly()
+						testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
+							// Create a client that uses a specific checksumType.
+							clientOpts := testutils.NewOpts().SetChecksumType(csTest.checksumType)
+							client := ts.NewClient(clientOpts)
+							defer client.Close()
 
-					ctx, cancel := NewContextBuilder(testutils.Timeout(time.Second)).
-						SetFormat(format).Build()
-					defer cancel()
-
-					// Make calls with different payloads and expected errors.
-					for _, aet := range appErrTests {
-						for _, tt := range payloadTests {
-							t.(*testing.T).Run(aet.msg+","+tt.msg, func(t *testing.T) {
-								arg2Encoded := encodeThriftHeaders(t, tt.arg2)
-
-								resArg2, resArg3, resp, err := raw.Call(ctx, client, ts.HostPort(), ts.ServiceName(), aet.method, arg2Encoded, tt.arg3)
-								require.NoError(t, err, "%v: Received unexpected error", tt.msg)
-								assert.Equal(t, format, resp.Format(), "%v: Unexpected error format")
-								assert.Equal(t, aet.wantAppErr, resp.ApplicationError(), "%v: Unexpected app error")
-
-								wantArg2 := copyHeaders(tt.arg2)
-								if mt.modifyArg2 != nil {
-									if wantArg2 == nil {
-										wantArg2 = make(map[string]string)
-									}
-									wantArg2 = mt.modifyArg2(wantArg2)
+							// Create a server echo verify endpoints (optionally returning an error).
+							for _, appErrTest := range appErrTests {
+								handler := echoVerifyHandler{
+									t:            t,
+									verifyFormat: format,
+									verifyCaller: client.ServiceName(),
+									verifyMethod: appErrTest.method,
+									appErr:       appErrTest.wantAppErr,
 								}
+								ts.Server().Register(raw.Wrap(handler), appErrTest.method)
+							}
 
-								gotArg2Map := decodeThriftHeaders(t, resArg2)
-								assert.Equal(t, wantArg2, gotArg2Map, "%v: Unexpected arg2 headers", tt.msg)
-								assert.Equal(t, resArg3, tt.arg3, "%v: Unexpected arg3", tt.msg)
-							})
-						}
-					}
-				})
-			})
+							ctx, cancel := NewContextBuilder(testutils.Timeout(time.Second)).
+								SetFormat(format).Build()
+							defer cancel()
+
+							arg2Encoded := encodeThriftHeaders(t, tt.arg2)
+
+							resArg2, resArg3, resp, err := raw.Call(ctx, client, ts.HostPort(), ts.ServiceName(), aet.method, arg2Encoded, tt.arg3)
+							require.NoError(t, err, "%v: Received unexpected error", tt.msg)
+							assert.Equal(t, format, resp.Format(), "%v: Unexpected error format")
+							assert.Equal(t, aet.wantAppErr, resp.ApplicationError(), "%v: Unexpected app error")
+
+							wantArg2 := modifier.modifyArg2(copyHeaders(tt.arg2))
+
+							gotArg2Map := decodeThriftHeaders(t, resArg2)
+							assert.Equal(t, wantArg2, gotArg2Map, "%v: Unexpected arg2 headers", tt.msg)
+							assert.Equal(t, resArg3, tt.arg3, "%v: Unexpected arg3", tt.msg)
+						})
+					})
+				}
+			}
 		}
 	}
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -508,11 +508,13 @@ func TestRelayMakeOutgoingCall(t *testing.T) {
 
 		sizes := []int{128, 1024, 128 * 1024}
 		for _, size := range sizes {
-			err := testutils.CallEcho(svr1, ts.HostPort(), "svc2", &raw.Args{
-				Arg2: testutils.RandBytes(size),
-				Arg3: testutils.RandBytes(size),
+			t.(*testing.T).Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+				err := testutils.CallEcho(svr1, ts.HostPort(), "svc2", &raw.Args{
+					Arg2: testutils.RandBytes(size),
+					Arg3: testutils.RandBytes(size),
+				})
+				assert.NoError(t, err, "Echo with size %v failed", size)
 			})
-			assert.NoError(t, err, "Echo with size %v failed", size)
 		}
 	})
 }
@@ -1497,11 +1499,11 @@ func inspectFrames(rh *relaytest.StubRelayHost) chan relay.CallFrame {
 }
 
 func TestRelayModifyArg2(t *testing.T) {
+	const kb = 1024
 	largeVal1 := testutils.RandString(16 * 1024)
 	largeVal2 := testutils.RandString(16 * 1024)
 	largeVal3 := testutils.RandString(16 * 1024)
 	largeVal4 := testutils.RandString(16 * 1024)
-	largePayload := testutils.RandString(1024)
 
 	modifyTests := []struct {
 		msg         string
@@ -1586,18 +1588,46 @@ func TestRelayModifyArg2(t *testing.T) {
 			arg3: []byte{},
 		},
 		{
-			msg: "small payloads",
+			msg: "1kB payloads",
 			arg2: map[string]string{
 				"existingKey": "existingValue",
 			},
-			arg3: []byte("hello world"),
+			arg3: testutils.RandBytes(kb),
 		},
 		{
-			msg: "large payloads",
+			msg: "16kB payloads",
 			arg2: map[string]string{
 				"existingKey": "existingValue",
 			},
-			arg3: []byte(largePayload),
+			arg3: testutils.RandBytes(16 * kb),
+		},
+		{
+			msg: "32kB payloads",
+			arg2: map[string]string{
+				"existingKey": "existingValue",
+			},
+			arg3: testutils.RandBytes(32 * kb),
+		},
+		{
+			msg: "64kB payloads",
+			arg2: map[string]string{
+				"existingKey": "existingValue",
+			},
+			arg3: testutils.RandBytes(64 * kb),
+		},
+		{
+			msg: "128kB payloads",
+			arg2: map[string]string{
+				"existingKey": "existingValue",
+			},
+			arg3: testutils.RandBytes(128 * kb),
+		},
+		{
+			msg: "512kB payloads",
+			arg2: map[string]string{
+				"existingKey": "existingValue",
+			},
+			arg3: testutils.RandBytes(512 * kb),
 		},
 	}
 


### PR DESCRIPTION
Our previous effort to add arg2 mutation left out an important detail: in TChannel, the checksum for every frame is seeded by the checksum of its previous frame. Meaning that once the `callReq` frame has been mutated, all subsequent `callReqContinue` frames must also have their checksum updated.

This change extends `relayItem` with a reference to the "call state", which tracks
- whether arg3 has been completed (arg2 must fit in `callReq` in order for mutation to be allowed)
- the running checksum for all the frames in the call

once a `callReq` frame has been mutated, all subsequent `callReqContinue` frames with the same ID will have their checksums recalculated and updated before the relayer forwards them to the destination.

The `TestRelayModifyArg2` tests have also been updated to include "large" payloads (64, 128, and 512kB) to ensure that we don't have future regression in this behavior.

## Update
 dropped the argComplete flags since:
- arg1complete and arg2complete are always true, since we don’t support arg2 mutation when it doesn’t fit in the first frame
- if arg2 was enlarged to go over the first frame, it would’ve been already relayed by the time we hit callReqContinue
- arg3complete is never true until the last frame, so we don’t need to check that either