### PR TITLE
Drop logs when idle connections are closed

### DIFF
--- a/idle_sweep.go
+++ b/idle_sweep.go
@@ -119,11 +119,10 @@ func (is *idleSweep) checkIdleConnections() {
 			continue
 		}
 
-		is.ch.log.WithFields(
-			LogField{"remotePeer", conn.remotePeerInfo},
+		conn.close(
+			LogField{"reason", "Idle connection closed"},
 			LogField{"lastActivityTimeRead", conn.getLastActivityReadTime()},
 			LogField{"lastActivityTimeWrite", conn.getLastActivityWriteTime()},
-		).Info("Closing idle inbound connection.")
-		conn.close(LogField{"reason", "Idle connection closed"})
+		)
 	}
 }


### PR DESCRIPTION
We currently have 2 logs whenever an idle connection is closed:
 * "Closing idle inbound connection"
 * "Connection closing." with reason="Idle connection closed"

The first log doesn't provide much value since the closing log already gives us
a detailed reason. Since it's redundant, drop the first log, and pass any fields
that only the first log had to the `close`, so they are included in the second log.