### PR TITLE
connections: don't call conncontext on outbound base context

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -318,6 +318,8 @@ func (ch *Channel) newConnection(baseCtx context.Context, conn net.Conn, initial
 	if outboundHP != "" {
 		connDirection = outbound
 		log = log.WithFields(LogField{"outboundHP", outboundHP})
+	} else {
+		baseCtx = ch.connContext(baseCtx, conn)
 	}
 
 	log = log.WithFields(LogField{"connectionDirection", connDirection})
@@ -348,7 +350,7 @@ func (ch *Channel) newConnection(baseCtx context.Context, conn net.Conn, initial
 		healthCheckHistory: newHealthHistory(),
 		lastActivityRead:   *atomic.NewInt64(timeNow),
 		lastActivityWrite:  *atomic.NewInt64(timeNow),
-		baseContext:        ch.connContext(baseCtx, conn),
+		baseContext:        baseCtx,
 	}
 
 	if tosPriority := opts.TosPriority; tosPriority > 0 {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1444,20 +1444,20 @@ func TestInboundConnContext(t *testing.T) {
 }
 
 func TestOutboundConnContext(t *testing.T) {
-	tests := []struct{
-		msg string
+	tests := []struct {
+		msg  string
 		opts *testutils.ChannelOpts
-	} {
+	}{
 		{
 			// As a channel can have both inbound and outbound connections, we may want a connContext set for the inbound,
 			// but this shouldn't affect the outbound
 			msg: "conncontext doesn't overwrite base context",
-			opts:testutils.NewOpts().NoRelay().SetConnContext(func(ctx context.Context, conn net.Conn) context.Context {
+			opts: testutils.NewOpts().NoRelay().SetConnContext(func(ctx context.Context, conn net.Conn) context.Context {
 				return context.WithValue(ctx, "foo", "baz")
 			}),
 		},
 		{
-			msg: "base context is propagated when without conncontext",
+			msg:  "base context is propagated when without conncontext",
 			opts: testutils.NewOpts().NoRelay(),
 		},
 	}


### PR DESCRIPTION
The `ConnContext()` function was originally meant for connection-specific initialization of the server's base context, but we are now also invoking it on the connection we freshly created for outbound connections, which wouldn't make sense since the outbound connection we created couldn't possibly have any caller information. This would end up overriding the base context meant to be attached to the outbound connection, resulting in unintended behavior.

This change changes `Channel.newConnection()` so that we only invoke `ConnContext()` on inbound connections, while leaving the base context unchanged for outbound connections.