### PR TITLE
Fixes for compatibility with Go 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,19 @@ cache:
   - $HOME/.glide/cache
 
 go:
-- 1.13.x
-- 1.14.x
+  - oldstable
+  - stable
 
 matrix:
   include:
-  - go: 1.13.x
+  - go: stable
     env: CROSSDOCK=true
     sudo: required
     dist: trusty
     services:
     - docker
   include:
-  - go: 1.13.x
+  - go: stable
     env: NO_TEST=yes COVERAGE=yes LINT=yes
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export GO15VENDOREXPERIMENT=1
+export GO111MODULE=off
 
 PATH := $(GOPATH)/bin:$(PATH)
 EXAMPLES=./examples/bench/server ./examples/bench/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server

--- a/relay_benchmark_test.go
+++ b/relay_benchmark_test.go
@@ -119,7 +119,7 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 	dec := testutils.Decrementor(b.N)
 
 	for i, c := range clients {
-		go func(b *testing.B, i int, c benchmark.Client) {
+		go func(i int, c benchmark.Client) {
 			// Do a warm up call.
 			c.RawCall(1)
 
@@ -141,7 +141,7 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 					quantiles[i].Insert(float64(d))
 				}
 			}
-		}(b, i, c)
+		}(i, c)
 	}
 
 	var started time.Time

--- a/relay_benchmark_test.go
+++ b/relay_benchmark_test.go
@@ -119,7 +119,7 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 	dec := testutils.Decrementor(b.N)
 
 	for i, c := range clients {
-		go func(i int, c benchmark.Client) {
+		go func(b *testing.B, i int, c benchmark.Client) {
 			// Do a warm up call.
 			c.RawCall(1)
 
@@ -141,7 +141,7 @@ func benchmarkRelay(b *testing.B, p benchmarkParams) {
 					quantiles[i].Insert(float64(d))
 				}
 			}
-		}(i, c)
+		}(b, i, c)
 	}
 
 	var started time.Time

--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -325,7 +325,7 @@ func runTest(t *testing.T, opts processOptions, extraChecks func(string) error) 
 	}
 
 	// Run go build to ensure that the generated code builds.
-	cmd := exec.Command("go", "build", "-i", "./...")
+	cmd := exec.Command("go", "build", "./...")
 	cmd.Dir = tempDir
 	// NOTE: we check output, since go build ./... returns 0 status code on failure:
 	// https://github.com/golang/go/issues/11407


### PR DESCRIPTION
Ref https://golang.org/doc/go1.16#go-command

go modules are now enabled by default, so `go get` would fail
without explicitly turning it off via GO111MODULE=off

additionally, `go build -i` now returns an error during tests. since
that flag has been deprecated, remove it so the tests can pass.