### PR TITLE
Fix flaky TestIdleSweepIgnoresConnectionsWithCalls

### DIFF
--- a/idle_sweep_test.go
+++ b/idle_sweep_test.go
@@ -410,8 +410,7 @@ func TestIdleSweepIgnoresConnectionsWithCalls(t *testing.T) {
 
 		// Since the idle sweep loop and message exchange run concurrently, there is
 		// a race between the idle sweep and exchange shutdown. To mitigate this,
-		// trigger the idle sweep a few times to ensure that a sweep happens
-		// after the inbound exchange has been shutdown
+		// wait for the exchanges to shut down before triggering the idel sweep.
 		listener.waitForZeroExchanges(t, ts.Server(), c2)
 
 		check.tick()

--- a/introspection.go
+++ b/introspection.go
@@ -433,7 +433,7 @@ func (mexset *messageExchangeSet) IntrospectState(opts *IntrospectionOptions) Ex
 		Count: len(mexset.exchanges),
 	}
 
-	if opts.IncludeExchanges {
+	if opts != nil && opts.IncludeExchanges {
 		setState.Exchanges = make(map[string]ExchangeRuntimeState, len(mexset.exchanges))
 		for k, v := range mexset.exchanges {
 			state := ExchangeRuntimeState{


### PR DESCRIPTION
Due to a race between the idle connection sweeper and message
exchange, the test may end up getting a false negative if the
exchange shutdown happened after the last sweep has been run.

To mitigate this, make the loop run a number of times
so that we can get at least one sweep if the exchange closes
slower than usual.