### PR TITLE
Test against Go 1.17 and 1.18

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,9 @@ jobs:
         working-directory: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     strategy:
       matrix:
-        go: ["1.15.x", "1.16.x"]
+        go: ["1.17.x", "1.18.x"]
         include:
-        - go: 1.16.x
+        - go: 1.18.x
           latest: true
           COVERAGE: "yes"
           LINT: "yes"

--- a/dial_16.go
+++ b/dial_16.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build !go1.7
 // +build !go1.7
 
 package tchannel

--- a/dial_17.go
+++ b/dial_17.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build go1.7
 // +build go1.7
 
 package tchannel

--- a/dial_17_test.go
+++ b/dial_17_test.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build go1.7
 // +build go1.7
 
 package tchannel_test

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/uber/tchannel-go
 
-go 1.16
+go 1.17
 
 require (
-	github.com/HdrHistogram/hdrhistogram-go v0.9.0 // indirect
 	// github.com/apache/thrift should be >=0.9.3, <0.11.0 due to
 	// https://issues.apache.org/jira/browse/THRIFT-5205
 	// We are currently pinned to b2a4d4ae21c789b689dd162deb819665567f481c
@@ -12,21 +11,27 @@ require (
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20190922033735-5ca90424ceb7
 	github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/kr/text v0.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/prashantv/protectmem v0.0.0-20171002184600-e20412882b3a
 	github.com/samuel/go-thrift v0.0.0-20190219015601-e8b6b52668fe
 	github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25
-	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/uber-go/tally v3.3.15+incompatible
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
-	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.6.0
 	go.uber.org/multierr v1.2.0
 	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/HdrHistogram/hdrhistogram-go v0.9.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/sockio_darwin.go
+++ b/sockio_darwin.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build darwin
 // +build darwin
 
 package tchannel

--- a/sockio_linux.go
+++ b/sockio_linux.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build linux
 // +build linux
 
 package tchannel

--- a/sockio_non_unix.go
+++ b/sockio_non_unix.go
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 // Opposite of sockio_unix.go
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
 // +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package tchannel

--- a/sockio_unix.go
+++ b/sockio_unix.go
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 // Match the golang/sys unix file, https://github.com/golang/sys/blob/master/unix/syscall_unix.go#L5
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package tchannel


### PR DESCRIPTION
Per the Go support policy, we should suopport the two most recent minor
releases.

The build tag changes are for Go 1.17/1.18 compatibility where the
`+build` tags are being transitioned to `//go:build`.
