### PR TITLE
Fix flaky TestLargeTimeoutsAreClamped

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -404,8 +404,12 @@ func TestLargeTimeoutsAreClamped(t *testing.T) {
 			close(done)
 		}()
 
+		// This test is very sensitive to system noise, where a spike of latency in the relay (e.g. caused by load)
+		// is able to cause the client call to timeout, making this test prone to false positives. As such, we
+		// can't time out too close to clampTTL, but instead check that we don't time out after longTTL/2. This might
+		// be a bit generous, but should be sufficient for our purposes here.
 		select {
-		case <-time.After(testutils.Timeout(10 * clampTTL)):
+		case <-time.After(testutils.Timeout(longTTL / 2)):
 			t.Fatal("Failed to clamp timeout.")
 		case <-done:
 		}


### PR DESCRIPTION
TestLargeTimeoutsAreClamped tests that timeouts for relayed calls are "clamped"
by:
- Setting up a backend with a blocking handler
- Setting up a relay with a max timeout of `clampTTL`
- Making a call from a client with a timeout of `longTTL`
- Checking that the call returns with a timeout error within 10x `clampTTL`

This worked before, but since the migration to github actions, this test has
become very flaky, likely due to heavier load than TravisCI. The flakiness arises
from the fact that since it's a "blackbox" style test, system noise can easily
factor into the timing, causing e.g. the latency in the relay to increase significantly
under heavy load and breaching the time limit of 10x `clampTTL`.

This change bumps the timeout in the final check to `longTTL/2` to account for
latencies on the order of 100ms. The purpose here becomes checking that we timed out
before `longTTL` is reached, rather than verifying that we're clamping exactly
at `clampTTL`.