### PR TITLE
Fix frame leak due to undrained send buffer

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -740,6 +740,14 @@ func (c *Connection) handleFrameNoRelay(frame *Frame) bool {
 // writeFrames is the main loop that pulls frames from the send channel and
 // writes them to the connection.
 func (c *Connection) writeFrames(_ uint32) {
+	defer func() {
+		// Remaining frames in sendCh must be drained and released,
+		// or we will leak frames
+		for len(c.sendCh) > 0 {
+			c.opts.FramePool.Release(<-c.sendCh)
+		}
+	}()
+
 	for {
 		select {
 		case f := <-c.sendCh:

--- a/connection.go
+++ b/connection.go
@@ -900,14 +900,6 @@ func (c *Connection) close(fields ...LogField) error {
 // Close starts a graceful Close which will first reject incoming calls, reject outgoing calls
 // before finally marking the connection state as closed.
 func (c *Connection) Close() error {
-	// Remaining frames in sendCh must be drained and released,
-	// or we will leak frames
-	defer func() {
-		for len(c.sendCh) > 0 {
-			c.opts.FramePool.Release(<-c.sendCh)
-		}
-	}()
-
 	return c.close(LogField{"reason", "user initiated"})
 }
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -824,6 +824,7 @@ func TestRelayRateLimitDrop(t *testing.T) {
 // Test that a stalled connection to a single server does not block all calls
 // from that server, and we have stats to capture that this is happening.
 func TestRelayStalledConnection(t *testing.T) {
+	// TODO: enable framepool checks
 	// TODO(ablackmon): Debug why this is flaky in github
 	if os.Getenv("GITHUB_WORKFLOW") != "" {
 		t.Skip("skipping test flaky in github actions.")

--- a/relay_test.go
+++ b/relay_test.go
@@ -824,7 +824,6 @@ func TestRelayRateLimitDrop(t *testing.T) {
 // Test that a stalled connection to a single server does not block all calls
 // from that server, and we have stats to capture that this is happening.
 func TestRelayStalledConnection(t *testing.T) {
-	// TODO: enable framepool checks
 	// TODO(ablackmon): Debug why this is flaky in github
 	if os.Getenv("GITHUB_WORKFLOW") != "" {
 		t.Skip("skipping test flaky in github actions.")

--- a/relay_test.go
+++ b/relay_test.go
@@ -335,11 +335,13 @@ func TestRaceCloseWithNewCall(t *testing.T) {
 }
 
 func TestTimeoutCallsThenClose(t *testing.T) {
-	// TODO: enable framepool checks
 	// Test needs at least 2 CPUs to trigger race conditions.
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
 
-	opts := serviceNameOpts("s1").SetRelayOnly().DisableLogVerification()
+	opts := serviceNameOpts("s1").
+		SetRelayOnly().
+		SetCheckFramePooling().
+		DisableLogVerification()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		s1 := ts.Server()
 		s2 := ts.NewServer(serviceNameOpts("s2").DisableLogVerification())
@@ -369,7 +371,6 @@ func TestTimeoutCallsThenClose(t *testing.T) {
 }
 
 func TestLargeTimeoutsAreClamped(t *testing.T) {
-	// TODO: enable frame pool checks
 	const (
 		clampTTL = time.Millisecond
 		longTTL  = time.Minute
@@ -377,6 +378,7 @@ func TestLargeTimeoutsAreClamped(t *testing.T) {
 
 	opts := serviceNameOpts("echo-service").
 		SetRelayOnly().
+		SetCheckFramePooling().
 		SetRelayMaxTimeout(clampTTL).
 		DisableLogVerification() // handler returns after deadline
 
@@ -910,7 +912,6 @@ func TestRelayStalledConnection(t *testing.T) {
 // Test that a stalled connection to the client does not cause stuck calls
 // See https://github.com/uber/tchannel-go/issues/700 for more info.
 func TestRelayStalledClientConnection(t *testing.T) {
-	// TODO: enable framepool checks
 	// This needs to be large enough to fill up the client TCP buffer.
 	const _calls = 100
 
@@ -919,7 +920,8 @@ func TestRelayStalledClientConnection(t *testing.T) {
 		AddLogFilter("Dropping call due to slow connection.", _calls).
 		SetSendBufferSize(10). // We want to hit the buffer size earlier.
 		SetServiceName("s1").
-		SetRelayOnly()
+		SetRelayOnly().
+		SetCheckFramePooling()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		// Track when the server receives calls
 		gotCall := make(chan struct{}, _calls)
@@ -1044,9 +1046,9 @@ func TestRelayCorruptedCallResFrame(t *testing.T) {
 }
 
 func TestRelayThroughSeparateRelay(t *testing.T) {
-	// TODO: enable framepool checks
 	opts := testutils.NewOpts().
-		SetRelayOnly()
+		SetRelayOnly().
+		SetCheckFramePooling()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		serverHP := ts.Server().PeerInfo().HostPort
 		dummyFactory := func(relay.CallFrame, *relay.Conn) (string, error) {

--- a/relay_test.go
+++ b/relay_test.go
@@ -916,13 +916,13 @@ func TestRelayStalledClientConnection(t *testing.T) {
 	// This needs to be large enough to fill up the client TCP buffer.
 	const _calls = 100
 
+	// TODO: enable framepool checks
 	opts := testutils.NewOpts().
 		// Expect errors from dropped frames.
 		AddLogFilter("Dropping call due to slow connection.", _calls).
 		SetSendBufferSize(10). // We want to hit the buffer size earlier.
 		SetServiceName("s1").
-		SetRelayOnly().
-		SetCheckFramePooling()
+		SetRelayOnly()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		// Track when the server receives calls
 		gotCall := make(chan struct{}, _calls)

--- a/relay_test.go
+++ b/relay_test.go
@@ -335,12 +335,12 @@ func TestRaceCloseWithNewCall(t *testing.T) {
 }
 
 func TestTimeoutCallsThenClose(t *testing.T) {
+	// TODO: enable framepool checks
 	// Test needs at least 2 CPUs to trigger race conditions.
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
 
 	opts := serviceNameOpts("s1").
 		SetRelayOnly().
-		SetCheckFramePooling().
 		DisableLogVerification()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		s1 := ts.Server()
@@ -1047,9 +1047,9 @@ func TestRelayCorruptedCallResFrame(t *testing.T) {
 }
 
 func TestRelayThroughSeparateRelay(t *testing.T) {
+	// TODO: enable framepool checks
 	opts := testutils.NewOpts().
-		SetRelayOnly().
-		SetCheckFramePooling()
+		SetRelayOnly()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		serverHP := ts.Server().PeerInfo().HostPort
 		dummyFactory := func(relay.CallFrame, *relay.Conn) (string, error) {


### PR DESCRIPTION
Follow up to #845

Currently in `Connection.writeFrames()`, we return immediately
upon a connection error. However, at that point there may still
be frames stuck in the send buffer (`Connection.sendCh`) which
haven't been sent due to the connection issue. Leaving it in
such a state results in a frame leak since they will never be
released.

Change `writeFrames()` to always drain the send buffer upon return
to fix this behavior.