### PR TITLE
Add make target to allow testing without checking frame leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,18 @@ else
 endif
 
 test: clean setup check_no_test_deps $(BIN)/thrift
+	$(MAKE) test_vanilla
+	$(MAKE) test_relay_frame_leaks
+
+test_vanilla:
 	@echo Testing packages:
-	PATH=$(BIN):$$PATH go test -parallel=4 $(TEST_ARG) $(ALL_PKGS)
+	PATH=$(BIN):$$PATH DISABLE_FRAME_POOLING_CHECKS=1 go test -parallel=4 $(TEST_ARG) $(ALL_PKGS)
 	@echo Running frame pool tests
 	PATH=$(BIN):$$PATH go test -run TestFramesReleased -stressTest $(TEST_ARG)
+
+test_relay_frame_leaks:
+	@echo Testing relay frame leaks
+	PATH=$(BIN):$$PATH go test -parallel=4 $(TEST_ARG) relay_test.go
 
 check_no_test_deps:
 	! go list -json $(PROD_PKGS) | jq -r '.Deps | select ((. | length) > 0) | .[]' | grep -e test -e mock | grep -v '^internal/testlog'

--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,14 @@ test: clean setup check_no_test_deps $(BIN)/thrift
 	$(MAKE) test_vanilla
 	$(MAKE) test_relay_frame_leaks
 
+# test_vanilla runs all unit tests without checking for frame leaks
 test_vanilla:
 	@echo Testing packages:
 	PATH=$(BIN):$$PATH DISABLE_FRAME_POOLING_CHECKS=1 go test -parallel=4 $(TEST_ARG) $(ALL_PKGS)
 	@echo Running frame pool tests
 	PATH=$(BIN):$$PATH go test -run TestFramesReleased -stressTest $(TEST_ARG)
 
+# test_relay_frame_leaks runs unit tests in relay_test.go with frame leak checks enabled
 test_relay_frame_leaks:
 	@echo Testing relay frame leaks
 	PATH=$(BIN):$$PATH go test -parallel=4 $(TEST_ARG) relay_test.go


### PR DESCRIPTION
Currently, `make test` bundles "vanilla" testing with frame leak
checks, which re-runs all tests with frame leak checks enabled
for some tests (currently all relay tests).

This makes routine testing pretty painful, as each test run
requires upwards of 10 minutes, slowing down development
significantly.

This change improves the situation by
- Adding a `test_vanilla` target that runs all tests without
  any leak checks
- Adding a `test_relay_frame_leaks` target which tests ONLY
  `relay_test.go` with frame leak checks enabled. Frame leak
  checks are currently enabled only in that file
- Change `make test` to run the above in succession

Except for scoping down the frame leak tests, the behavior of
`make test` is intentionally maintained since we still run all
tests in CI.