### PR TITLE
More explicitly manage Channel and Connection lifetimes

### DIFF
--- a/close_test.go
+++ b/close_test.go
@@ -230,13 +230,15 @@ func TestRaceExchangesWithClose(t *testing.T) {
 		// Now try to close the channel, it should block since there's active exchanges.
 		server.Close()
 		closed.Store(true)
+		close(completeCall)
+		<-callDone
 
 		// n.b. As it's shutting down, server state can be in any of the
 		//      outlined states below. It doesn't matter which specific state
 		//      it's in, as long as we're verifying that it's at least in the
 		//      process of shutting down.
 		var (
-			timeout    = time.After(testutils.Timeout(time.Second))
+			timeout    = time.After(testutils.Timeout(5 * time.Second))
 			validState = func() bool {
 				switch ts.Server().State() {
 				case ChannelStartClose, ChannelInboundClosed, ChannelClosed:
@@ -261,10 +263,6 @@ func TestRaceExchangesWithClose(t *testing.T) {
 				)
 			}
 		}
-
-		closed.Store(true)
-		close(completeCall)
-		<-callDone
 	})
 
 	// Wait for all calls to complete

--- a/connection_test.go
+++ b/connection_test.go
@@ -1245,7 +1245,7 @@ func TestLastActivityTimePings(t *testing.T) {
 	clock := testutils.NewStubClock(initialTime)
 
 	opts := testutils.NewOpts().SetTimeNow(clock.Now)
-	ctx, cancel := NewContext(testutils.Timeout(100 * time.Millisecond))
+	ctx, cancel := NewContext(testutils.Timeout(300 * time.Millisecond))
 	defer cancel()
 
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {

--- a/idle_sweep_test.go
+++ b/idle_sweep_test.go
@@ -328,7 +328,7 @@ func TestIdleSweepIgnoresConnectionsWithCalls(t *testing.T) {
 	listener := newPeerStatusListener()
 	// TODO: Log filtering doesn't require the message to be seen.
 	serverOpts := testutils.NewOpts().
-		AddLogFilter("Skip closing idle Connection as it has pending calls.", 2).
+		AddLogFilter("Skip closing idle Connection as it has pending calls.", 3).
 		SetOnPeerStatusChanged(listener.onStatusChange).
 		SetTimeNow(clock.Now).
 		SetTimeTicker(clientTicker.New).

--- a/relay_test.go
+++ b/relay_test.go
@@ -607,8 +607,10 @@ func TestRelayContextInheritsFromOutboundConnection(t *testing.T) {
 }
 
 func TestRelayConnection(t *testing.T) {
-	var errTest = errors.New("test")
-	var gotConn *relay.Conn
+	var (
+		errTest = errors.New("test")
+		gotConn *relay.Conn
+	)
 
 	getHost := func(_ relay.CallFrame, conn *relay.Conn) (string, error) {
 		gotConn = conn
@@ -1187,6 +1189,7 @@ func TestRelayRaceCompletionAndTimeout(t *testing.T) {
 		AddLogFilter("Too many tombstones, deleting relay item immediately.", numCalls).
 		AddLogFilter("Received a frame without a RelayItem.", numCalls).
 		AddLogFilter("Attempted to create new mex after mexset shutdown.", numCalls).
+		AddLogFilter("Couldn't register exchange.", numCalls).
 		SetRelayOnly()
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		testutils.RegisterEcho(ts.Server(), nil)
@@ -1216,7 +1219,7 @@ func TestRelayRaceCompletionAndTimeout(t *testing.T) {
 }
 
 func TestRelayArg2OffsetIntegration(t *testing.T) {
-	ctx, cancel := NewContext(testutils.Timeout(time.Second))
+	ctx, cancel := NewContext(testutils.Timeout(2 * time.Second))
 	defer cancel()
 
 	rh := relaytest.NewStubRelayHost()

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	_defaultTimeout = 300 * time.Millisecond
+	_defaultTimeout = time.Second
 )
 
 // CallEcho calls the "echo" endpoint from the given src to target.

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -362,7 +362,7 @@ func (ts *TestServer) addChannel(createChannel func(t testing.TB, opts *ChannelO
 func (ts *TestServer) close(ch *tchannel.Channel) {
 	ch.Close()
 
-	timeout := Timeout(time.Second)
+	timeout := Timeout(3 * time.Second)
 	select {
 	case <-time.After(timeout):
 		ts.Errorf("Channel %p did not close after %v, last state: %v", ch, timeout, ch.State())


### PR DESCRIPTION
- Tracks all goroutines
- Ensures that `<-Channel.ClosedChan()` only unblocks when all internal routines are done
- Restructures some routines (e.g. `Connection.readFrames`) for better lifetime control (i.e. better exit control)
- Prevents `Connection.close` from being called during or immediately after `Connection` creation
- Refactors `chan *Frame` drains to be tolerant of slight delays in the case of imminent `chansend`s
- Adds edge case handling for `Handler` delays due to not reading the entire call (e.g. blackhole)
- Releases frames within `messageExchange` when bound for an unknown exchange
- Minor semantic naming tweaks for `Relayer.handleLocalCallReq`