### PR TITLE
Fix protocol and add test

### DIFF
--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
@@ -173,6 +173,8 @@ func Skip(self TProtocol, fieldType TType, maxDepth int) (err error) {
 			}
 		}
 		return self.ReadListEnd()
+	default:
+		return NewTProtocolExceptionWithType(INVALID_DATA, fmt.Errorf("Unknown data type %d", fieldType))
 	}
 	return nil
 }

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
@@ -21,6 +21,7 @@ package thrift
 
 import (
 	"errors"
+	"fmt"
 )
 
 const (

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol.go
@@ -88,7 +88,7 @@ func SkipDefaultDepth(prot TProtocol, typeId TType) (err error) {
 
 // Skips over the next data element from the provided input TProtocol object.
 func Skip(self TProtocol, fieldType TType, maxDepth int) (err error) {
-	
+
     if maxDepth <= 0 {
 		return NewTProtocolExceptionWithType( DEPTH_LIMIT, errors.New("Depth limit exceeded"))
 	}

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol_test.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/protocol_test.go
@@ -477,3 +477,88 @@ func ReadWriteBinary(t testing.TB, p TProtocol, trans TTransport) {
 		}
 	}
 }
+
+func UnmatchedBeginEndProtocolTest(t *testing.T, protocolFactory TProtocolFactory) {
+	// NOTE: not all protocol implementations do strict state check to
+	// return an error on unmatched Begin/End calls.
+	// This test is only meant to make sure that those unmatched Begin/End
+	// calls won't cause panic. There's no real "test" here.
+	trans := NewTMemoryBuffer()
+	t.Run("Read", func(t *testing.T) {
+		t.Run("Message", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.ReadMessageEnd()
+			p.ReadMessageEnd()
+		})
+		t.Run("Struct", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.ReadStructEnd()
+			p.ReadStructEnd()
+		})
+		t.Run("Field", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.ReadFieldEnd()
+			p.ReadFieldEnd()
+		})
+		t.Run("Map", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.ReadMapEnd()
+			p.ReadMapEnd()
+		})
+		t.Run("List", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.ReadListEnd()
+			p.ReadListEnd()
+		})
+		t.Run("Set", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.ReadSetEnd()
+			p.ReadSetEnd()
+		})
+	})
+	t.Run("Write", func(t *testing.T) {
+		t.Run("Message", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.WriteMessageEnd()
+			p.WriteMessageEnd()
+		})
+		t.Run("Struct", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.WriteStructEnd()
+			p.WriteStructEnd()
+		})
+		t.Run("Field", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.WriteFieldEnd()
+			p.WriteFieldEnd()
+		})
+		t.Run("Map", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.WriteMapEnd()
+			p.WriteMapEnd()
+		})
+		t.Run("List", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.WriteListEnd()
+			p.WriteListEnd()
+		})
+		t.Run("Set", func(t *testing.T) {
+			trans.Reset()
+			p := protocolFactory.GetProtocol(trans)
+			p.WriteSetEnd()
+			p.WriteSetEnd()
+		})
+	})
+	trans.Close()
+}


### PR DESCRIPTION
For `Skip()`, if no type is recognized in switch statement, the function returns nil before. This PR fixed it to return an error.

This PR also adds a test for protocol, which follows [apache thrift library](https://github.com/apache/thrift/blob/master/lib/go/thrift/protocol_test.go). 

The original fix already existed in [upstream](https://github.com/apache/thrift/blob/master/lib/go/thrift/protocol.go#L186)