### PR TITLE
change log level of connection create and close to debug

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -394,7 +394,7 @@ func (c *Connection) callOnActive() {
 			{"remotePeerTChannelVersion", remoteVersion.TChannelVersion},
 		}...)
 	}
-	log.Info("Created new active connection.")
+	log.Debug("Created new active connection.")
 
 	if f := c.events.OnActive; f != nil {
 		f(c)
@@ -849,7 +849,7 @@ func (c *Connection) checkExchanges() {
 }
 
 func (c *Connection) close(fields ...LogField) error {
-	c.log.WithFields(fields...).Info("Connection closing.")
+	c.log.WithFields(fields...).Debug("Connection closing.")
 
 	// Update the state which will start blocking incoming calls.
 	if err := c.withStateLock(func() error {


### PR DESCRIPTION
The connection creation and close logs are a bit excessive and can get
really spammy when a client is crashlooping. Change them to debug level
so they don't show up by default