### PR TITLE
Fix frame leaks in handleNonCallReq

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -209,6 +209,8 @@ const (
 	responseFrame frameType = 1
 )
 
+var _ frameReceiver = (*Relayer)(nil)
+
 // A Relayer forwards frames.
 type Relayer struct {
 	relayHost      RelayHost
@@ -266,7 +268,7 @@ func NewRelayer(ch *Channel, conn *Connection) *Relayer {
 // Relay is called for each frame that is read on the connection.
 func (r *Relayer) Relay(f *Frame) (shouldRelease bool, _ error) {
 	if f.messageType() != messageTypeCallReq {
-		err := r.handleNonCallReq(f)
+		shouldRelease, err := r.handleNonCallReq(f)
 		if err == errUnknownID {
 			// This ID may be owned by an outgoing call, so check the outbound
 			// message exchange, and if it succeeds, then the frame has been
@@ -275,7 +277,7 @@ func (r *Relayer) Relay(f *Frame) (shouldRelease bool, _ error) {
 				return _relayNoRelease, nil
 			}
 		}
-		return _relayNoRelease, err
+		return shouldRelease, err
 	}
 
 	cr, err := newLazyCallReq(f)
@@ -530,7 +532,7 @@ func (r *Relayer) handleCallReq(f *lazyCallReq) (shouldRelease bool, _ error) {
 }
 
 // Handle all frames except messageTypeCallReq.
-func (r *Relayer) handleNonCallReq(f *Frame) error {
+func (r *Relayer) handleNonCallReq(f *Frame) (shouldRelease bool, _ error) {
 	frameType := frameTypeFor(f)
 	finished := finishesCall(f)
 
@@ -544,12 +546,12 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	// Stop the timeout if the call if finished.
 	item, stopped, ok := items.Get(f.Header.ID, finished /* stopTimeout */)
 	if !ok {
-		return errUnknownID
+		return _relayShouldRelease, errUnknownID
 	}
 	if item.tomb || (finished && !stopped) {
 		// Item has previously timed out, or is in the process of timing out.
 		// TODO: metrics for late-arriving frames.
-		return nil
+		return _relayShouldRelease, nil
 	}
 
 	switch f.messageType() {
@@ -582,13 +584,13 @@ func (r *Relayer) handleNonCallReq(f *Frame) error {
 	sent, failure := item.destination.Receive(f, frameType)
 	if !sent {
 		r.failRelayItem(items, originalID, failure, errFrameNotSent)
-		return nil
+		return _relayShouldRelease, nil
 	}
 
 	if finished {
 		r.finishRelayItem(items, originalID)
 	}
-	return nil
+	return !sent, nil
 }
 
 // addRelayItem adds a relay item to either outbound or inbound.

--- a/relay.go
+++ b/relay.go
@@ -506,7 +506,7 @@ func (r *Relayer) handleCallReq(f *lazyCallReq) (shouldRelease bool, _ error) {
 	// over the max frame size. Do a fragmenting send which is slightly more expensive but
 	// will handle fragmenting if it is needed.
 	if len(f.arg2Appends) > 0 {
-		if err := r.fragmentingSend(call, f, relayToDest, origID); err != nil && true {
+		if err := r.fragmentingSend(call, f, relayToDest, origID); err != nil {
 			r.failRelayItem(r.outbound, origID, _relayArg2ModifyFailed, err)
 			r.logger.WithFields(
 				LogField{"id", origID},
@@ -590,7 +590,7 @@ func (r *Relayer) handleNonCallReq(f *Frame) (shouldRelease bool, _ error) {
 	if finished {
 		r.finishRelayItem(items, originalID)
 	}
-	return !sent, nil
+	return _relayNoRelease, nil
 }
 
 // addRelayItem adds a relay item to either outbound or inbound.

--- a/relay_fragment_sender_test.go
+++ b/relay_fragment_sender_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/uber/tchannel-go/typed"
 )
 
+var _ frameReceiver = (*dummyFrameReceiver)(nil)
+
 type dummyFrameReceiver struct {
 	t                *testing.T
 	retSent          bool

--- a/relay_test.go
+++ b/relay_test.go
@@ -259,8 +259,8 @@ func TestErrorFrameEndsRelay(t *testing.T) {
 	// TestServer validates that there are no relay items left after the given func.
 	opts := serviceNameOpts("svc").
 		SetRelayOnly().
-		DisableLogVerification().
-		SetCheckFramePooling()
+		SetCheckFramePooling().
+		DisableLogVerification()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		client := ts.NewClient(nil)
 
@@ -558,8 +558,8 @@ func TestRelayInboundConnContext(t *testing.T) {
 
 	opts := testutils.NewOpts().
 		SetRelayOnly().
-		SetRelayHost(rh).
 		SetCheckFramePooling().
+		SetRelayHost(rh).
 		SetConnContext(func(ctx context.Context, conn net.Conn) context.Context {
 			return context.WithValue(ctx, "foo", "bar")
 		})
@@ -581,8 +581,8 @@ func TestRelayContextInheritsFromOutboundConnection(t *testing.T) {
 	})
 	opts := testutils.NewOpts().
 		SetRelayOnly().
-		SetRelayHost(rh).
-		SetCheckFramePooling()
+		SetCheckFramePooling().
+		SetRelayHost(rh)
 
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		rly := ts.Relay()
@@ -1217,8 +1217,8 @@ func TestRelayArg2OffsetIntegration(t *testing.T) {
 	frameCh := inspectFrames(rh)
 	opts := testutils.NewOpts().
 		SetRelayOnly().
-		SetRelayHost(rh).
-		SetCheckFramePooling()
+		SetCheckFramePooling().
+		SetRelayHost(rh)
 
 	testutils.WithTestServer(t, opts, func(tb testing.TB, ts *testutils.TestServer) {
 		const (
@@ -1353,8 +1353,8 @@ func TestRelayThriftArg2KeyValueIteration(t *testing.T) {
 	frameCh := inspectFrames(rh)
 	opts := testutils.NewOpts().
 		SetRelayOnly().
-		SetRelayHost(rh).
-		SetCheckFramePooling()
+		SetCheckFramePooling().
+		SetRelayHost(rh)
 
 	testutils.WithTestServer(t, opts, func(tb testing.TB, ts *testutils.TestServer) {
 		kv := map[string]string{
@@ -1567,8 +1567,8 @@ func TestRelayCallResponse(t *testing.T) {
 
 	opts := testutils.NewOpts().
 		SetRelayOnly().
-		SetRelayHost(rh).
-		SetCheckFramePooling()
+		SetCheckFramePooling().
+		SetRelayHost(rh)
 
 	testutils.WithTestServer(t, opts, func(tb testing.TB, ts *testutils.TestServer) {
 		const (
@@ -1638,8 +1638,8 @@ func TestRelayAppendArg2SentBytes(t *testing.T) {
 
 			opts := testutils.NewOpts().
 				SetRelayOnly().
-				SetRelayHost(rh).
-				SetCheckFramePooling()
+				SetCheckFramePooling().
+				SetRelayHost(rh)
 			testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 				rly := ts.Relay()
 				svr := ts.Server()
@@ -2029,8 +2029,8 @@ func TestRelayModifyArg2ShouldFail(t *testing.T) {
 			})
 			opts := testutils.NewOpts().
 				SetRelayOnly().
-				SetRelayHost(rh).
 				SetCheckFramePooling().
+				SetRelayHost(rh).
 				AddLogFilter("Failed to send call with modified arg2.", 1)
 
 			testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {

--- a/relay_test.go
+++ b/relay_test.go
@@ -823,11 +823,13 @@ func TestRelayStalledConnection(t *testing.T) {
 	if os.Getenv("GITHUB_WORKFLOW") != "" {
 		t.Skip("skipping test flaky in github actions.")
 	}
+
 	opts := testutils.NewOpts().
 		AddLogFilter("Dropping call due to slow connection.", 1, "sendChCapacity", "32").
 		SetSendBufferSize(32). // We want to hit the buffer size earlier, but also ensure we're only dropping once the sendCh is full.
 		SetServiceName("s1").
-		SetRelayOnly()
+		SetRelayOnly().
+		SetCheckFramePooling()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		s2 := ts.NewServer(testutils.NewOpts().SetServiceName("s2"))
 		testutils.RegisterEcho(s2, nil)
@@ -1993,7 +1995,6 @@ func TestRelayModifyArg2(t *testing.T) {
 }
 
 func TestRelayModifyArg2ShouldFail(t *testing.T) {
-	// TODO: enable framepool checks
 	tests := []struct {
 		msg     string
 		arg2    []byte
@@ -2029,6 +2030,7 @@ func TestRelayModifyArg2ShouldFail(t *testing.T) {
 			opts := testutils.NewOpts().
 				SetRelayOnly().
 				SetRelayHost(rh).
+				SetCheckFramePooling().
 				AddLogFilter("Failed to send call with modified arg2.", 1)
 
 			testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -31,13 +31,15 @@ import (
 	"golang.org/x/net/context"
 )
 
+const _echoTimeout = 500 * time.Millisecond
+
 // CallEcho calls the "echo" endpoint from the given src to target.
 func CallEcho(src *tchannel.Channel, targetHostPort, targetService string, args *raw.Args) error {
 	if args == nil {
 		args = &raw.Args{}
 	}
 
-	ctx, cancel := tchannel.NewContextBuilder(Timeout(300 * time.Millisecond)).
+	ctx, cancel := tchannel.NewContextBuilder(Timeout(_echoTimeout)).
 		SetFormat(args.Format).
 		Build()
 	defer cancel()
@@ -49,7 +51,7 @@ func CallEcho(src *tchannel.Channel, targetHostPort, targetService string, args 
 // AssertEcho calls the "echo" endpoint with random data, and asserts
 // that the returned data matches the arguments "echo" was called with.
 func AssertEcho(tb testing.TB, src *tchannel.Channel, targetHostPort, targetService string) {
-	ctx, cancel := tchannel.NewContext(Timeout(300 * time.Millisecond))
+	ctx, cancel := tchannel.NewContext(Timeout(_echoTimeout))
 	defer cancel()
 
 	args := &raw.Args{

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -31,15 +31,13 @@ import (
 	"golang.org/x/net/context"
 )
 
-const _echoTimeout = 500 * time.Millisecond
-
 // CallEcho calls the "echo" endpoint from the given src to target.
 func CallEcho(src *tchannel.Channel, targetHostPort, targetService string, args *raw.Args) error {
 	if args == nil {
 		args = &raw.Args{}
 	}
 
-	ctx, cancel := tchannel.NewContextBuilder(Timeout(_echoTimeout)).
+	ctx, cancel := tchannel.NewContextBuilder(Timeout(300 * time.Millisecond)).
 		SetFormat(args.Format).
 		Build()
 	defer cancel()
@@ -51,7 +49,7 @@ func CallEcho(src *tchannel.Channel, targetHostPort, targetService string, args 
 // AssertEcho calls the "echo" endpoint with random data, and asserts
 // that the returned data matches the arguments "echo" was called with.
 func AssertEcho(tb testing.TB, src *tchannel.Channel, targetHostPort, targetService string) {
-	ctx, cancel := tchannel.NewContext(Timeout(_echoTimeout))
+	ctx, cancel := tchannel.NewContext(Timeout(300 * time.Millisecond))
 	defer cancel()
 
 	args := &raw.Args{


### PR DESCRIPTION
Recently it was discovered that a number of code paths in the relayer would result in frame leaks, where after a relay decision (either send to `Connection.writeFrames()` for sending or dropped) the frame isn't returned to the frame pool, resulting in a memory leak.

With the previous PRs #847 and #852, we are now in a position to address the leaks in each code path. This change fixes the leaks in `handleNonCallReq()` as detected by the existing tests.