### PR TITLE
relay: Prefactor relay_messagest_test for flexible payload sizes

### DIFF
--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -82,7 +82,7 @@ func (cr testCallReq) frameWithParams(t testing.TB, p testCallReqParams) *Frame 
 
 	// Set the size in the header and write out the header after we know the payload contents.
 	defer func() {
-		fh.size = uint16(len(f.Payload)) + 16 // add 16 bytes for the header
+		fh.size = FrameHeaderSize + uint16(len(f.Payload))
 		f.Header = fh
 		require.NoError(t, fh.write(typed.NewWriteBuffer(f.headerBuffer)), "failed to write header")
 	}()


### PR DESCRIPTION
Currently, the test frame generation has some issues:
 * It assumes a fixed frame size (200 bytes)
 * It ignores errors from the typed Writer

Update the test to set the frame payload size based on the contents of
the payload, and to check for errors in the typed Writer.