### PR TITLE
Fix compile issue on MacOS

### DIFF
--- a/sockio_bsd.go
+++ b/sockio_bsd.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd netbsd openbsd solaris
+//go:build aix || dragonfly || freebsd || netbsd || openbsd || solaris
+// +build aix dragonfly freebsd netbsd openbsd solaris
 
 package tchannel
 


### PR DESCRIPTION
This PR fixes compilation fail on MacOS(darwin), that occurrs after fixing the FreeBSD 14 compile issue described on [issue by hxw](https://github.com/uber/tchannel-go/issues/914) The problem is, that now there are two getSendQueueLen functions defined for darwin platform, which causes compile failure. The fix removes darwin build tag from sockio_bsd file.