### PR TITLE
Increase test timeouts, close test server relay, misc test tweaks

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -470,7 +470,7 @@ func TestTimeout(t *testing.T) {
 		testHandler := onErrorTestHandler{newTestHandler(t), onError}
 		ts.Register(raw.Wrap(testHandler), "block")
 
-		ctx, cancel := NewContext(testutils.Timeout(15 * time.Millisecond))
+		ctx, cancel := NewContext(testutils.Timeout(100 * time.Millisecond))
 		defer cancel()
 
 		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), ts.ServiceName(), "block", []byte("Arg2"), []byte("Arg3"))
@@ -622,7 +622,7 @@ func TestWriteArg3AfterTimeout(t *testing.T) {
 
 		// Wait for the write to complete, make sure there are no errors.
 		select {
-		case <-time.After(testutils.Timeout(60 * time.Millisecond)):
+		case <-time.After(testutils.Timeout(300 * time.Millisecond)):
 			t.Errorf("Handler should have failed due to timeout")
 		case <-timedOut:
 		}
@@ -777,7 +777,7 @@ func TestReadTimeout(t *testing.T) {
 func TestWriteTimeout(t *testing.T) {
 	testutils.WithTestServer(t, nil, func(t testing.TB, ts *testutils.TestServer) {
 		ch := ts.Server()
-		ctx, cancel := NewContext(testutils.Timeout(15 * time.Millisecond))
+		ctx, cancel := NewContext(testutils.Timeout(100 * time.Millisecond))
 		defer cancel()
 
 		call, err := ch.BeginCall(ctx, ts.HostPort(), ch.ServiceName(), "call", nil)

--- a/relay_test.go
+++ b/relay_test.go
@@ -351,7 +351,7 @@ func TestTimeoutCallsThenClose(t *testing.T) {
 			<-unblockEcho
 		})
 
-		ctx, cancel := NewContext(testutils.Timeout(30 * time.Millisecond))
+		ctx, cancel := NewContext(testutils.Timeout(100 * time.Millisecond))
 		defer cancel()
 
 		var callers sync.WaitGroup
@@ -1404,7 +1404,7 @@ func TestRelayThriftArg2KeyValueIteration(t *testing.T) {
 
 func TestRelayConnectionTimeout(t *testing.T) {
 	var (
-		minTimeout = testutils.Timeout(10 * time.Millisecond)
+		minTimeout = testutils.Timeout(100 * time.Millisecond)
 		maxTimeout = testutils.Timeout(time.Minute)
 	)
 	tests := []struct {

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -430,11 +430,11 @@ func TestThriftTimeout(t *testing.T) {
 		handler := make(chan struct{})
 
 		args.s2.On("Echo", ctxArg(), "asd").Return("asd", nil).Run(func(args mock.Arguments) {
-			time.Sleep(testutils.Timeout(15 * time.Millisecond))
+			time.Sleep(testutils.Timeout(150 * time.Millisecond))
 			close(handler)
 		})
 
-		ctx, cancel := NewContext(testutils.Timeout(10 * time.Millisecond))
+		ctx, cancel := NewContext(testutils.Timeout(100 * time.Millisecond))
 		defer cancel()
 
 		_, err := args.c2.Echo(ctx, "asd")


### PR DESCRIPTION
- Generally speaking, increases all test timeouts by a factor of 2-3
- Ensures that the `TestServer`'s relay `Channel` is closed during server shutdown, if used
- Adds some special handling for cases like `TestRaceExchangesWithClose`:
  - added a new `testutils.CallEchoWithContext` method that optionally respects context deadlines instead of hardcoding timeouts
  - permits various shutdown states, as their transitions are nondeterministic
- Closes channels and connections in parallel during TestServer shutdown due to their (impending) synchronization
- A few other non-intrusive/cosmetic tweaks
 