### PR TITLE
Remove extraneous PeerList.exists check during PeerList.GetOrAdd

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -216,9 +216,7 @@ func (l *PeerList) choosePeer(prevSelected map[string]struct{}, avoidHost bool) 
 
 // GetOrAdd returns a peer for the given hostPort, creating one if it doesn't yet exist.
 func (l *PeerList) GetOrAdd(hostPort string) *Peer {
-	if ps, ok := l.exists(hostPort); ok {
-		return ps.Peer
-	}
+	// TODO: remove calls to GetOrAdd, use Add instead
 	return l.Add(hostPort)
 }
 


### PR DESCRIPTION
Minor change just to remove the unnecessary call. `PeerList.GetOrAdd` already calls `PeerList.Add` (which calls `PeerList.exists`), so there's no advantage to calling `exists` explicitly before the call to `GetOrAdd`. Essentially, `GetOrAdd` is functionally the same as `Add`.