### PR TITLE
Add component tag to tracing spans

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -38,6 +38,8 @@ import (
 // NB: the string value is what's actually shared between implementations
 const zipkinSpanFormat = "zipkin-span-format"
 
+const componentName = "tchannel-go"
+
 // Span is an internal representation of Zipkin-compatible OpenTracing Span.
 // It is used as OpenTracing inject/extract Carrier with ZipkinSpanFormat.
 type Span struct {
@@ -151,6 +153,7 @@ func (c *Connection) startOutboundSpan(ctx context.Context, serviceName, methodN
 	}
 	ext.SpanKindRPCClient.Set(span)
 	ext.PeerService.Set(span, serviceName)
+	ext.Component.Set(span, componentName)
 	c.setPeerHostPort(span)
 	span.SetTag("as", call.callReq.Headers[ArgScheme])
 	var injectable injectableSpan
@@ -214,6 +217,7 @@ func (c *Connection) extractInboundSpan(callReq *callReq) opentracing.Span {
 	span := c.Tracer().StartSpan(operationName, ext.RPCServerOption(spanCtx))
 	span.SetTag("as", callReq.Headers[ArgScheme])
 	ext.PeerService.Set(span, callReq.Headers[CallerName])
+	ext.Component.Set(span, componentName)
 	c.setPeerHostPort(span)
 	return span
 }
@@ -252,6 +256,7 @@ func ExtractInboundSpan(ctx context.Context, call *InboundCall, headers map[stri
 		}
 		span = tracer.StartSpan(call.MethodString(), ext.RPCServerOption(parent))
 		ext.PeerService.Set(span, call.CallerName())
+		ext.Component.Set(span, componentName)
 		span.SetTag("as", string(call.Format()))
 		call.conn.setPeerHostPort(span)
 		call.Response().span = span

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -166,6 +166,8 @@ func TestTracingSpanAttributes(t *testing.T) {
 		assert.NotNil(t, child.Tag("peer.ipv4"))
 		assert.NotNil(t, parent.Tag("peer.port"))
 		assert.NotNil(t, child.Tag("peer.port"))
+		assert.Equal(t, "tchannel-go", parent.Tag("component"))
+		assert.Equal(t, "tchannel-go", child.Tag("component"))
 	})
 }
 


### PR DESCRIPTION
This PR is making a minor change to add span component tag to tracing spans. According to the [OpneTracing sematic conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md), the component tag indicates the library that created the spans. At Uber, It is quite useful for the tracing team to understand the span creation distribution among libraries in order to optimize the operational cost.
> The software package, framework, library, or module that generated the associated Span. E.g., "grpc", "django", "JDBI". 