### PR TITLE
Release unsent frames when flushing fragments

### DIFF
--- a/checked_frame_pool_test.go
+++ b/checked_frame_pool_test.go
@@ -1,9 +1,11 @@
 package tchannel
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/testutils/goroutines"
 )
 
 func TestCheckedFramePoolForTest(t *testing.T) {
@@ -61,5 +63,21 @@ func TestCheckedFramePoolForTest(t *testing.T) {
 			assert.Equal(t, tt.wantBadAllocations, len(results.Unreleased), "Unexpected allocs")
 			assert.Equal(t, tt.wantBadReleases, len(results.BadReleases), "Unexpected bad releases")
 		})
+	}
+}
+
+func CheckFramePoolIsEmpty(t testing.TB, pool *CheckedFramePoolForTest) {
+	t.Helper()
+
+	stacks := goroutines.GetAll()
+	if result := pool.CheckEmpty(); result.HasIssues() {
+		if len(result.Unreleased) > 0 {
+			t.Errorf("Frame pool has %v unreleased frames, errors:\n%v\nStacks:%v",
+				len(result.Unreleased), strings.Join(result.Unreleased, "\n"), stacks)
+		}
+		if len(result.BadReleases) > 0 {
+			t.Errorf("Frame pool has %v bad releases, errors:\n%v\nStacks:%v",
+				len(result.BadReleases), strings.Join(result.BadReleases, "\n"), stacks)
+		}
 	}
 }

--- a/frame_pool_test.go
+++ b/frame_pool_test.go
@@ -27,7 +27,6 @@ import (
 	"bytes"
 	"io"
 	"math/rand"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -36,7 +35,6 @@ import (
 
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/testutils"
-	"github.com/uber/tchannel-go/testutils/goroutines"
 	"github.com/uber/tchannel-go/testutils/testreader"
 
 	"github.com/stretchr/testify/assert"
@@ -134,19 +132,7 @@ func TestFramesReleased(t *testing.T) {
 		wg.Wait()
 	})
 
-	// TODO: The goroutines.GetAll is to debug test failures in Travis. Remove this once
-	// we confirm that the test is not flaky.
-	stacks := goroutines.GetAll()
-	if result := pool.CheckEmpty(); result.HasIssues() {
-		if len(result.Unreleased) > 0 {
-			t.Errorf("Frame pool has %v unreleased frames, errors:\n%v\nStacks:%v",
-				len(result.Unreleased), strings.Join(result.Unreleased, "\n"), stacks)
-		}
-		if len(result.BadReleases) > 0 {
-			t.Errorf("Frame pool has %v bad releases, errors:\n%v\nStacks:%v",
-				len(result.BadReleases), strings.Join(result.BadReleases, "\n"), stacks)
-		}
-	}
+	CheckFramePoolIsEmpty(t, pool)
 }
 
 type dirtyFramePool struct{}

--- a/relay.go
+++ b/relay.go
@@ -933,6 +933,7 @@ func (rfs *relayFragmentSender) flushFragment(wf *writableFragment) error {
 	sent, failure := rfs.frameReceiver.Receive(wf.frame, requestFrame)
 	if !sent {
 		rfs.failRelayItemFunc(rfs.outboundRelayItems, rfs.origID, failure, errFrameNotSent)
+		rfs.framePool.Release(wf.frame)
 		return nil
 	}
 	return nil

--- a/relay_fragment_sender_test.go
+++ b/relay_fragment_sender_test.go
@@ -103,15 +103,17 @@ func TestRelayFragmentSender(t *testing.T) {
 			wf, err := rfs.newFragment(true, nullChecksum{})
 			require.NoError(t, err)
 
-			wantPayload := make([]byte, wf.contents.BytesWritten())
-			copy(wantPayload, wf.frame.Payload[:wf.contents.BytesWritten()])
-
 			err = rfs.flushFragment(wf)
 			if tt.wantError != "" {
 				require.EqualError(t, err, tt.wantError)
 				return
 			}
 			require.NoError(t, err)
+			var wantPayload []byte
+			if tt.sent {
+				wantPayload = make([]byte, wf.contents.BytesWritten())
+				copy(wantPayload, wf.frame.Payload[:wf.contents.BytesWritten()])
+			}
 			assert.Equal(t, wantPayload, receiver.gotPayload)
 			assert.Equal(t, tt.wantFailureRelayItemFuncCalled, failRelayItemFuncCalled, "unexpected failRelayItemFunc called state")
 		})


### PR DESCRIPTION
Currently, when sending mutated frames via `Relayer.fragmentingSend()`
frames that aren't successfully sent (e.g. due to send buffer being
full during fragment flush) aren't returned to the frame pool and
end up piling up until either OOM or the connection gets closed.

This change adds a release call after marking the relay item as failed
to ensure that frames are properly returned to the pool.