### PR TITLE
Add option to check frame leaks after each test with WtihTestServer

### DIFF
--- a/checked_frame_pool.go
+++ b/checked_frame_pool.go
@@ -1,0 +1,97 @@
+package tchannel
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+// CheckedFramePoolForTest tracks gets and releases of frames, verifies that
+// frames aren't double released, and can be used to check for frame leaks.
+// As such, it is not performant, nor is it even a proper frame pool.
+//
+// It is intended to be used ONLY in tests.
+type CheckedFramePoolForTest struct {
+	mu sync.Mutex
+
+	allocations map[*Frame]string
+	badRelease  []string
+}
+
+// NewCheckedFramePoolForTest initializes a new CheckedFramePoolForTest.
+func NewCheckedFramePoolForTest() *CheckedFramePoolForTest {
+	return &CheckedFramePoolForTest{
+		allocations: make(map[*Frame]string),
+	}
+}
+
+// Get implements FramePool
+func (p *CheckedFramePoolForTest) Get() *Frame {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	frame := NewFrame(MaxFramePayloadSize)
+	p.allocations[frame] = recordStack()
+	return frame
+}
+
+// Release implements FramePool
+func (p *CheckedFramePoolForTest) Release(f *Frame) {
+	// Make sure the payload is not used after this point by clearing the frame.
+	zeroOut(f.Payload)
+	f.Payload = nil
+	zeroOut(f.buffer)
+	f.buffer = nil
+	zeroOut(f.headerBuffer)
+	f.headerBuffer = nil
+	f.Header = FrameHeader{}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, ok := p.allocations[f]; !ok {
+		p.badRelease = append(p.badRelease, "bad Release at "+recordStack())
+		return
+	}
+
+	delete(p.allocations, f)
+}
+
+// CheckedFramePoolForTestResult contains info on mismatched gets/releases
+type CheckedFramePoolForTestResult struct {
+	BadReleases []string
+	Unreleased  []string
+}
+
+// HasIssues indicates whether there were any issues with gets/releases
+func (r CheckedFramePoolForTestResult) HasIssues() bool {
+	return len(r.BadReleases)+len(r.Unreleased) > 0
+}
+
+// CheckEmpty returns the number of unreleased frames in the pool
+func (p *CheckedFramePoolForTest) CheckEmpty() CheckedFramePoolForTestResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var badCalls []string
+	for f, s := range p.allocations {
+		badCalls = append(badCalls, fmt.Sprintf("frame %p: %v not released, get from: %v", f, f.Header, s))
+	}
+
+	return CheckedFramePoolForTestResult{
+		Unreleased:  badCalls,
+		BadReleases: p.badRelease,
+	}
+}
+
+func recordStack() string {
+	buf := make([]byte, 4096)
+	runtime.Stack(buf, false /* all */)
+	return string(buf)
+}
+
+func zeroOut(bs []byte) {
+	for i := range bs {
+		bs[i] = 0
+	}
+}

--- a/checked_frame_pool_test.go
+++ b/checked_frame_pool_test.go
@@ -1,0 +1,65 @@
+package tchannel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckedFramePoolForTest(t *testing.T) {
+	tests := []struct {
+		msg                string
+		operations         func(pool *CheckedFramePoolForTest)
+		wantHasIssues      bool
+		wantBadAllocations int
+		wantBadReleases    int
+	}{
+		{
+			msg: "no bad releases or leaks",
+			operations: func(pool *CheckedFramePoolForTest) {
+				for i := 0; i < 10; i++ {
+					pool.Release(pool.Get())
+				}
+			},
+		},
+		{
+			msg: "frames are leaked",
+			operations: func(pool *CheckedFramePoolForTest) {
+				for i := 0; i < 10; i++ {
+					pool.Release(pool.Get())
+				}
+				for i := 0; i < 10; i++ {
+					_ = pool.Get()
+				}
+			},
+			wantHasIssues:      true,
+			wantBadAllocations: 10,
+		},
+		{
+			msg: "frames are double released",
+			operations: func(pool *CheckedFramePoolForTest) {
+				for i := 0; i < 10; i++ {
+					pool.Release(pool.Get())
+				}
+				f := pool.Get()
+				pool.Release(f)
+				pool.Release(f)
+			},
+			wantHasIssues:   true,
+			wantBadReleases: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			pool := NewCheckedFramePoolForTest()
+
+			tt.operations(pool)
+			results := pool.CheckEmpty()
+
+			assert.Equal(t, tt.wantHasIssues, results.HasIssues(), "Unexpected HasIssues() state")
+			assert.Equal(t, tt.wantBadAllocations, len(results.Unreleased), "Unexpected allocs")
+			assert.Equal(t, tt.wantBadReleases, len(results.BadReleases), "Unexpected bad releases")
+		})
+	}
+}

--- a/frame_utils_test.go
+++ b/frame_utils_test.go
@@ -22,20 +22,11 @@ package tchannel
 
 import (
 	"fmt"
-	"runtime"
-	"strings"
 	"sync"
 	"unsafe"
 
 	"github.com/prashantv/protectmem"
 )
