### PR TITLE
Channel: Fix ignore-user-handler methods lookup map

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -909,7 +909,7 @@ func toStringSet(ss []string) map[string]struct{} {
 }
 
 // take a list of service::method formatted string and make
-// the map[service]map[method]struct{} set
+// the map[service]map[service::method]struct{} set
 func toServiceMethodSet(sms []string) (map[string]map[string]struct{}, error) {
 	set := map[string]map[string]struct{}{}
 	for _, sm := range sms {
@@ -917,11 +917,11 @@ func toServiceMethodSet(sms []string) (map[string]map[string]struct{}, error) {
 		if len(s) != 2 {
 			return nil, fmt.Errorf("each %q value should be of service::Method format but got %q", "SkipHandlerMethods", sm)
 		}
-		svc, method := s[0], s[1]
+		svc := s[0]
 		if _, ok := set[svc]; !ok {
 			set[svc] = map[string]struct{}{}
 		}
-		set[svc][method] = struct{}{}
+		set[svc][sm] = struct{}{}
 	}
 	return set, nil
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -195,7 +195,7 @@ func TestToServiceMethodSet(t *testing.T) {
 			sms:  []string{"service::Method"},
 			want: map[string]map[string]struct{}{
 				"service": map[string]struct{}{
-					"Method": struct{}{},
+					"service::Method": struct{}{},
 				},
 			},
 		},
@@ -204,9 +204,9 @@ func TestToServiceMethodSet(t *testing.T) {
 			sms:  []string{"service::Method1", "service::Method2", "service::Method3"},
 			want: map[string]map[string]struct{}{
 				"service": map[string]struct{}{
-					"Method1": struct{}{},
-					"Method2": struct{}{},
-					"Method3": struct{}{},
+					"service::Method1": struct{}{},
+					"service::Method2": struct{}{},
+					"service::Method3": struct{}{},
 				},
 			},
 		},
@@ -215,13 +215,13 @@ func TestToServiceMethodSet(t *testing.T) {
 			sms:  []string{"service1::Method1", "service2::Method1", "service3::Method1"},
 			want: map[string]map[string]struct{}{
 				"service1": map[string]struct{}{
-					"Method1": struct{}{},
+					"service1::Method1": struct{}{},
 				},
 				"service2": map[string]struct{}{
-					"Method1": struct{}{},
+					"service2::Method1": struct{}{},
 				},
 				"service3": map[string]struct{}{
-					"Method1": struct{}{},
+					"service3::Method1": struct{}{},
 				},
 			},
 		},
@@ -230,12 +230,12 @@ func TestToServiceMethodSet(t *testing.T) {
 			sms:  []string{"service1::Method1", "service1::Method2", "service2::Method1", "service2::Method2"},
 			want: map[string]map[string]struct{}{
 				"service1": map[string]struct{}{
-					"Method1": struct{}{},
-					"Method2": struct{}{},
+					"service1::Method1": struct{}{},
+					"service1::Method2": struct{}{},
 				},
 				"service2": map[string]struct{}{
-					"Method1": struct{}{},
-					"Method2": struct{}{},
+					"service2::Method1": struct{}{},
+					"service2::Method2": struct{}{},
 				},
 			},
 		},

--- a/handlers_with_skip_test.go
+++ b/handlers_with_skip_test.go
@@ -58,21 +58,21 @@ func TestUserHandlerWithSkip(t *testing.T) {
 
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		// channel should be able to handle user ignored methods
-		ts.Register(channelCounter, userHandleSkipMethod)
+		ts.Register(channelCounter, procedure(svc, userHandleSkipMethod))
 
 		client := ts.NewClient(nil)
 
 		for i := 0; i < handleRuns; i++ {
 			ctx, cancel := tchannel.NewContext(testutils.Timeout(300 * time.Millisecond))
 			defer cancel()
-			raw.Call(ctx, client, ts.HostPort(), svc, userHandleMethod, nil, nil)
+			raw.Call(ctx, client, ts.HostPort(), svc, procedure(svc, userHandleMethod), nil, nil)
 		}
 		assert.Equal(t, uint32(handleRuns), userCounter.c.Load(), "user provided handler not invoked correct amount of times")
 
 		for i := 0; i < handleSkipRuns; i++ {
 			ctx, cancel := tchannel.NewContext(testutils.Timeout(300 * time.Millisecond))
 			defer cancel()
-			raw.Call(ctx, client, ts.HostPort(), svc, userHandleSkipMethod, nil, nil)
+			raw.Call(ctx, client, ts.HostPort(), svc, procedure(svc, userHandleSkipMethod), nil, nil)
 		}
 		assert.Equal(t, uint32(handleSkipRuns), channelCounter.c.Load(), "user provided handler not invoked correct amount of times")
 	})


### PR DESCRIPTION
Skip user-handler (originally added in #835 by @AllenLuUber) uses the` ignoreUserHandler` map to decide when the user-provided handler or the local handler must handle a call. During channel creation, `Ignore-map` is created with the `method` name without the service prefix, but the handler receives the procedure with the service prefix, which causes the skip handler always to forward the request user-handler.
Earlier:
```go
map[service]map[method]struct{}
```

After:
```go
map[service]map[service::method]struct{} set
```