### PR TITLE
Send a cancelled error on request abort to propagate cancellation

### DIFF
--- a/calloptions.go
+++ b/calloptions.go
@@ -60,6 +60,14 @@ type CallOptions struct {
 	// Optionally override this field to support transparent proxying when inbound
 	// caller names vary across calls.
 	CallerName string
+
+	// ContextDoneCancelsRequest will start a listener to each call and
+	// if the context completes before the call is finished a cancelled
+	// error frame will be sent to the server for server side cancellation
+	// of the request.
+	// Note: This does require an extra goroutine per call to listen
+	// and propagate the cancel error frame if the context is cancelled.
+	ContextDoneCancelsRequest bool
 }
 
 var defaultCallOptions = &CallOptions{}

--- a/calloptions.go
+++ b/calloptions.go
@@ -60,14 +60,6 @@ type CallOptions struct {
 	// Optionally override this field to support transparent proxying when inbound
 	// caller names vary across calls.
 	CallerName string
-
-	// ContextDoneCancelsRequest will start a listener to each call and
-	// if the context completes before the call is finished a cancelled
-	// error frame will be sent to the server for server side cancellation
-	// of the request.
-	// Note: This does require an extra goroutine per call to listen
-	// and propagate the cancel error frame if the context is cancelled.
-	ContextDoneCancelsRequest bool
 }
 
 var defaultCallOptions = &CallOptions{}

--- a/connection.go
+++ b/connection.go
@@ -158,6 +158,14 @@ type ConnectionOptions struct {
 	// MaxCloseTime controls how long we allow a connection to complete pending
 	// calls before shutting down. Only used if it is non-zero.
 	MaxCloseTime time.Duration
+
+	// ContextDoneCancelsRequest will start a listener to each call and
+	// if the context completes before the call is finished a cancelled
+	// error frame will be sent to the server for server side cancellation
+	// of the request.
+	// Note: This does require an extra goroutine per call to listen
+	// and propagate the cancel error frame if the context is cancelled.
+	ContextDoneCancelsRequest bool
 }
 
 // connectionEvents are the events that can be triggered by a connection.

--- a/mex.go
+++ b/mex.go
@@ -232,11 +232,11 @@ func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, er
 // exchange set so  that it cannot receive more messages from the peer.  The
 // receive channel remains open, however, in case there are concurrent
 // goroutines sending to it.
-func (mex *messageExchange) shutdown() {
+func (mex *messageExchange) shutdown() bool {
 	// The reader and writer side can both hit errors and try to shutdown the mex,
 	// so we ensure that it's only shut down once.
 	if !mex.shutdownAtomic.CAS(false, true) {
-		return
+		return false
 	}
 
 	if mex.errChNotified.CAS(false, true) {
@@ -244,6 +244,7 @@ func (mex *messageExchange) shutdown() {
 	}
 
 	mex.mexset.removeExchange(mex.msgID)
+	return true
 }
 
 // inboundExpired is called when an exchange is canceled or it times out,

--- a/outbound.go
+++ b/outbound.go
@@ -136,14 +136,14 @@ func (c *Connection) beginCall(ctx context.Context, serviceName, methodName stri
 		return nil, err
 	}
 
-	if !callOptions.ContextDoneCancelsRequest {
+	if !call.conn.opts.ContextDoneCancelsRequest {
 		// No need to launch a routine to check for cancellation.
 		return call, nil
 	}
 
 	go func() {
 		<-ctx.Done()
-		if !mex.shutdown() {
+		if !call.mex.shutdown() {
 			// Already shutdown, no need to send frame.
 			return
 		}

--- a/outbound.go
+++ b/outbound.go
@@ -21,7 +21,6 @@
 package tchannel
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 


### PR DESCRIPTION
Opening this PR for a discussion to see if folks would be open to this approach of sending an error frame from client to server if the client aborts the request locally by cancelling the calling context.

This is working nicely end-to-end and causes the server side context to cancel in the case of a client side request abort, but I want to make sure doing this right by making it opt-in with the ConnectionOptions since it adds a goroutine per call overhead and how others feel about the general approach.

Thank you for any and all feedback.