### PR TITLE
Remove service name map in ignore user handler 

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -909,7 +909,7 @@ func toStringSet(ss []string) map[string]struct{} {
 }
 
 // take a list of service::method formatted string and make
-// the map[service]map[service::method]struct{} set
+// the map[service::method]struct{} set
 func toServiceMethodSet(sms []string) (map[string]struct{}, error) {
 	set := map[string]struct{}{}
 	for _, sm := range sms {

--- a/channel.go
+++ b/channel.go
@@ -913,8 +913,7 @@ func toStringSet(ss []string) map[string]struct{} {
 func toServiceMethodSet(sms []string) (map[string]struct{}, error) {
 	set := map[string]struct{}{}
 	for _, sm := range sms {
-		s := strings.Split(sm, "::")
-		if len(s) != 2 {
+		if len(strings.Split(sm, "::")) != 2 {
 			return nil, fmt.Errorf("each %q value should be of service::Method format but got %q", "SkipHandlerMethods", sm)
 		}
 		set[sm] = struct{}{}

--- a/channel.go
+++ b/channel.go
@@ -910,18 +910,14 @@ func toStringSet(ss []string) map[string]struct{} {
 
 // take a list of service::method formatted string and make
 // the map[service]map[service::method]struct{} set
-func toServiceMethodSet(sms []string) (map[string]map[string]struct{}, error) {
-	set := map[string]map[string]struct{}{}
+func toServiceMethodSet(sms []string) (map[string]struct{}, error) {
+	set := map[string]struct{}{}
 	for _, sm := range sms {
 		s := strings.Split(sm, "::")
 		if len(s) != 2 {
 			return nil, fmt.Errorf("each %q value should be of service::Method format but got %q", "SkipHandlerMethods", sm)
 		}
-		svc := s[0]
-		if _, ok := set[svc]; !ok {
-			set[svc] = map[string]struct{}{}
-		}
-		set[svc][sm] = struct{}{}
+		set[sm] = struct{}{}
 	}
 	return set, nil
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -187,56 +187,23 @@ func TestToServiceMethodSet(t *testing.T) {
 	tests := []struct {
 		desc    string
 		sms     []string
-		want    map[string]map[string]struct{}
+		want    map[string]struct{}
 		wantErr string
 	}{
 		{
 			desc: "single service, single method",
 			sms:  []string{"service::Method"},
-			want: map[string]map[string]struct{}{
-				"service": map[string]struct{}{
-					"service::Method": struct{}{},
-				},
+			want: map[string]struct{}{
+				"service::Method": struct{}{},
 			},
 		},
 		{
 			desc: "single service, multiple methods",
 			sms:  []string{"service::Method1", "service::Method2", "service::Method3"},
-			want: map[string]map[string]struct{}{
-				"service": map[string]struct{}{
-					"service::Method1": struct{}{},
-					"service::Method2": struct{}{},
-					"service::Method3": struct{}{},
-				},
-			},
-		},
-		{
-			desc: "multiple services, single method",
-			sms:  []string{"service1::Method1", "service2::Method1", "service3::Method1"},
-			want: map[string]map[string]struct{}{
-				"service1": map[string]struct{}{
-					"service1::Method1": struct{}{},
-				},
-				"service2": map[string]struct{}{
-					"service2::Method1": struct{}{},
-				},
-				"service3": map[string]struct{}{
-					"service3::Method1": struct{}{},
-				},
-			},
-		},
-		{
-			desc: "multiple services, multiple methods",
-			sms:  []string{"service1::Method1", "service1::Method2", "service2::Method1", "service2::Method2"},
-			want: map[string]map[string]struct{}{
-				"service1": map[string]struct{}{
-					"service1::Method1": struct{}{},
-					"service1::Method2": struct{}{},
-				},
-				"service2": map[string]struct{}{
-					"service2::Method1": struct{}{},
-					"service2::Method2": struct{}{},
-				},
+			want: map[string]struct{}{
+				"service::Method1": struct{}{},
+				"service::Method2": struct{}{},
+				"service::Method3": struct{}{},
 			},
 		},
 		{

--- a/handlers.go
+++ b/handlers.go
@@ -143,12 +143,12 @@ func (c channelHandler) Register(h Handler, methodName string) {
 // from ignore.
 type userHandlerWithSkip struct {
 	localHandler      channelHandler
-	ignoreUserHandler map[string]map[string]struct{} // key is service, subkey is method
+	ignoreUserHandler map[string]struct{} // key is service, subkey is method
 	userHandler       Handler
 }
 
 func (u userHandlerWithSkip) Handle(ctx context.Context, call *InboundCall) {
-	if _, ok := u.ignoreUserHandler[call.ServiceName()][call.MethodString()]; ok {
+	if _, ok := u.ignoreUserHandler[call.MethodString()]; ok {
 		u.localHandler.Handle(ctx, call)
 		return
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -139,11 +139,10 @@ func (c channelHandler) Register(h Handler, methodName string) {
 // userHandlerWithSkip is a Handler that wraps a localHandler backed by the channel.
 // and a user provided handler.
 // The inbound call will be handled by user handler, unless the call's
-// service and method name are configured to be handled by localHandler
-// from ignore.
+// method name is configured to be handled by localHandler from ignore.
 type userHandlerWithSkip struct {
 	localHandler      channelHandler
-	ignoreUserHandler map[string]struct{} // key is service, subkey is method
+	ignoreUserHandler map[string]struct{} // key is service::method
 	userHandler       Handler
 }
 


### PR DESCRIPTION
`IgnoreUserHandler` works on the primary channel where it handles methods belonging to the root service name. Also, the current ignore-user-handler derives the Tchannel service name from the method name, but the method name contains thrift service name which may be different, for example, tchannel service name: `echo` and method name: `Echo::echohi`. To avoid such cases, we can drop the service name map and use the procedure map.