### PR TITLE
Extend RelayCall to inspect the call response frame

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -73,6 +73,11 @@ func (fh FrameHeader) FrameSize() uint16 {
 	return fh.size
 }
 
+// MessageType returns the type of the message
+func (fh FrameHeader) MessageType() byte {
+	return byte(fh.messageType)
+}
+
 func (fh FrameHeader) String() string { return fmt.Sprintf("%v[%d]", fh.messageType, fh.ID) }
 
 // MarshalJSON returns a `{"id":NNN, "msgType":MMM, "size":SSS}` representation

--- a/relay.go
+++ b/relay.go
@@ -554,7 +554,7 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 
 	switch f.messageType() {
 	case messageTypeCallRes:
-		// Invoke call.CallResponse() if we got the response frame
+		// Invoke call.CallResponse() if we get a valid call response frame.
 		cr, err := newLazyCallRes(f)
 		if err == nil {
 			item.call.CallResponse(cr)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -67,6 +67,18 @@ type CallFrame interface {
 	Arg2Append(key, val []byte)
 }
 
+// RespFrame is an interface that abstracts access to the CallRes frame
+type RespFrame interface {
+	// OK indicates whether the call was successful
+	OK() bool
+
+	// Arg2 returns the raw arg2 payload
+	Arg2() []byte
+
+	// Arg2Iterator returns an iterator for iterating over arg2 headers
+	Arg2Iterator() (arg2.KeyValIterator, error)
+}
+
 // Conn contains information about the underlying connection.
 type Conn struct {
 	// RemoteAddr is the remote address of the underlying TCP connection.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -72,11 +72,11 @@ type RespFrame interface {
 	// OK indicates whether the call was successful
 	OK() bool
 
+	// ArgScheme returns the scheme of the arg
+	ArgScheme() []byte
+
 	// Arg2 returns the raw arg2 payload
 	Arg2() []byte
-
-	// Arg2Iterator returns an iterator for iterating over arg2 headers
-	Arg2Iterator() (arg2.KeyValIterator, error)
 }
 
 // Conn contains information about the underlying connection.

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -75,6 +75,9 @@ type RespFrame interface {
 	// ArgScheme returns the scheme of the arg
 	ArgScheme() []byte
 
+	// Arg2IsFragmented indicates whether arg2 runs over the first frame
+	Arg2IsFragmented() bool
+
 	// Arg2 returns the raw arg2 payload
 	Arg2() []byte
 }

--- a/relay/relaytest/func_host.go
+++ b/relay/relaytest/func_host.go
@@ -14,7 +14,8 @@ type hostFunc struct {
 type hostFuncPeer struct {
 	*MockCallStats
 
-	peer *tchannel.Peer
+	peer      *tchannel.Peer
+	respFrame relay.RespFrame
 }
 
 // HostFunc wraps a given function to implement tchannel.RelayHost.
@@ -36,7 +37,7 @@ func (hf *hostFunc) Start(cf relay.CallFrame, conn *relay.Conn) (tchannel.RelayC
 	}
 
 	// We still track stats if we failed to get a peer, so return the peer.
-	return &hostFuncPeer{hf.stats.Begin(cf), peer}, err
+	return &hostFuncPeer{MockCallStats: hf.stats.Begin(cf), peer: peer}, err
 }
 
 func (hf *hostFunc) Stats() *MockStats {
@@ -45,4 +46,8 @@ func (hf *hostFunc) Stats() *MockStats {
 
 func (p *hostFuncPeer) Destination() (*tchannel.Peer, bool) {
 	return p.peer, p.peer != nil
+}
+
+func (p *hostFuncPeer) CallResponse(frame relay.RespFrame) {
+	p.respFrame = frame
 }

--- a/relay/relaytest/func_host.go
+++ b/relay/relaytest/func_host.go
@@ -5,6 +5,11 @@ import (
 	"github.com/uber/tchannel-go/relay"
 )
 
+// Ensure that the hostFunc implements tchannel.RelayHost and hostFuncPeer implements
+// tchannel.RelayCall
+var _ tchannel.RelayHost = (*hostFunc)(nil)
+var _ tchannel.RelayCall = (*hostFuncPeer)(nil)
+
 type hostFunc struct {
 	ch    *tchannel.Channel
 	stats *MockStats

--- a/relay/relaytest/stub_host.go
+++ b/relay/relaytest/stub_host.go
@@ -25,8 +25,10 @@ import (
 	"github.com/uber/tchannel-go/relay"
 )
 
-// Ensure that the StubRelayHost implements tchannel.RelayHost.
+// Ensure that the StubRelayHost implements tchannel.RelayHost and stubCall implements
+// tchannel.RelayCall
 var _ tchannel.RelayHost = (*StubRelayHost)(nil)
+var _ tchannel.RelayCall = (*stubCall)(nil)
 
 // StubRelayHost is a stub RelayHost for tests that backs peer selection to an
 // underlying channel using isolated subchannels and the default peer selection.

--- a/relay_api.go
+++ b/relay_api.go
@@ -20,7 +20,9 @@
 
 package tchannel
 
-import "github.com/uber/tchannel-go/relay"
+import (
+	"github.com/uber/tchannel-go/relay"
+)
 
 // RelayHost is the interface used to create RelayCalls when the relay
 // receives an incoming call.
@@ -48,6 +50,9 @@ type RelayCall interface {
 
 	// ReceivedBytes is called when a frame is received from the destination peer.
 	ReceivedBytes(uint16)
+
+	// CallResponse is called when a call response frame is received from the destination peer
+	CallResponse(relay.RespFrame)
 
 	// The call succeeded (possibly after retrying).
 	Succeeded()

--- a/relay_api.go
+++ b/relay_api.go
@@ -20,9 +20,7 @@
 
 package tchannel
 
-import (
-	"github.com/uber/tchannel-go/relay"
-)
+import "github.com/uber/tchannel-go/relay"
 
 // RelayHost is the interface used to create RelayCalls when the relay
 // receives an incoming call.

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -141,8 +141,14 @@ func (cr lazyCallRes) OK() bool {
 	return isCallResOK(cr.Frame)
 }
 
+// ArgScheme implements relay.RespFrame
 func (cr lazyCallRes) ArgScheme() []byte {
 	return cr.as
+}
+
+// Arg2IsFragmented implements relay.RespFrame
+func (cr lazyCallRes) Arg2IsFragmented() bool {
+	return cr.arg2IsFragmented
 }
 
 // Arg2 implements relay.RespFrame

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -31,6 +31,8 @@ import (
 	"github.com/uber/tchannel-go/typed"
 )
 
+var _ relay.RespFrame = (*lazyCallRes)(nil)
+
 var (
 	_callerNameKeyBytes      = []byte(CallerName)
 	_routingDelegateKeyBytes = []byte(RoutingDelegate)

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -98,10 +98,10 @@ func newLazyCallRes(f *Frame) (lazyCallRes, error) {
 	var as []byte
 	nh := int(rbuf.ReadSingleByte())
 	for i := 0; i < nh; i++ {
-		hk := int(rbuf.ReadSingleByte())
-		key := rbuf.ReadBytes(hk)
-		hv := int(rbuf.ReadSingleByte())
-		val := rbuf.ReadBytes(hv)
+		keyLen := int(rbuf.ReadSingleByte())
+		key := rbuf.ReadBytes(keyLen)
+		valLen := int(rbuf.ReadSingleByte())
+		val := rbuf.ReadBytes(valLen)
 
 		if bytes.Equal(key, _argSchemeKeyBytes) {
 			as = val

--- a/relay_messages.go
+++ b/relay_messages.go
@@ -80,7 +80,6 @@ func (e lazyError) Code() SystemErrCode {
 type lazyCallRes struct {
 	*Frame
 
-	isOK             bool
 	as               []byte
 	isThrift         bool
 	arg2IsFragmented bool
@@ -93,9 +92,9 @@ func newLazyCallRes(f *Frame) (lazyCallRes, error) {
 	}
 
 	rbuf := typed.NewReadBuffer(f.SizedPayload())
-	rbuf.SkipBytes(1)                           // flags
-	isOK := rbuf.ReadSingleByte() == _resCodeOK // code
-	rbuf.SkipBytes(_spanLength)                 // tracing
+	rbuf.SkipBytes(1)           // flags
+	rbuf.SkipBytes(1)           // code
+	rbuf.SkipBytes(_spanLength) // tracing
 
 	var (
 		as       []byte
@@ -137,7 +136,6 @@ func newLazyCallRes(f *Frame) (lazyCallRes, error) {
 
 	return lazyCallRes{
 		Frame:            f,
-		isOK:             isOK,
 		as:               as,
 		isThrift:         isThrift,
 		arg2IsFragmented: arg2IsFragmented,
@@ -147,7 +145,7 @@ func newLazyCallRes(f *Frame) (lazyCallRes, error) {
 
 // OK implements relay.RespFrame
 func (cr lazyCallRes) OK() bool {
-	return cr.isOK
+	return isCallResOK(cr.Frame)
 }
 
 // Arg2 implements relay.RespFrame

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -162,7 +162,6 @@ func withLazyCallReqCombinations(f func(cr testCallReq)) {
 type testCallRes int
 
 type testCallResParams struct {
-	payloadSize       int
 	hasFragmentedArg2 bool
 
 	flags       byte
@@ -187,9 +186,8 @@ const (
 )
 
 func (cr testCallRes) res(tb testing.TB) lazyCallRes {
-	params := testCallResParams{
-		payloadSize: MaxFramePayloadSize,
-	}
+	var params testCallResParams
+
 	if cr&resHasFragmentedArg2 != 0 {
 		params.hasFragmentedArg2 = true
 	}
@@ -230,7 +228,7 @@ func withLazyCallResCombinations(t *testing.T, f func(t *testing.T, cr testCallR
 }
 
 func newCallResFrame(tb testing.TB, p testCallResParams) *Frame {
-	f := NewFrame(p.payloadSize)
+	f := NewFrame(MaxFramePayloadSize)
 	fh := fakeHeader(messageTypeCallRes)
 	payload := typed.NewWriteBuffer(f.Payload)
 
@@ -676,7 +674,6 @@ func TestLazyCallRes(t *testing.T) {
 
 func TestLazyCallResCorruptedFrame(t *testing.T) {
 	_, err := newLazyCallRes(newCallResFrame(t, testCallResParams{
-		payloadSize: 100,
 		arg2Prefix:  []byte{0, 100},
 		arg2KeyVals: exampleArg2Map,
 	}))

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -688,7 +688,7 @@ func TestLazyCallRes(t *testing.T) {
 	})
 }
 
-func TestLazyCallResCorruptedFrame(t *testing.T) {
+func TestNewLazyCallResCorruptedFrame(t *testing.T) {
 	_, err := newLazyCallRes(newCallResFrame(t, testCallResParams{
 		arg2Prefix:  []byte{0, 100},
 		arg2KeyVals: exampleArg2Map,

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -199,12 +199,11 @@ func (cr testCallRes) res(tb testing.TB) lazyCallRes {
 	if cr&resIsOK == 0 {
 		params.code = 1
 	}
+	params.headers = map[string]string{}
 	if cr&resHasHeaders != 0 {
-		params.headers = map[string]string{
-			"k1":      "v1",
-			"k222222": "",
-			"k3":      "thisisalonglongkey",
-		}
+		params.headers["k1"] = "v1"
+		params.headers["k222222"] = ""
+		params.headers["k3"] = "thisisalonglongkey"
 	}
 	if cr&(resHasArg2|resHasFragmentedArg2) != 0 {
 		params.headers[string(_argSchemeKeyBytes)] = string(_tchanThriftValueBytes)
@@ -681,7 +680,7 @@ func TestLazyCallRes(t *testing.T) {
 func TestLazyCallResCorruptedFrame(t *testing.T) {
 	_, err := newLazyCallRes(newCallResFrame(t, testCallResParams{
 		payloadSize: 100,
-		arg2Prefix:  []byte{0, 1},
+		arg2Prefix:  []byte{0, 100},
 		arg2KeyVals: exampleArg2Map,
 	}))
 

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -286,9 +286,6 @@ func newCallResFrame(tb testing.TB, p testCallResParams) *Frame {
 	}
 
 	require.NoError(tb, payload.Err(), "Got unexpected error constructing callRes frame")
-	fh.SetPayloadSize(uint16(payload.BytesWritten()))
-	f.Header = fh
-	require.NoError(tb, fh.write(typed.NewWriteBuffer(f.headerBuffer)), "Failed to write header")
 
 	return f
 }

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -665,7 +665,7 @@ func TestLazyCallRes(t *testing.T) {
 
 		// arg2IsFragmented
 		if crt&resHasFragmentedArg2 != 0 {
-			assert.True(t, cr.arg2IsFragmented, "Expected arg2 to be fragmented")
+			assert.True(t, cr.Arg2IsFragmented(), "Expected arg2 to be fragmented")
 		}
 
 		if crt&resIsThrift != 0 {


### PR DESCRIPTION
In order to support features where inspection of the response frame is required, extend `RelayCall` with an additional `CallResponse()` method which can be used for inspecting the response frame of a call. A new interface `RespFrame` is added which mirrors the `CallFrame` passed into `RelayHost.Start()`.