### PR TITLE
Emit the error code and type to the tracing span for inbound calls

### DIFF
--- a/inbound.go
+++ b/inbound.go
@@ -426,7 +426,7 @@ func (response *InboundCallResponse) doneSending() {
 				// if the error is a system error, set the error code in span log
 				span.SetTag("rpc.tchannel.system_error_code", GetSystemErrorCode(response.err))
 			}
-			span.SetTag("rpc.tchannel.app_error_type", errorType)
+			span.SetTag("rpc.tchannel.error_type", errorType)
 		}
 		span.FinishWithOptions(opentracing.FinishOptions{FinishTime: now})
 	}

--- a/inbound.go
+++ b/inbound.go
@@ -424,9 +424,9 @@ func (response *InboundCallResponse) doneSending() {
 			if response.systemError {
 				errorType = systemErrorType
 				// if the error is a system error, set the error code in span log
-				span.LogKV("error-code", GetSystemErrorCode(response.err))
+				span.SetTag("rpc.tchannel.system_error_code", GetSystemErrorCode(response.err))
 			}
-			span.LogKV("error-type", errorType)
+			span.SetTag("rpc.tchannel.app_error_type", errorType)
 		}
 		span.FinishWithOptions(opentracing.FinishOptions{FinishTime: now})
 	}

--- a/inbound.go
+++ b/inbound.go
@@ -31,6 +31,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	systemErrorType = "system"
+	appErrorType    = "application"
+)
+
 var errInboundRequestAlreadyActive = errors.New("inbound request is already active; possible duplicate client id")
 
 // handleCallReq handles an incoming call request, registering a message
@@ -415,6 +420,13 @@ func (response *InboundCallResponse) doneSending() {
 	if span := response.span; span != nil {
 		if response.applicationError || response.systemError {
 			ext.Error.Set(span, true)
+			errorType := appErrorType
+			if response.systemError {
+				errorType = systemErrorType
+				// if the error is a system error, set the error code in span log
+				span.LogKV("error-code", GetSystemErrorCode(response.err))
+			}
+			span.LogKV("error-type", errorType)
 		}
 		span.FinishWithOptions(opentracing.FinishOptions{FinishTime: now})
 	}


### PR DESCRIPTION
### Changelog
1. Emit the error code and type to the tracing span for inbound calls

### Description
This change adds the error type and code (for system errors) to the tracing spans for inbound requests.