### PR TITLE
Fix skip map value without depth limit

### DIFF
--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
@@ -143,7 +143,10 @@ func Skip(self TProtocol, fieldType TType, maxDepth int) (err error) {
 			if err != nil {
 				return err
 			}
-			self.Skip(valueType)
+			err = Skip(self, valueType, maxDepth-1)
+			if err != nil {
+				return err
+			}
 		}
 		return self.ReadMapEnd()
 	case SET:


### PR DESCRIPTION
Fix skip map value without depth limit.

The [vendored apache thrift library](https://github.com/uber/tchannel-go/tree/dev/thirdparty/github.com/apache/thrift/lib/go/thrift) is vulnerable to DoS: incorrect thrift message would cause 100% CPU utilization by the processing goroutine.

The issue [was addressed in the apache/thrift](https://github.com/apache/thrift/pull/2461/commits/63e5b0cf166b458ce52a056a6b20b1b107ac548e) library, but the fix is not available in tchannel-go due to vendored old version. This PR applied this fix to tchannel-go.

Also confirmed other types of collection type (list, map key, and structs) already have the same logic. 