### PR TITLE
Fix span leak for inbound & outbound

### DIFF
--- a/json/call.go
+++ b/json/call.go
@@ -120,6 +120,7 @@ func (c *Client) Call(ctx Context, method string, arg, resp interface{}) error {
 		if err != nil {
 			return err
 		}
+		defer call.Response().Done()
 
 		isOK, errAt, err = makeCall(call, headers, arg, &respHeaders, resp, &respErr)
 		return err
@@ -157,6 +158,7 @@ func CallPeer(ctx Context, peer *tchannel.Peer, serviceName, method string, arg,
 	if err != nil {
 		return err
 	}
+	defer call.Response().Done()
 
 	return wrapCall(ctx, call, method, arg, resp)
 }
@@ -167,6 +169,7 @@ func CallSC(ctx Context, sc *tchannel.SubChannel, method string, arg, resp inter
 	if err != nil {
 		return err
 	}
+	defer call.Response().Done()
 
 	return wrapCall(ctx, call, method, arg, resp)
 }

--- a/raw/call.go
+++ b/raw/call.go
@@ -78,6 +78,7 @@ func Call(ctx context.Context, ch *tchannel.Channel, hostPort string, serviceNam
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	defer call.Response().Done()
 
 	return WriteArgs(call, arg2, arg3)
 }
@@ -90,6 +91,7 @@ func CallSC(ctx context.Context, sc *tchannel.SubChannel, method string, arg2, a
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	defer call.Response().Done()
 
 	return WriteArgs(call, arg2, arg3)
 }
@@ -115,6 +117,7 @@ func CallV2(ctx context.Context, sc *tchannel.SubChannel, cArgs CArgs) (*CRes, e
 	if err != nil {
 		return nil, err
 	}
+	defer call.Response().Done()
 
 	arg2, arg3, res, err := WriteArgs(call, cArgs.Arg2, cArgs.Arg3)
 	if err != nil {

--- a/thrift/client.go
+++ b/thrift/client.go
@@ -143,6 +143,7 @@ func (c *client) Call(ctx Context, thriftService, methodName string, req, resp t
 		if err != nil {
 			return err
 		}
+		defer call.Response().Done()
 
 		if err := writeArgs(call, headers, req); err != nil {
 			return err

--- a/thrift/server_test.go
+++ b/thrift/server_test.go
@@ -1,4 +1,4 @@
-package thrift
+package thrift_test
 
 import (
 	"errors"
@@ -9,6 +9,7 @@ import (
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
 	athrift "github.com/uber/tchannel-go/thirdparty/github.com/apache/thrift/lib/go/thrift"
+	. "github.com/uber/tchannel-go/thrift"
 )
 
 var errIO = errors.New("IO Error")


### PR DESCRIPTION
## Problem

Span leak is a issue in observability tracing where a span is started, but is not finished. The span will not be sent to tracing backend if it is not finished, hence causing incomplete traces.
```
span := tracer.StartSpan(...)
...
span.Finish()   // span leak happens when this line is not executed.
```

Internally at Uber, we fond incomplete traces from time to time due to span leak caused in tchannel-go library. In the happy path, the span is properly finished, but the span leak issue in tchannel-go happens in error path when a function early returns with error.   
E.g. 
https://github.com/uber/tchannel-go/blob/af146f5a54ac5787563a6857ed9b6ff26394f0ca/thrift/client.go#L139-L152
In above code snippet, A span is created within `c.startCall`, and is finished within `readResponse` when `reader.Close()` is executed. If there is an error occurred in `writeArgs`, then the span leak happens.

This PR is to fix the span leak issue.


## Change Summary
1. Add span component tag following the [OpenTracing semantic conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md) to indicate the software package that created spans.
2. For inbound:
  2.1.  Add `finishSpanWithOptions` method that allows `span.Finish()` to be invoked many times in `InboundCallResponse`.
  2.2 . Use `finishSpanWithOptions` in `dispatchInbound` to always try to finish a span after the handler is called.
3. For outbound:
  3.1.  Add `finishSpanWithOptions` in `OutboundCallResponse` similar to inbound case
  3.2.  Use `finishSpanWithOptions` json, thrift and raw clients.


## Next
At Uber, YARPC ([yarpc-go](https://github.com/yarpc/yarpc-go)) is often used as a umbrella RPC framework with gRPC, TChannel and HTTP as transports.  When YARPC is used with TChannel, the span leak issue does also exist. 

With this PR, the span leak in inbound is expected to be fixed for YARPC as well, but for outbound, we need to add `defer call.Response().Done` [here](https://github.com/yarpc/yarpc-go/blob/1597f032793ab9575e6e9be5c2308264616b4a0b/transport/tchannel/outbound.go#L146) in yarpc-go after this PR is merged.  