-
-type RecordingFramePool struct {
-	sync.Mutex
-
-	allocations map[*Frame]string
-	badRelease  []string
-}
 
 type protectMemAllocs struct {
 	frameAlloc  *protectmem.Allocation
@@ -46,66 +37,6 @@ type ProtectMemFramePool struct {
 	sync.Mutex
 
 	allocations map[*Frame]protectMemAllocs
-}
-
-func NewRecordingFramePool() *RecordingFramePool {
-	return &RecordingFramePool{
-		allocations: make(map[*Frame]string),
-	}
-}
-
-func recordStack() string {
-	buf := make([]byte, 4096)
-	runtime.Stack(buf, false)
-	return string(buf)
-}
-
-func (p *RecordingFramePool) Get() *Frame {
-	p.Lock()
-	defer p.Unlock()
-
-	frame := NewFrame(MaxFramePayloadSize)
-	p.allocations[frame] = recordStack()
-	return frame
-}
-
-func zeroOut(bs []byte) {
-	for i := range bs {
-		bs[i] = 0
-	}
-}
-
-func (p *RecordingFramePool) Release(f *Frame) {
-	// Make sure the payload is not used after this point by clearing the frame.
-	zeroOut(f.Payload)
-	f.Payload = nil
-	zeroOut(f.buffer)
-	f.buffer = nil
-	zeroOut(f.headerBuffer)
-	f.headerBuffer = nil
-	f.Header = FrameHeader{}
-
-	p.Lock()
-	defer p.Unlock()
-
-	if _, ok := p.allocations[f]; !ok {
-		p.badRelease = append(p.badRelease, "bad Release at "+recordStack())
-		return
-	}
-
-	delete(p.allocations, f)
-}
-
-func (p *RecordingFramePool) CheckEmpty() (int, string) {
-	p.Lock()
-	defer p.Unlock()
-
-	var badCalls []string
-	badCalls = append(badCalls, p.badRelease...)
-	for f, s := range p.allocations {
-		badCalls = append(badCalls, fmt.Sprintf("frame %p: %v not released, get from: %v", f, f.Header, s))
-	}
-	return len(p.allocations), strings.Join(badCalls, "\n")
 }
 
 // NewProtectMemFramePool creates a frame pool that ensures that released frames

--- a/relay_test.go
+++ b/relay_test.go
@@ -398,8 +398,7 @@ func TestLargeTimeoutsAreClamped(t *testing.T) {
 // TestRelayConcurrentCalls makes many concurrent calls and ensures that
 // we don't try to reuse any frames once they've been released.
 func TestRelayConcurrentCalls(t *testing.T) {
-	pool := NewProtectMemFramePool()
-	opts := testutils.NewOpts().SetRelayOnly().SetFramePool(pool)
+	opts := testutils.NewOpts().SetRelayOnly().SetCheckFramePooling()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		server := benchmark.NewServer(
 			benchmark.WithNoLibrary(),

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -288,6 +288,7 @@ func (o *ChannelOpts) SetConnContext(f func(context.Context, net.Conn) context.C
 	return o
 }
 
+// SetCheckFramePooling sets a flag to enable frame pooling checks such as leaks or bad releases
 func (o *ChannelOpts) SetCheckFramePooling() *ChannelOpts {
 	o.CheckFramePooling = true
 	return o

--- a/testutils/channel_opts.go
+++ b/testutils/channel_opts.go
@@ -66,6 +66,12 @@ type ChannelOpts struct {
 	// negative values are treated as a single run.
 	RunCount int
 
+	// CheckFramePooling indicates whether we should check for frame leaks or not.
+	// This causes the same tests to be run twice, first with the default frame pool,
+	// then with the recording frame pool, which will double the amount of time it takes
+	// for the test.
+	CheckFramePooling bool
+
 	// postFns is a list of functions that are run after the test.
 	// They are run even if the test fails.
 	postFns []func()
@@ -279,6 +285,11 @@ func (o *ChannelOpts) SetDialer(f func(context.Context, string, string) (net.Con
 // SetConnContext sets the connection's ConnContext function
 func (o *ChannelOpts) SetConnContext(f func(context.Context, net.Conn) context.Context) *ChannelOpts {
 	o.ConnContext = f
+	return o
+}
+
+func (o *ChannelOpts) SetCheckFramePooling() *ChannelOpts {
+	o.CheckFramePooling = true
 	return o
 }
 


### PR DESCRIPTION
With the realization that some code paths aren't properly releasing frames
(e.g. #845), I'd like to add an option to `WithTestServer` to optionally check
for frame leaks along with each test.

As `RecordingFramePool` isn't an actual frame pool, we can't simply replace
the frame pool in all of our tests - we'd miss signals on how the code
is actually run in production. As such, we'll need to run the same test again
with `RecordingFramePool`, which will more than double the time it takes
to run a test.

To avoid an outsized impact to test duration, make the option opt-in so that
we can selectively onboard tests to this check.