### PR TITLE
Remove use of io/ioutil

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -24,7 +24,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/uber/tchannel-go/internal/argreader"
 )
@@ -86,7 +85,7 @@ func (r ArgReadHelper) read(f func() error) error {
 func (r ArgReadHelper) Read(bs *[]byte) error {
 	return r.read(func() error {
 		var err error
-		*bs, err = ioutil.ReadAll(r.reader)
+		*bs, err = io.ReadAll(r.reader)
 		return err
 	})
 }

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -23,7 +23,6 @@ package tchannel
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -79,7 +78,7 @@ func TestReadNotEmpty(t *testing.T) {
 	r := bytes.NewReader([]byte("{}" + strings.Repeat("{}\n", 10000)))
 
 	var data map[string]interface{}
-	reader := NewArgReader(ioutil.NopCloser(r), nil)
+	reader := NewArgReader(io.NopCloser(r), nil)
 	require.Error(t, reader.ReadJSON(&data), "Read should fail due to extra bytes")
 }
 

--- a/benchmark/build_manager.go
+++ b/benchmark/build_manager.go
@@ -21,7 +21,6 @@
 package benchmark
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sync"
@@ -60,7 +59,7 @@ func (m *buildManager) GoBinary(mainFile string) (string, error) {
 }
 
 func (b *build) Build() {
-	tempFile, err := ioutil.TempFile("", "bench")
+	tempFile, err := os.CreateTemp("", "bench")
 	if err != nil {
 		panic("Failed to create temp file: " + err.Error())
 	}

--- a/benchmark/tcp_bench_test.go
+++ b/benchmark/tcp_bench_test.go
@@ -22,7 +22,6 @@ package benchmark
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"testing"
 
@@ -56,7 +55,7 @@ func benchmarkClient(b *testing.B, dst string, reqSize int) {
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		n, err := io.CopyN(ioutil.Discard, conn, int64(totalExpected))
+		n, err := io.CopyN(io.Discard, conn, int64(totalExpected))
 		assert.NoError(b, err, "Expected %v response bytes, got %v", totalExpected, n)
 	}()
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -21,7 +21,7 @@
 package tchannel
 
 import (
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"runtime"
@@ -66,7 +66,7 @@ func TestNewChannel(t *testing.T) {
 
 func TestLoggers(t *testing.T) {
 	ch, err := NewChannel("svc", &ChannelOptions{
-		Logger: NewLogger(ioutil.Discard),
+		Logger: NewLogger(io.Discard),
 	})
 	require.NoError(t, err, "NewChannel failed")
 	defer ch.Close()
@@ -83,7 +83,7 @@ func TestLoggers(t *testing.T) {
 
 func TestStats(t *testing.T) {
 	ch, err := NewChannel("svc", &ChannelOptions{
-		Logger: NewLogger(ioutil.Discard),
+		Logger: NewLogger(io.Discard),
 	})
 	require.NoError(t, err, "NewChannel failed")
 	defer ch.Close()
@@ -131,7 +131,7 @@ func TestRelayMaxTTL(t *testing.T) {
 
 func TestIsolatedSubChannelsDontSharePeers(t *testing.T) {
 	ch, err := NewChannel("svc", &ChannelOptions{
-		Logger: NewLogger(ioutil.Discard),
+		Logger: NewLogger(io.Discard),
 	})
 	require.NoError(t, err, "NewChannel failed")
 	defer ch.Close()

--- a/conn_leak_test.go
+++ b/conn_leak_test.go
@@ -20,7 +20,7 @@
 package tchannel_test
 
 import (
-	"io/ioutil"
+	"io"
 	"runtime"
 	"testing"
 	"time"
@@ -70,7 +70,7 @@ func TestPeerConnectionLeaks(t *testing.T) {
 
 	testutils.WithTestServer(t, opts, func(t testing.TB, ts *testutils.TestServer) {
 		s2Opts := testutils.NewOpts().SetServiceName("s2")
-		s2Opts.Logger = NewLogger(ioutil.Discard)
+		s2Opts.Logger = NewLogger(io.Discard)
 		s2 := ts.NewServer(s2Opts)
 
 		// Set a finalizer to detect when the connection from s1 -> s2 is freed.

--- a/fragmentation_test.go
+++ b/fragmentation_test.go
@@ -23,7 +23,6 @@ package tchannel
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"sync"
 	"testing"
 
@@ -300,7 +299,7 @@ func TestFragmentationChecksumMismatch(t *testing.T) {
 	reader, err := r.ArgReader(true /* last */)
 	assert.NoError(t, err)
 
-	_, err = io.Copy(ioutil.Discard, reader)
+	_, err = io.Copy(io.Discard, reader)
 	assert.Equal(t, errMismatchedChecksums, err)
 }
 

--- a/fragmenting_reader.go
+++ b/fragmenting_reader.go
@@ -167,7 +167,7 @@ func (r *fragmentingReader) Read(b []byte) (int, error) {
 		// There wasn't enough data in the current chunk to satisfy the
 		// current read.  If there are more chunks in the current
 		// fragment, then we've reach the end of this argument.  Return
-		// an io.EOF so functions like ioutil.ReadFully know to finish
+		// an io.EOF so functions like io.ReadAll know to finish
 		if len(r.remainingChunks) > 0 {
 			return totalRead, io.EOF
 		}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -165,9 +164,9 @@ func makeTChanCall(t *testing.T, tchanAddr string, req *http.Request) *http.Resp
 }
 
 func compareResponseBasic(t *testing.T, testName string, resp1, resp2 *http.Response) {
-	resp1Body, err := ioutil.ReadAll(resp1.Body)
+	resp1Body, err := io.ReadAll(resp1.Body)
 	require.NoError(t, err, "Read response failed")
-	resp2Body, err := ioutil.ReadAll(resp2.Body)
+	resp2Body, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err, "Read response failed")
 
 	assert.Equal(t, resp1.Status, resp2.Status, "%v: Response status mismatch", testName)

--- a/hyperbahn/client_test.go
+++ b/hyperbahn/client_test.go
@@ -22,7 +22,6 @@ package hyperbahn
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"sort"
 	"testing"
@@ -92,7 +91,7 @@ func TestParseConfiguration(t *testing.T) {
 	for _, tt := range tests {
 		peerFile := ""
 		if tt.peersFile != "" {
-			f, err := ioutil.TempFile("", "hosts")
+			f, err := os.CreateTemp("", "hosts")
 			if !assert.NoError(t, err, "%v: TempFile failed", tt.name) {
 				continue
 			}

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -21,7 +21,7 @@
 package pprof
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -52,7 +52,7 @@ func TestPProfEndpoint(t *testing.T) {
 	require.NoError(t, err, "ReadResponse failed")
 
 	assert.Equal(t, http.StatusOK, response.StatusCode)
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if assert.NoError(t, err, "Read body failed") {
 		assert.Contains(t, string(body), "contention", "Response does not contain expected string")
 	}

--- a/relay_messages_benchmark_test.go
+++ b/relay_messages_benchmark_test.go
@@ -22,7 +22,7 @@ package tchannel
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -48,5 +48,5 @@ func BenchmarkCallReqFrame(b *testing.B) {
 	}
 	b.StopTimer()
 
-	fmt.Fprint(ioutil.Discard, service, caller, method)
+	fmt.Fprint(io.Discard, service, caller, method)
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -2114,7 +2113,7 @@ func decodeThriftHeaders(t testing.TB, bs []byte) map[string]string {
 	require.NoError(t, err, "Failed to read headers")
 
 	// Ensure there are no remaining bytes left.
-	remaining, err := ioutil.ReadAll(r)
+	remaining, err := io.ReadAll(r)
 	require.NoError(t, err, "failed to read from arg2 reader")
 	assert.Empty(t, remaining, "expected no bytes after reading headers")
 

--- a/scripts/vbumper/main.go
+++ b/scripts/vbumper/main.go
@@ -27,7 +27,6 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -63,13 +62,13 @@ func main() {
 }
 
 func updateVersion(prevVersion string) error {
-	versionBytes, err := ioutil.ReadFile(*_versionFile)
+	versionBytes, err := os.ReadFile(*_versionFile)
 	if err != nil {
 		return err
 	}
 
 	newContents := insertNewVersion(string(versionBytes), prevVersion, *_version)
-	return ioutil.WriteFile(*_versionFile, []byte(newContents), 0666)
+	return os.WriteFile(*_versionFile, []byte(newContents), 0666)
 }
 
 func insertNewVersion(contents, prevVersion, newVersion string) string {
@@ -81,7 +80,7 @@ func insertNewVersion(contents, prevVersion, newVersion string) string {
 }
 
 func updateChangelog() (oldVersion string, _ error) {
-	changelogBytes, err := ioutil.ReadFile(*_changelogFile)
+	changelogBytes, err := os.ReadFile(*_changelogFile)
 	if err != nil {
 		return "", err
 	}
@@ -100,7 +99,7 @@ func updateChangelog() (oldVersion string, _ error) {
 		return oldVersion, nil
 	}
 
-	return oldVersion, ioutil.WriteFile(*_changelogFile, []byte(newLog), 0666)
+	return oldVersion, os.WriteFile(*_changelogFile, []byte(newLog), 0666)
 }
 
 func insertNewChangelog(contents string) (string, string, error) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -219,7 +218,7 @@ func TestStreamPartialArg(t *testing.T) {
 		require.NoError(t, argWriter.Close(), "arg3 close failed")
 
 		// Once closed, we expect the reader to return EOF
-		n, err := io.Copy(ioutil.Discard, argReader)
+		n, err := io.Copy(io.Discard, argReader)
 		assert.Equal(t, int64(0), n, "arg2 reader expected to EOF after arg3 writer is closed")
 		assert.NoError(t, err, "Copy should not fail")
 		assert.NoError(t, argReader.Close(), "close arg reader failed")
@@ -234,7 +233,7 @@ func TestStreamSendError(t *testing.T) {
 		require.NoError(t, argWriter.Close(), "arg3 close failed")
 
 		// Now we expect an error on our next read.
-		_, err = ioutil.ReadAll(argReader)
+		_, err = io.ReadAll(argReader)
 		assert.Error(t, err, "ReadAll should fail")
 		assert.True(t, strings.Contains(err.Error(), "intentional failure"), "err %v unexpected", err)
 	})
@@ -280,7 +279,7 @@ func TestStreamCancelled(t *testing.T) {
 
 		close(cancelContext)
 
-		n, err := io.Copy(ioutil.Discard, arg3Reader)
+		n, err := io.Copy(io.Discard, arg3Reader)
 		assert.EqualValues(t, 0, n, "Read should not read any bytes after cancel")
 		assert.Error(t, err, "Read should fail after cancel")
 		assert.Error(t, arg3Reader.Close(), "reader.Close should fail after cancel")

--- a/testutils/random_bench_test.go
+++ b/testutils/random_bench_test.go
@@ -23,7 +23,6 @@ package testutils
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -33,7 +32,7 @@ func benchmarkRandom(b *testing.B, numBytes int) {
 		randCache = nil
 		bs = RandBytes(numBytes)
 	}
-	io.Copy(ioutil.Discard, bytes.NewReader(bs))
+	io.Copy(io.Discard, bytes.NewReader(bs))
 }
 
 func BenchmarkRandom256(b *testing.B) {

--- a/testutils/testreader/chunk_test.go
+++ b/testutils/testreader/chunk_test.go
@@ -22,7 +22,6 @@ package testreader
 
 import (
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,11 +63,11 @@ func TestChunkReader(t *testing.T) {
 	writer <- []byte{}
 	close(writer)
 
-	buf, err := ioutil.ReadAll(reader)
+	buf, err := io.ReadAll(reader)
 	assert.Equal(t, ErrUser, err, "Expected error after initial bytes")
 	assert.Equal(t, []byte{1, 2, 3}, buf, "Unexpected bytes")
 
-	buf, err = ioutil.ReadAll(reader)
+	buf, err = io.ReadAll(reader)
 	assert.NoError(t, err, "Reader shouldn't fail on second set of bytes")
 	assert.Equal(t, []byte{4, 5, 6}, buf, "Unexpected bytes")
 }

--- a/thrift/headers_test.go
+++ b/thrift/headers_test.go
@@ -22,7 +22,7 @@ package thrift
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 	"testing/iotest"
 
@@ -149,14 +149,14 @@ func TestReadHeadersLeftoverBytes(t *testing.T) {
 	assert.NoError(t, err, "ReadHeaders failed")
 	assert.Equal(t, map[string]string(nil), headers, "Headers mismatch")
 
-	leftover, err := ioutil.ReadAll(r)
+	leftover, err := io.ReadAll(r)
 	assert.NoError(t, err, "ReadAll failed")
 	assert.Equal(t, []byte{1, 2, 3}, leftover, "Reader consumed leftover bytes")
 }
 
 func BenchmarkWriteHeaders(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		WriteHeaders(ioutil.Discard, headers)
+		WriteHeaders(io.Discard, headers)
 	}
 }
 

--- a/thrift/struct_test.go
+++ b/thrift/struct_test.go
@@ -22,7 +22,7 @@ package thrift_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 
@@ -103,7 +103,7 @@ func TestReadStruct(t *testing.T) {
 		// Even if there's an error, the struct will be partially filled.
 		assert.Equal(t, tt.s, s, "Unexpected struct")
 
-		leftover, err := ioutil.ReadAll(reader)
+		leftover, err := io.ReadAll(reader)
 		if assert.NoError(t, err, "Read leftover bytes failed") {
 			// ReadAll always returns a non-nil byte slice.
 			if tt.leftover == nil {

--- a/thrift/thrift-gen/compile_test.go
+++ b/thrift/thrift-gen/compile_test.go
@@ -24,7 +24,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -78,7 +77,7 @@ func getCurrentTChannelPath(t *testing.T) string {
 }
 
 func createGoPath(t *testing.T) {
-	goPath, err := ioutil.TempDir("", "thrift-gen")
+	goPath, err := os.MkdirTemp("", "thrift-gen")
 	require.NoError(t, err, "TempDir failed")
 
 	// Create $GOPATH/src/github.com/uber/tchannel-go and symlink everything.
@@ -88,7 +87,7 @@ func createGoPath(t *testing.T) {
 
 	// Symlink the contents of tchannel-go into the temp directory.
 	realTChannelDir := getCurrentTChannelPath(t)
-	realDirContents, err := ioutil.ReadDir(realTChannelDir)
+	realDirContents, err := os.ReadDir(realTChannelDir)
 	require.NoError(t, err, "Failed to read real tchannel-go dir")
 
 	for _, f := range realDirContents {
@@ -117,7 +116,7 @@ func getOutputDir(t *testing.T) (dir, pkg string) {
 }
 
 func TestAllThrift(t *testing.T) {
-	files, err := ioutil.ReadDir("test_files")
+	files, err := os.ReadDir("test_files")
 	require.NoError(t, err, "Cannot read test_files directory: %v", err)
 
 	for _, f := range files {
@@ -133,7 +132,7 @@ func TestAllThrift(t *testing.T) {
 }
 
 func TestIncludeThrift(t *testing.T) {
-	dirs, err := ioutil.ReadDir("test_files/include_test")
+	dirs, err := os.ReadDir("test_files/include_test")
 	require.NoError(t, err, "Cannot read test_files/include_test directory: %v", err)
 
 	for _, d := range dirs {
@@ -202,16 +201,16 @@ func TestExternalTemplate(t *testing.T) {
 }
 
 func writeTempFile(t *testing.T, contents string) string {
-	tempFile, err := ioutil.TempFile("", "temp")
+	tempFile, err := os.CreateTemp("", "temp")
 	require.NoError(t, err, "Failed to create temp file")
 	tempFile.Close()
-	require.NoError(t, ioutil.WriteFile(tempFile.Name(), []byte(contents), 0666),
+	require.NoError(t, os.WriteFile(tempFile.Name(), []byte(contents), 0666),
 		"Write temp file failed")
 	return tempFile.Name()
 }
 
 func verifyFileContents(filename, expected string) error {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -243,7 +242,7 @@ func copyFile(src, dst string) error {
 
 // setupDirectory creates a temporary directory.
 func setupDirectory(thriftFile string) (string, error) {
-	tempDir, err := ioutil.TempDir("", "thrift-gen")
+	tempDir, err := os.MkdirTemp("", "thrift-gen")
 	if err != nil {
 		return "", err
 	}
@@ -287,7 +286,7 @@ func createAdditionalTestFile(thriftFile, tempDir string) error {
 }
 
 func checkDirectoryFiles(dir string, n int) error {
-	dirContents, err := ioutil.ReadDir(dir)
+	dirContents, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}

--- a/thrift/thrift-gen/gopath_test.go
+++ b/thrift/thrift-gen/gopath_test.go
@@ -21,7 +21,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -37,13 +36,13 @@ func getFakeFS(t *testing.T) string {
 		"src/pkg2/sub/ringpop.thriftgen",
 	}
 
-	tempDir, err := ioutil.TempDir("", "thriftgen")
+	tempDir, err := os.MkdirTemp("", "thriftgen")
 	require.NoError(t, err, "TempDir failed")
 
 	for _, f := range files {
 		require.NoError(t, os.MkdirAll(filepath.Join(tempDir, filepath.Dir(f)), 0770),
 			"Failed to create directory structure for %v", f)
-		require.NoError(t, ioutil.WriteFile(filepath.Join(tempDir, f), nil, 0660),
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, f), nil, 0660),
 			"Failed to create dummy file")
 	}
 	return tempDir

--- a/thrift/thrift-gen/template.go
+++ b/thrift/thrift-gen/template.go
@@ -27,7 +27,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"text/template"
 )
@@ -61,7 +61,7 @@ func parseTemplateFile(file string) (*Template, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadFile(file)
+	bytes, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %q: %v", file, err)
 	}
@@ -97,7 +97,7 @@ func (t *Template) execute(outputFile string, td TemplateData) error {
 	}
 
 	generated := cleanGeneratedCode(buf.Bytes())
-	if err := ioutil.WriteFile(outputFile, generated, 0660); err != nil {
+	if err := os.WriteFile(outputFile, generated, 0660); err != nil {
 		return fmt.Errorf("cannot write output file %q: %v", outputFile, err)
 	}
 


### PR DESCRIPTION
io/ioutil was deprecated in go 1.16,
https://pkg.go.dev/io/ioutil