### PR TITLE
Disable frame pooling checks when calculating coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ benchmark: clean setup $(BIN)/thrift
 cover_profile: clean setup $(BIN)/thrift
 	@echo Testing packages:
 	mkdir -p $(BUILD)
-	PATH=$(BIN)::$$PATH go test $(COV_PKG) $(TEST_ARG) -coverprofile=$(BUILD)/coverage.out
+	PATH=$(BIN)::$$PATH DISABLE_FRAME_POOLING_CHECKS=1 go test $(COV_PKG) $(TEST_ARG) -coverprofile=$(BUILD)/coverage.out
 
 cover: cover_profile
 	go tool cover -html=$(BUILD)/coverage.out

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -22,6 +22,7 @@ package testutils
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -161,7 +162,7 @@ func WithTestServer(t testing.TB, chanOpts *ChannelOpts, f func(testing.TB, *Tes
 	chanOptsCopy := chanOpts.Copy()
 	runTest(t, chanOptsCopy)
 
-	if chanOptsCopy.CheckFramePooling {
+	if os.Getenv("DISABLE_FRAME_POOLING_CHECKS") == "" && chanOptsCopy.CheckFramePooling {
 		runSubTest(t, "check frame leaks", func(t testing.TB) {
 			pool := tchannel.NewCheckedFramePoolForTest()
 


### PR DESCRIPTION
Due to the increased time when enabling frame pooling checks,
coverage calculations in CI are often timing out. Disable
said checks during coverage calculation since the impact to
coverage is minimal.