### PR TITLE
[tchannel-go] Add options to support handlers with ignoring methods

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -124,10 +124,12 @@ type ChannelOptions struct {
 	// default handler that delegates to a subchannel.
 	Handler Handler
 
-	// HandlerWithIgnore allows users to configure TChannel server such that
-	// requests with specified methods can be ignored by passed-in handler and natively by TChannel.
-	// All other methods will be handled by passed-in handler.
-	HandlerWithIgnore HandlerWithIgnore
+	// IgnoreMethods allow users to configure TChannel server such that
+	// requests with specified methods can be ignored by the above passed-in handler
+	// and handled natively by TChannel.
+	// Requests with other methods will be handled by passed-in handler.
+	// This is useful for the gradual migration purpose.
+	IgnoreMethods []string
 
 	// Dialer is optional factory method which can be used for overriding
 	// outbound connections for things like TLS handshake
@@ -137,16 +139,6 @@ type ChannelOptions struct {
 	// the per-connection base context. This context is used as the parent context
 	// for incoming calls.
 	ConnContext func(ctx context.Context, conn net.Conn) context.Context
-}
-
-// HandlerWithIgnore allows users to configure TChannel server such that
-// requests with method listed in NativeHanderMethods are
-// ignored by passed-in handler and natively by TChannel.
-// All other methods will be handled by passed-in handler.
-type HandlerWithIgnore struct {
-	Handler Handler
-	// should we generalize to a func(request) bool here?
-	IgnoreMethods []string
 }
 
 // ChannelState is the state of a channel.
@@ -319,15 +311,15 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 	}
 	ch.peers = newRootPeerList(ch, opts.OnPeerStatusChanged).newChild()
 
