### PR TITLE
Enable frame pool leak checks for more tests

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -1245,7 +1245,7 @@ func TestLastActivityTimePings(t *testing.T) {
 	clock := testutils.NewStubClock(initialTime)
 
 	opts := testutils.NewOpts().SetTimeNow(clock.Now)
-	ctx, cancel := NewContext(testutils.Timeout(100 * time.Millisecond))
+	ctx, cancel := NewContext(testutils.Timeout(300 * time.Millisecond))
 	defer cancel()
 
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {

--- a/relay_test.go
+++ b/relay_test.go
@@ -607,8 +607,10 @@ func TestRelayContextInheritsFromOutboundConnection(t *testing.T) {
 }
 
 func TestRelayConnection(t *testing.T) {
-	var errTest = errors.New("test")
-	var gotConn *relay.Conn
+	var (
+		errTest = errors.New("test")
+		gotConn *relay.Conn
+	)
 
 	getHost := func(_ relay.CallFrame, conn *relay.Conn) (string, error) {
 		gotConn = conn
@@ -1216,7 +1218,7 @@ func TestRelayRaceCompletionAndTimeout(t *testing.T) {
 }
 
 func TestRelayArg2OffsetIntegration(t *testing.T) {
-	ctx, cancel := NewContext(testutils.Timeout(time.Second))
+	ctx, cancel := NewContext(testutils.Timeout(2 * time.Second))
 	defer cancel()
 
 	rh := relaytest.NewStubRelayHost()

--- a/testutils/echo.go
+++ b/testutils/echo.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	_defaultTimeout = 300 * time.Millisecond
+	_defaultTimeout = 500 * time.Millisecond
 )
 
 // CallEcho calls the "echo" endpoint from the given src to target.

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -362,7 +362,7 @@ func (ts *TestServer) addChannel(createChannel func(t testing.TB, opts *ChannelO
 func (ts *TestServer) close(ch *tchannel.Channel) {
 	ch.Close()
 
-	timeout := Timeout(time.Second)
+	timeout := Timeout(3 * time.Second)
 	select {
 	case <-time.After(timeout):
 		ts.Errorf("Channel %p did not close after %v, last state: %v", ch, timeout, ch.State())


### PR DESCRIPTION
Enables framepool checks for all remaining relay tests that still had TODOs.