### PR TITLE
Fix race in TestRelayConnection

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -639,7 +639,9 @@ func TestRelayConnection(t *testing.T) {
 		require.NoError(t, err, "Failed to connect from relay to listening host:port")
 
 		// Wait for inbound connection to be established before making call
-		if !waitForInboundConnection(listeningHBSvc, ts.Relay()) {
+		if !testutils.WaitFor(time.Second, func() bool {
+			return getInbounds(listeningHBSvc, ts.Relay()) > 0
+		}) {
 			require.Fail(t, "no inbound connections established from relay to listeningHBSvc")
 		}
 
@@ -2066,16 +2068,6 @@ func copyHeaders(m map[string]string) map[string]string {
 		copied[k] = v
 	}
 	return copied
-}
-
-func waitForInboundConnection(listeningCh, callingCh *Channel) bool {
-	for beg := time.Now(); time.Now().Sub(beg) < time.Second; {
-		if getInbounds(listeningCh, callingCh) > 0 {
-			break
-		}
-		<-time.After(10 * time.Millisecond)
-	}
-	return getInbounds(listeningCh, callingCh) > 0
 }
 
 func getInbounds(listeningCh, callingCh *Channel) int {

--- a/relay_test.go
+++ b/relay_test.go
@@ -2071,7 +2071,7 @@ func copyHeaders(m map[string]string) map[string]string {
 }
 
 func getInbounds(listeningCh, callingCh *Channel) int {
-	callingPeer, ok := listeningCh.IntrospectState(nil).RootPeers[callingCh.PeerInfo().HostPort]
+	callingPeer, ok := listeningCh.IntrospectState(nil /* opts */).RootPeers[callingCh.PeerInfo().HostPort]
 	if !ok {
 		return 0
 	}


### PR DESCRIPTION
In TestRelayConnection, the final test is for the relay to create an inbound connection to a listening Hyperbhan service and verify that a call originating from the HB service uses that connection rather than creating a new outbound connection. The test, however, suffered from a race condition where the call could be made before the inbound handshake completed, resulting in an outbound being created by the HB service.

Add a verification step before `CallEcho` to ensure that the connection is established before the call is made.