### PR TITLE
relay: Reject arg2 modifications for non-Thrift calls

### DIFF
--- a/relay_messages.go
+++ b/relay_messages.go
@@ -249,7 +249,7 @@ func (f *lazyCallReq) arg3() []byte {
 // of TChannel-Thrift Arg Scheme.
 func (f *lazyCallReq) Arg2Iterator() (arg2.KeyValIterator, error) {
 	if !bytes.Equal(f.as, _tchanThriftValueBytes) {
-		return arg2.KeyValIterator{}, fmt.Errorf("non thrift scheme %s", f.as)
+		return arg2.KeyValIterator{}, fmt.Errorf("%v: got %s", errArg2ThriftOnly, f.as)
 	}
 	return arg2.NewKeyValIterator(f.Payload[f.arg2StartOffset:f.arg2EndOffset])
 }

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -469,12 +469,12 @@ func TestLazyCallReqSetTChanThriftArg2(t *testing.T) {
 			msg:        "not tchannel thrift",
 			argScheme:  HTTP,
 			bufKV:      map[string]string{"key": "val"},
-			wantBadErr: "non thrift scheme",
+			wantBadErr: "non-Thrift",
 		},
 		{
 			msg:        "not arg scheme",
 			bufKV:      map[string]string{"key": "val"},
-			wantBadErr: "non thrift scheme",
+			wantBadErr: "non-Thrift",
 		},
 	}
 

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -33,12 +33,14 @@ import (
 
 // CallEcho calls the "echo" endpoint from the given src to target.
 func CallEcho(src *tchannel.Channel, targetHostPort, targetService string, args *raw.Args) error {
-	ctx, cancel := tchannel.NewContext(Timeout(300 * time.Millisecond))
-	defer cancel()
-
 	if args == nil {
 		args = &raw.Args{}
 	}
+
+	ctx, cancel := tchannel.NewContextBuilder(Timeout(300 * time.Millisecond)).
+		SetFormat(args.Format).
+		Build()
+	defer cancel()
 
 	_, _, _, err := raw.Call(ctx, src, targetHostPort, targetService, "echo", args.Arg2, args.Arg3)
 	return err


### PR DESCRIPTION
Arg2 modification assumes the Thrift encoding, and will not work
correctly for any other encoding. To avoid any unexpected corruption
of headers, reject mutating headers for any non-Thrift calls.