### PR TITLE
Fix compile issue on FreeBSD 14

### DIFF
--- a/sockio_bsd.go
+++ b/sockio_bsd.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd netbsd openbsd solaris
+
+package tchannel
+
+import "golang.org/x/sys/unix"
+
+func getSendQueueLen(fd uintptr) (int, error) {
+	return unix.IoctlGetInt(int(fd), unix.TIOCOUTQ)
+}


### PR DESCRIPTION
This PR fixes compilation fail on FreeBSD 14, described on [issue by hxw](https://github.com/uber/tchannel-go/issues/914) The problem is, that there's no getSendQueueLen function defined for bsd platform, which causes compile failure. The fix adds new, sockio_bsd file with corresponding function implementation and build tags.