### PR TITLE
peer: Avoid unnecessary rand when selecting from 1 connection

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -375,7 +375,10 @@ func (p *Peer) getActiveConnLocked() (*Connection, bool) {
 
 	// We cycle through the connection list, starting at a random point
 	// to avoid always choosing the same connection.
-	startOffset := peerRng.Intn(allConns)
+	var startOffset int
+	if allConns > 1 {
+		startOffset = peerRng.Intn(allConns)
+	}
 	for i := 0; i < allConns; i++ {
 		connIndex := (i + startOffset) % allConns
 		if conn := p.getConn(connIndex); conn.IsActive() {


### PR DESCRIPTION
If there's only a single connection, then allConns == 1, and
rand.Intn(1) is always 0. There's no point in calling rand (which
requires a mutex).