### PR TITLE
Fix flaky TestRelayConnection

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -635,7 +635,8 @@ func TestRelayConnection(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		_, err = ts.Relay().Connect(ctx, listeningHBSvc.PeerInfo().HostPort)
+		// Ping to ensure the connection has been added to peers on both sides.
+		err = ts.Relay().Ping(ctx, listeningHBSvc.PeerInfo().HostPort)
 		require.NoError(t, err, "Failed to connect from relay to listening host:port")
 
 		// Now when listeningHBSvc makes a call, it should use the above connection.


### PR DESCRIPTION
See #848 for context. This fixes the same issue but instead of waiting
for the inbound connection, we use Ping, which ensures the connection is
added to the channels on both the inbound/outbound side, and then
returns the pingRes.

This is similar to other fixes in the past, e.g., #440, #433.