### PR TITLE
relay: Send error frame to caller on fragmented arg2

### DIFF
--- a/relay_fragment_sender_test.go
+++ b/relay_fragment_sender_test.go
@@ -75,10 +75,11 @@ func TestRelayFragmentSender(t *testing.T) {
 					retFailureReason: tt.failure,
 					wantPayload:      tt.wantPayload,
 				},
-				failRelayItemFunc: func(items *relayItems, id uint32, failure string) {
+				failRelayItemFunc: func(items *relayItems, id uint32, failure string, err error) {
 					failRelayItemFuncCalled = true
 					assert.Equal(t, uint32(123), id, "got unexpected id")
 					assert.Equal(t, tt.failure, failure, "got unexpected failure string")
+					assert.Error(t, err, "missing err")
 				},
 				origID:       123,
 				sentReporter: &noopSentReporter{},

--- a/relay_test.go
+++ b/relay_test.go
@@ -1693,7 +1693,7 @@ func TestRelayModifyArg2OnFrameWithFragmentedArg2ShouldFail(t *testing.T) {
 	opts := testutils.NewOpts().
 		SetRelayOnly().
 		SetRelayHost(rh).
-		AddLogFilter("Failed to relay frame.", 1, "error", "fragmented arg2 not supported for appends")
+		AddLogFilter("Failed to send call with modified arg2.", 1)
 
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		rly := ts.Relay()
@@ -1717,7 +1717,8 @@ func TestRelayModifyArg2OnFrameWithFragmentedArg2ShouldFail(t *testing.T) {
 				"fum": testutils.RandString(16 * 1024),
 			}),
 		})
-		assert.EqualError(t, err, "tchannel error ErrCodeTimeout: timeout")
+		require.Error(t, err, "should fail to send call with large arg2")
+		assert.Contains(t, err.Error(), "relay-arg2-modify-failed: fragmented arg2")
 	})
 }
 


### PR DESCRIPTION
Currently, if a call fails due to a fragmented arg2 (e.g., arg2 does not
fit in the first frame as it's too large), we drop the frame and log
an error internally, but no error is returned to the caller, so they
see a timeout.

Instead of a timeout, fail the relay item, which triggers an error frame
to be sent to the caller, so they receive mroe information on why the
call failed (and they receive an immediate error instead of waiting for
the timeout to expire).

This also improves other error frames sent back with the same
reason that is used in metrics, although we still have a generic
"frame was not sent to remote side" which could be replaced with
much more specific errors.