### PR TITLE
Fix frame leaks detected in TestRelayStalledConnection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -438,7 +438,9 @@ func (c *Connection) ping(ctx context.Context) error {
 // handlePingRes calls registered ping handlers.
 func (c *Connection) handlePingRes(frame *Frame) bool {
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
-		c.log.WithFields(LogField{"response", frame.Header}).Warn("Unexpected ping response.")
+		if err != errUnknownMex {
+			c.log.WithFields(LogField{"response", frame.Header}).Warn("Unexpected ping response.")
+		}
 		return true
 	}
 	// ping req is waiting for this frame, and will release it.

--- a/inbound.go
+++ b/inbound.go
@@ -131,7 +131,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 // defragmentation
 func (c *Connection) handleCallReqContinue(frame *Frame) bool {
 	if err := c.inbound.forwardPeerFrame(frame); err != nil {
-		// If forward fails, it's due to a timeout. We can free this frame.
+		// If forward fails we can free this frame.
 		return true
 	}
 	return false

--- a/outbound.go
+++ b/outbound.go
@@ -293,13 +293,15 @@ func (c *Connection) handleError(frame *Frame) bool {
 	}
 
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
-		c.log.WithFields(
-			LogField{"frameHeader", frame.Header.String()},
-			LogField{"id", errMsg.id},
-			LogField{"errorMessage", errMsg.message},
-			LogField{"errorCode", errMsg.errCode},
-			ErrField(err),
-		).Info("Failed to forward error frame.")
+		if err != errUnknownMex {
+			c.log.WithFields(
+				LogField{"frameHeader", frame.Header.String()},
+				LogField{"id", errMsg.id},
+				LogField{"errorMessage", errMsg.message},
+				LogField{"errorCode", errMsg.errCode},
+				ErrField(err),
+			).Info("Failed to forward error frame.")
+		}
 		return true
 	}
 


### PR DESCRIPTION
Due to a race between the message exchange and relayer,
a subtle frame leak would only show up when the message
exchange was shut down (receiver closed the connection)
before the relayer stopped sending frames.

This leak is due to 2 reasons:
- When an exchange is shut down before the relayer has finished relaying,
  the frame can no longer be forwarded. But since we didn't treat that
  as an error, we also didn't release the frame in question.
- When the message exchange shuts down, it doesn't drain the receive
  buffer.

This change fixes the issues above. The test is tested with
100s of repeated runs to ensure it is no longer leaking frames
intermittently.