### PR TITLE
Trigger workflows for branches with slashes in their names

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on:
     branches: ['*']
     tags: ['v*']
   pull_request:
-    branches: ['*']
+    branches: ['**']
 
 jobs:
   test:


### PR DESCRIPTION
github actions isn't being triggered for some PRs where the base
commit contains slashes. Change wildcard matching to `**` to fix this.