### PR TITLE
Update linting in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TEST_PORT=0
 
 -include crossdock/rules.mk
 
-all: test examples
+all: lint test examples
 
 $(BIN)/thrift:
 	mkdir -p $(BIN)
@@ -40,7 +40,7 @@ install:
 
 install_lint:
 	@echo "Installing golint, since we expect to lint"
-	go get -u -f golang.org/x/lint/golint
+	go install golang.org/x/lint/golint@latest
 
 install_ci: $(BIN)/thrift install
 ifdef CROSSDOCK
@@ -100,7 +100,7 @@ cover_ci:
 
 
 FILTER := grep -v -e '_string.go' -e '/gen-go/' -e '/mocks/' -e 'vendor/'
-lint:
+lint: install
 	@echo "Running golint"
 	-golint $(ALL_PKGS) | $(FILTER) | tee lint.log
 	@echo "Running go vet"


### PR DESCRIPTION
Addressing an issue and adding some improvements in the Makefile:
- Add `install` as a dependency to `lint` so that `vendor` is updated before linting
- Add `lint` as a dependency to `all` so that invoking `make` would also do linting
- Call `go install` for installing the `golint` binary