-	switch n := opts.HandlerWithIgnore; {
+	switch {
+	case len(opts.IgnoreMethods) > 0 && opts.Handler != nil:
+		ch.handler = userHandlerWithIgnore{
+			localHandler:      channelHandler{ch},
+			ignoreUserHandler: toStringSet(opts.IgnoreMethods),
+			userHandler:       opts.Handler,
+		}
 	case opts.Handler != nil:
 		ch.handler = opts.Handler
-	case len(n.IgnoreMethods) > 0 && n.Handler != nil:
-		ch.handler = userHandlerWithIgnore{
-			ch:          ch,
-			ignore:      toStringSet(n.IgnoreMethods),
-			userHandler: n.Handler,
-		}
 	default:
 		ch.handler = channelHandler{ch}
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -23,6 +23,7 @@ package tchannel
 import (
 	"reflect"
 	"runtime"
+	"strings"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -124,4 +125,26 @@ type channelHandler struct{ ch *Channel }
 
 func (c channelHandler) Handle(ctx context.Context, call *InboundCall) {
 	c.ch.GetSubChannel(call.ServiceName()).handler.Handle(ctx, call)
+}
+
+// channelHandlerWithNative is a Handler that wraps a Channel and delegates requests
+// to SubChannels if the inbound call's service and method name are configured to
+// ignore passed-in thirdparty handlers.
+type userHandlerWithIgnore struct {
+	ch          *Channel
+	ignore      map[string]struct{} // key is serviceName::method format
+	userHandler Handler
+}
+
+func (u userHandlerWithIgnore) Handle(ctx context.Context, call *InboundCall) {
+	var sb strings.Builder
+	sb.WriteString(call.ServiceName())
+	sb.WriteString("::")
+	sb.Write(call.Method())
+
+	if _, ok := u.ignore[sb.String()]; ok {
+		u.ch.GetSubChannel(call.ServiceName()).handler.Handle(ctx, call)
+		return
+	}
+	u.userHandler.Handle(ctx, call)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -21,9 +21,11 @@
 package tchannel
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -56,4 +58,59 @@ func TestHandlers(t *testing.T) {
 	hmap.register(h2, m2)
 	assert.Equal(t, h1, hmap.find(m1b))
 	assert.Equal(t, h2, hmap.find(m2b))
+}
+
+func procedure(svc, method string) string {
+	return fmt.Sprintf("%s::%s", svc, method)
+}
+
+func TestUserHandlerWithIgnore(t *testing.T) {
+	const (
+		svc          = "svc"
+		method       = "method"
+		ignoreMethod = "ignoreMethod"
+		runs         = 3
+	)
+
+	ch, err := NewChannel(svc, nil /* ChannelOptions */)
+	require.NoError(t, err, "error creating a TChannel channel")
+
+	userCounter, channelCounter := map[string]int{}, map[string]int{}
+	ch.Register(recorderHandler(channelCounter), ignoreMethod)
+
+	u := userHandlerWithIgnore{
+		ch: ch,
+		ignore: map[string]struct{}{
+			procedure(svc, ignoreMethod): struct{}{},
+		},
+		userHandler: recorderHandler(userCounter),
+	}
+	// need to populate connection.log to avoid nil pointer
+	conn := &Connection{}
+	conn.log = ch.log
+	call := &InboundCall{
+		serviceName:  svc,
+		method:       []byte(method),
+		methodString: method,
+		conn:         conn,
+	}
+	ignoreCall := &InboundCall{
+		serviceName:  svc,
+		method:       []byte(ignoreMethod),
+		methodString: ignoreMethod,
+		conn:         conn,
+	}
+
+	for i := 0; i < runs; i++ {
+		u.Handle(context.Background(), ignoreCall)
+		u.Handle(context.Background(), call)
+	}
+	assert.Equal(t, map[string]int{procedure(svc, method): runs}, userCounter, "user provided handler not invoked correct amount of times")
+	assert.Equal(t, map[string]int{procedure(svc, ignoreMethod): runs}, channelCounter, "channel handler not invoked correct amount of times after ignoring user provided handler")
+}
+
+type recorderHandler map[string]int
+
+func (r recorderHandler) Handle(ctx context.Context, call *InboundCall) {
+	r[procedure(call.ServiceName(), call.MethodString())]++
 }

--- a/introspection.go
+++ b/introspection.go
@@ -563,7 +563,7 @@ func (ch *Channel) createInternalHandlers() *handlerMap {
 		}
 
 		h := HandlerFunc(handler)
-		internalHandlers.register(h, ep.name)
+		internalHandlers.Register(h, ep.name)
 
 		// Register under the service name of channel as well (for backwards compatibility).
 		ch.GetSubChannel(ch.PeerInfo().ServiceName).Register(h, ep.name)

--- a/subchannel.go
+++ b/subchannel.go
@@ -108,14 +108,15 @@ func (c *SubChannel) Isolated() bool {
 // This function panics if the Handler for the SubChannel was overwritten with
 // SetHandler.
 func (c *SubChannel) Register(h Handler, methodName string) {
-	handlers, ok := c.handler.(*handlerMap)
+	r, ok := c.handler.(registrar)
 	if !ok {
 		panic(fmt.Sprintf(
-			"handler for SubChannel(%v) was changed to disallow method registration",
+			"handler for SubChannel(%v) configured with alternate root handler without Register method",
 			c.ServiceName(),
 		))
 	}
-	handlers.register(h, methodName)
+
+	r.Register(h, methodName)
 }
 
 // GetHandlers returns all handlers registered on this subchannel by method name.

--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ package tchannel
 // VersionInfo identifies the version of the TChannel library.
 // Due to lack of proper package management, this version string will
 // be maintained manually.
-const VersionInfo = "1.12.2"
+const VersionInfo = "1.21.2"

--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ package tchannel
 // VersionInfo identifies the version of the TChannel library.
 // Due to lack of proper package management, this version string will
 // be maintained manually.
-const VersionInfo = "1.21.2"
+const VersionInfo = "1.21.2-dev"


### PR DESCRIPTION
If a user wants to migrate off tchannel-go server on a per method level, we need a way to allow users to specify: `for those specified methods, tchannel-go should handle it as before. But for others, let passed-in handler handle it`. This PR provides an additional option to allow such use case for gradual migration.