### PR TITLE
relay: Fix overflow when reading large service

### DIFF
--- a/relay_messages.go
+++ b/relay_messages.go
@@ -46,20 +46,21 @@ const (
 	// Common to many frame types.
 	_flagsIndex = 0
 
-	// For call req.
-	_ttlIndex         = 1
-	_ttlLen           = 4
-	_spanIndex        = _ttlIndex + _ttlLen
-	_spanLength       = 25
-	_serviceLenIndex  = _spanIndex + _spanLength
-	_serviceNameIndex = _serviceLenIndex + 1
+	// For call req, indexes into the frame.
+	// Use int for indexes to avoid overflow caused by accidental byte arithmentic.
+	_ttlIndex         int = 1
+	_ttlLen           int = 4
+	_spanIndex        int = _ttlIndex + _ttlLen
+	_spanLength       int = 25
+	_serviceLenIndex  int = _spanIndex + _spanLength
+	_serviceNameIndex int = _serviceLenIndex + 1
 
 	// For call res and call res continue.
-	_resCodeOK    = 0x00
-	_resCodeIndex = 1
+	_resCodeOK        = 0x00
+	_resCodeIndex int = 1
 
 	// For error.
-	_errCodeIndex = 0
+	_errCodeIndex int = 0
 )
 
 type lazyError struct {
@@ -184,7 +185,7 @@ func (f *lazyCallReq) Caller() []byte {
 // Service returns the name of the destination service for this callReq.
 func (f *lazyCallReq) Service() []byte {
 	l := f.Payload[_serviceLenIndex]
-	return f.Payload[_serviceNameIndex : _serviceNameIndex+l]
+	return f.Payload[_serviceNameIndex : _serviceNameIndex+int(l)]
 }
 
 // Method returns the name of the method being called.

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -55,7 +55,7 @@ var (
 )
 
 const (
-	exampleService  = "bankemoji"
+	exampleService  = "fooservice"
 	exampleArg3Data = "some arg3 data"
 )
 

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -629,7 +629,7 @@ func TestLazyCallReqLargeService(t *testing.T) {
 				})
 
 				callReq, err := newLazyCallReq(f)
-				require.NoError(t, err)
+				require.NoError(t, err, "newLazyCallReq failed")
 
 				assert.Equal(t, largeService, string(callReq.Service()), "service name mismatch")
 			})


### PR DESCRIPTION
Ref SWNFWD-3138

Service names are expected to end at (_serviceNameIndex + length).
However, the length of the service is read as a byte, and
_serviceNameIndex is a constant (untyped). This results in the above
addition happening as a byte instead of an int, so it ends up
overflowing when _serviceNameIndex + length > 255. This overflow
can result in the end index being incorrect (pointing to before the
start index), which results in a panic:
```
panic: runtime error: slice bounds out of range [31:20]

goroutine 142 [running]:
github.com/uber/tchannel-go.(*lazyCallReq).Service(...)
        [..]/tchannel-go/relay_messages.go:187
[...]
```

To fix this, we need to do all operations using ints. To enforce this,
update all index constants to be typed as ints, as arithmetic operations
between 2 different types is disallowed, and fails on byte + int.

Update the test frame generator to support arbitrary service names
and adapt the frame length based on the contents vs a hardcoded value.