### PR TITLE
Expose `inbound.cancels.{requested,honored}` metrics

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -522,8 +522,9 @@ func TestServerClientCancellation(t *testing.T) {
 		_, _, _, err := raw.Call(ctx, ts.Server(), ts.HostPort(), ts.ServiceName(), "ctxWait", nil, nil)
 		assert.Equal(t, ErrRequestCancelled, err, "client call result")
 
-		serverStats.Expected.IncCounter("inbound.cancels.requested", ts.Server().StatsTags(), 1)
-		serverStats.Expected.IncCounter("inbound.cancels.honored", ts.Server().StatsTags(), 1)
+		statsTags := ts.Server().StatsTags()
+		serverStats.Expected.IncCounter("inbound.cancels.requested", statsTags, 1)
+		serverStats.Expected.IncCounter("inbound.cancels.honored", statsTags, 1)
 
 		calls := relaytest.NewMockStats()
 		calls.Add(ts.ServiceName(), ts.ServiceName(), "ctxWait").Failed("canceled").End()

--- a/inbound.go
+++ b/inbound.go
@@ -144,12 +144,16 @@ func (c *Connection) handleCallReqContinue(frame *Frame) bool {
 }
 
 func (c *Connection) handleCancel(frame *Frame) bool {
+	c.statsReporter.IncCounter("inbound.cancels.requested", c.commonStatsTags, 1)
+
 	if !c.opts.PropagateCancel {
 		if c.log.Enabled(LogLevelDebug) {
 			c.log.Debugf("Ignoring cancel for %v", frame.Header.ID)
 		}
 		return true
 	}
+
+	c.statsReporter.IncCounter("inbound.cancels.honored", c.commonStatsTags, 1)
 
 	c.inbound.handleCancel(frame)
 

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -400,6 +400,10 @@ func (ts *TestServer) verify(ch *tchannel.Channel) {
 	assert.NoError(ts, errs, "Verification failed. Channel state:\n%v", IntrospectJSON(ch, nil /* opts */))
 }
 
+func (ts *TestServer) AddPostFn(fn func()) {
+	ts.postFns = append(ts.postFns, fn)
+}
+
 func (ts *TestServer) post() {
 	if !ts.Failed() {
 		for _, ch := range ts.channels {

--- a/testutils/test_server.go
+++ b/testutils/test_server.go
@@ -400,6 +400,7 @@ func (ts *TestServer) verify(ch *tchannel.Channel) {
 	assert.NoError(ts, errs, "Verification failed. Channel state:\n%v", IntrospectJSON(ch, nil /* opts */))
 }
 
+// AddPostFn registers a function that will be executed after channels are closed.
 func (ts *TestServer) AddPostFn(fn func()) {
 	ts.postFns = append(ts.postFns, fn)
 }


### PR DESCRIPTION
This commit adds `inbound.cancels.requested` and `inbound.cancels.honored` metrics. The [documentation mentions these metrics](https://tchannel.readthedocs.io/en/latest/metrics/#inboundcancelsrequested), but they were not yet implemented.