### PR TITLE
adding caller procedure in the call options

### DIFF
--- a/calloptions.go
+++ b/calloptions.go
@@ -60,6 +60,8 @@ type CallOptions struct {
 	// Optionally override this field to support transparent proxying when inbound
 	// caller names vary across calls.
 	CallerName string
+
+	CallerProcedure string
 }
 
 var defaultCallOptions = &CallOptions{}
@@ -85,6 +87,10 @@ func (c *CallOptions) overrideHeaders(headers transportHeaders) {
 	}
 	if c.CallerName != "" {
 		headers[CallerName] = c.CallerName
+	}
+
+	if c.CallerProcedure != "" {
+		headers[CallerProcedure] = c.CallerProcedure
 	}
 }
 

--- a/calloptions_test.go
+++ b/calloptions_test.go
@@ -32,6 +32,7 @@ func TestSetHeaders(t *testing.T) {
 		routingDelegate string
 		routingKey      string
 		callerName      string
+		callerProcedure string
 		expectedHeaders transportHeaders
 	}{
 		{
@@ -66,6 +67,14 @@ func TestSetHeaders(t *testing.T) {
 				RoutingKey: "canary",
 			},
 		},
+		{
+			format:          JSON,
+			callerProcedure: "callerP",
+			expectedHeaders: transportHeaders{
+				ArgScheme:       JSON.String(),
+				CallerProcedure: "callerP",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +83,7 @@ func TestSetHeaders(t *testing.T) {
 			RoutingDelegate: tt.routingDelegate,
 			RoutingKey:      tt.routingKey,
 			CallerName:      tt.callerName,
+			CallerProcedure: tt.callerProcedure,
 		}
 		headers := make(transportHeaders)
 		callOpts.setHeaders(headers)

--- a/context.go
+++ b/context.go
@@ -61,6 +61,8 @@ type IncomingCall interface {
 	// transport header.
 	RoutingDelegate() string
 
+	CallerProcedure() string
+
 	// LocalPeer returns the local peer information.
 	LocalPeer() LocalPeerInfo
 

--- a/context_builder.go
+++ b/context_builder.go
@@ -136,6 +136,15 @@ func (cb *ContextBuilder) SetRoutingDelegate(rd string) *ContextBuilder {
 	return cb
 }
 
+// SetCallerProcedure sets the CallerProcedure call options ("cp" transport header).
+func (cb *ContextBuilder) SetCallerProcedure(rd string) *ContextBuilder {
+	if cb.CallOptions == nil {
+		cb.CallOptions = new(CallOptions)
+	}
+	cb.CallOptions.CallerProcedure = rd
+	return cb
+}
+
 // SetConnectTimeout sets the ConnectionTimeout for this context.
 // The context timeout applies to the whole call, while the connect
 // timeout only applies to creating a new connection.

--- a/inbound.go
+++ b/inbound.go
@@ -257,6 +257,10 @@ func (call *InboundCall) RoutingDelegate() string {
 	return call.headers[RoutingDelegate]
 }
 
+func (call *InboundCall) CallerProcedure() string {
+	return call.headers[CallerProcedure]
+}
+
 // LocalPeer returns the local peer information for this call.
 func (call *InboundCall) LocalPeer() LocalPeerInfo {
 	return call.conn.localPeerInfo
@@ -275,6 +279,7 @@ func (call *InboundCall) CallOptions() *CallOptions {
 		ShardKey:        call.ShardKey(),
 		RoutingDelegate: call.RoutingDelegate(),
 		RoutingKey:      call.RoutingKey(),
+		CallerProcedure: call.CallerProcedure(),
 	}
 }
 

--- a/inbound_test.go
+++ b/inbound_test.go
@@ -152,6 +152,7 @@ func TestCallOptionsPropogated(t *testing.T) {
 		ShardKey:        "test-shard-key",
 		RoutingKey:      "test-routing-key",
 		RoutingDelegate: "test-routing-delegate",
+		CallerProcedure: "test-caller-procedure",
 	}
 
 	var gotCallOpts *CallOptions

--- a/messages.go
+++ b/messages.go
@@ -175,6 +175,8 @@ const (
 	// requested service. A relay may use the routing key over the service if
 	// it knows about traffic groups.
 	RoutingKey TransportHeaderName = "rk"
+
+	CallerProcedure TransportHeaderName = "cp"
 )
 
 // transportHeaders are passed as part of a CallReq/CallRes

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -49,6 +49,8 @@ type CallFrame interface {
 	Method() []byte
 	// RoutingDelegate is the name of the routing delegate, if any.
 	RoutingDelegate() []byte
+	// CallerProcedure is the name of the caller procedure of the service making the request
+	CallerProcedure() []byte
 	// RoutingKey may refer to an alternate traffic group instead of the
 	// traffic group identified by the service name.
 	RoutingKey() []byte

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -35,6 +35,7 @@ import (
 var (
 	_callerNameKeyBytes      = []byte(CallerName)
 	_routingDelegateKeyBytes = []byte(RoutingDelegate)
+	_callerProcedureKeyBytes = []byte(CallerProcedure)
 	_routingKeyKeyBytes      = []byte(RoutingKey)
 	_argSchemeKeyBytes       = []byte(ArgScheme)
 	_tchanThriftValueBytes   = []byte(Thrift)
@@ -99,10 +100,10 @@ type lazyCallReq struct {
 	arg2StartOffset, arg2EndOffset uint16
 	arg3StartOffset                uint16
 
-	caller, method, delegate, key, as []byte
-	arg2Appends                       []relay.KeyVal
-	checksumType                      ChecksumType
-	isArg2Fragmented                  bool
+	caller, method, delegate, callerProcedure, key, as []byte
+	arg2Appends                                        []relay.KeyVal
+	checksumType                                       ChecksumType
+	isArg2Fragmented                                   bool
 
 	// Intentionally an array to combine allocations with that of lazyCallReq
 	arg2InitialBuf [1]relay.KeyVal
@@ -140,6 +141,8 @@ func newLazyCallReq(f *Frame) (*lazyCallReq, error) {
 			cr.caller = val
 		} else if bytes.Equal(key, _routingDelegateKeyBytes) {
 			cr.delegate = val
+		} else if bytes.Equal(key, _callerProcedureKeyBytes) {
+			cr.callerProcedure = val
 		} else if bytes.Equal(key, _routingKeyKeyBytes) {
 			cr.key = val
 		}
@@ -195,6 +198,11 @@ func (f *lazyCallReq) Method() []byte {
 // RoutingDelegate returns the routing delegate for this call req, if any.
 func (f *lazyCallReq) RoutingDelegate() []byte {
 	return f.delegate
+}
+
+//CallerProcedure return the caller procedure for this call req, if any.
+func (f *lazyCallReq) CallerProcedure() []byte {
+	return f.callerProcedure
 }
 
 // RoutingKey returns the routing delegate for this call req, if any.

--- a/testutils/call.go
+++ b/testutils/call.go
@@ -50,6 +50,9 @@ type FakeIncomingCall struct {
 
 	// RoutingDelegateF is the routing delegate.
 	RoutingDelegateF string
+
+	// CallerProcedureF is the caller procedure
+	CallerProcedureF string
 }
 
 // CallerName returns the caller name as specified in the fake call.
@@ -72,6 +75,11 @@ func (f *FakeIncomingCall) RoutingDelegate() string {
 	return f.RoutingDelegateF
 }
 
+// CallerProcedure returns the caller procedure as specified in the fake call.
+func (f *FakeIncomingCall) CallerProcedure() string {
+	return f.CallerProcedureF
+}
+
 // LocalPeer returns the local peer information for this call.
 func (f *FakeIncomingCall) LocalPeer() tchannel.LocalPeerInfo {
 	return f.LocalPeerF
@@ -88,6 +96,7 @@ func (f *FakeIncomingCall) CallOptions() *tchannel.CallOptions {
 		ShardKey:        f.ShardKey(),
 		RoutingKey:      f.RoutingKey(),
 		RoutingDelegate: f.RoutingDelegate(),
+		CallerProcedure: f.CallerProcedure(),
 	}
 }
 
@@ -101,7 +110,7 @@ type FakeCallFrame struct {
 	tb   testing.TB
 	TTLF time.Duration
 
-	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF string
+	ServiceF, MethodF, CallerF, RoutingKeyF, RoutingDelegateF, CallerProcedureF string
 
 	Arg2StartOffsetVal, Arg2EndOffsetVal int
 	IsArg2Fragmented                     bool
@@ -144,6 +153,11 @@ func (f *FakeCallFrame) RoutingDelegate() []byte {
 	return []byte(f.RoutingDelegateF)
 }
 
+// CallerProcedure returns the caller procedure field.
+func (f *FakeCallFrame) CallerProcedure() []byte {
+	return []byte(f.CallerProcedureF)
+}
+
 // Arg2StartOffset returns the offset from start of payload to
 // the beginning of Arg2.
 func (f *FakeCallFrame) Arg2StartOffset() int {
@@ -179,6 +193,7 @@ func CopyCallFrame(f relay.CallFrame) *FakeCallFrame {
 		CallerF:            string(f.Caller()),
 		RoutingKeyF:        string(f.RoutingKey()),
 		RoutingDelegateF:   string(f.RoutingDelegate()),
+		CallerProcedureF:   string(f.CallerProcedure()),
 		Arg2StartOffsetVal: f.Arg2StartOffset(),
 		Arg2EndOffsetVal:   endOffset,
 		IsArg2Fragmented:   hasMore,


### PR DESCRIPTION
### Requirement:
 For observability, we are able to identify caller services for a service endpoint but we don't have caller procedure -> callee procedure mapping in that. Caller procedure information in other services can only be provided through yarpc header. So we propose to add a header "CallerProcedure" in the yarpc request which would reference the name of the procedure this service making the request. This will improve the observability in services as well as for yarpc.

This pull request is the follow up from the https://github.com/yarpc/yarpc-go/pull/2027.  This request specifically implements the tchannel related changes to add caller procedure in to the header.

### Testing Done:
* Added unit tests for coverage
* Had locally replaced this package in yarpc-go and verified the encoding/decoding of tchannel headers


