### PR TITLE
Preparing v1.31.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## [1.30.0] - 2022-05-04
+## [1.31.0] - 2022-05-04
 ### Changed
  * thrift-gen going to use vendored apache-thrift code. Currently vendored apache-thrift pinned to b2a4d4ae21c789b689dd162deb819665567f481c.
 
@@ -347,7 +347,7 @@ Changelog
 * Thrift support, including includes.
 
 [//]: # (Version Links)
-[1.30.0]: https://github.com/uber/tchannel-go/compare/v1.22.3...v1.30.0
+[1.31.0]: https://github.com/uber/tchannel-go/compare/v1.22.3...v1.31.0
 [1.22.3]: https://github.com/uber/tchannel-go/compare/v1.22.2...v1.22.3
 [1.22.1]: https://github.com/uber/tchannel-go/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/uber/tchannel-go/compare/v1.21.2...v1.22.0

--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ package tchannel
 // VersionInfo identifies the version of the TChannel library.
 // Due to lack of proper package management, this version string will
 // be maintained manually.
-const VersionInfo = "1.30.0"
+const VersionInfo = "1.31.0"


### PR DESCRIPTION
Tchannel-go already contains a tag with version 1.3.0 https://github.com/uber/tchannel-go/releases/tag/v1.3.0. That was causing issues with tagging. Hence releasing changes with 1.31.0.