### PR TITLE
refactor callRes test frame construction

### DIFF
--- a/frame_test.go
+++ b/frame_test.go
@@ -37,16 +37,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func fakeHeader() FrameHeader {
+func fakeHeader(t messageType) FrameHeader {
 	return FrameHeader{
 		size:        uint16(0xFF34),
-		messageType: messageTypeCallReq,
+		messageType: t,
 		ID:          0xDEADBEEF,
 	}
 }
 
 func TestFrameHeaderJSON(t *testing.T) {
-	fh := fakeHeader()
+	fh := fakeHeader(messageTypeCallReq)
 	logged, err := json.Marshal(fh)
 	assert.NoError(t, err, "FrameHeader can't be marshalled to JSON")
 	assert.Equal(
@@ -58,7 +58,7 @@ func TestFrameHeaderJSON(t *testing.T) {
 }
 
 func TestFraming(t *testing.T) {
-	fh := fakeHeader()
+	fh := fakeHeader(messageTypeCallReq)
 	wbuf := typed.NewWriteBufferWithSize(1024)
 	require.Nil(t, fh.write(wbuf))
 

--- a/relay_messages_test.go
+++ b/relay_messages_test.go
@@ -37,10 +37,6 @@ import (
 
 type testCallReq int
 
-type keyVal struct {
-	key, val string
-}
-
 const (
 	reqHasHeaders testCallReq = (1 << iota)
 	reqHasCaller


### PR DESCRIPTION
Prefactor for #830 

I'd like to refactor the code for constructing `callRes` frames so that we can easily add more scenarios such as malformed args or different arg schemes. This is important since arg2 iteration is supported only for thrift calls, and we will be doing some error checking in `newLazyCallRes` which can be complicated to test with the current code.