### PR TITLE
Fix serversocket addr race condition

### DIFF
--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
@@ -69,15 +69,12 @@ func (p *TServerSocket) Listen() error {
 func (p *TServerSocket) Accept() (TTransport, error) {
 	p.mu.RLock()
 	interrupted := p.interrupted
+	listener := p.listener
 	p.mu.RUnlock()
 
 	if interrupted {
 		return nil, errTransportInterrupted
 	}
-
-	p.mu.Lock()
-	listener := p.listener
-	p.mu.Unlock()
 	if listener == nil {
 		return nil, NewTTransportException(NOT_OPEN, "No underlying server socket")
 	}

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
@@ -98,7 +98,7 @@ func (p *TServerSocket) Open() error {
 func (p *TServerSocket) Addr() net.Addr {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	if p.IsListening() != nil {
+	if p.IsListening() {
 		return p.listener.Addr()
 	}
 	return p.addr

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
@@ -26,12 +26,12 @@ import (
 )
 
 type TServerSocket struct {
-	listener      net.Listener
 	addr          net.Addr
 	clientTimeout time.Duration
 
-	// Protects the interrupted value to make it thread safe.
+	// Protects the listener and interrupted fields to make them thread safe.
 	mu          sync.RWMutex
+	listener    net.Listener
 	interrupted bool
 }
 
@@ -96,7 +96,9 @@ func (p *TServerSocket) Open() error {
 }
 
 func (p *TServerSocket) Addr() net.Addr {
-	if p.listener != nil {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.IsListening() != nil {
 		return p.listener.Addr()
 	}
 	return p.addr

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
@@ -17,124 +17,117 @@
  * under the License.
  */
 
- package thrift
+package thrift
 
- import (
-	 "net"
-	 "sync"
-	 "time"
- )
- 
- type TServerSocket struct {
-	 addr          net.Addr
-	 clientTimeout time.Duration
- 
-	 // Protects the listener and interrupted fields to make them thread safe.
-	 mu          sync.RWMutex
-	 listener    net.Listener
-	 interrupted bool
- }
- 
- func NewTServerSocket(listenAddr string) (*TServerSocket, error) {
-	 return NewTServerSocketTimeout(listenAddr, 0)
- }
- 
- func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*TServerSocket, error) {
-	 addr, err := net.ResolveTCPAddr("tcp", listenAddr)
-	 if err != nil {
-		 return nil, err
-	 }
-	 return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
- }
- 
- // Creates a TServerSocket from a net.Addr
- func NewTServerSocketFromAddrTimeout(addr net.Addr, clientTimeout time.Duration) *TServerSocket {
-	 return &TServerSocket{addr: addr, clientTimeout: clientTimeout}
- }
- 
- func (p *TServerSocket) Listen() error {
-	 p.mu.Lock()
-	 defer p.mu.Unlock()
-	 if p.IsListening() {
-		 return nil
-	 }
-	 l, err := net.Listen(p.addr.Network(), p.addr.String())
-	 if err != nil {
-		 return err
-	 }
-	 p.listener = l
-	 return nil
- }
- 
- func (p *TServerSocket) Accept() (TTransport, error) {
-	 p.mu.RLock()
-	 interrupted := p.interrupted
-	 p.mu.RUnlock()
- 
-	 if interrupted {
-		 return nil, errTransportInterrupted
-	 }
- 
-	 p.mu.Lock()
-	 listener := p.listener
-	 p.mu.Unlock()
-	 if listener == nil {
-		 return nil, NewTTransportException(NOT_OPEN, "No underlying server socket")
-	 }
- 
-	 conn, err := listener.Accept()
-	 if err != nil {
-		 return nil, NewTTransportExceptionFromError(err)
-	 }
-	 return NewTSocketFromConnTimeout(conn, p.clientTimeout), nil
- }
- 
- // Checks whether the socket is listening.
- func (p *TServerSocket) IsListening() bool {
-	 return p.listener != nil
- }
- 
- // Connects the socket, creating a new socket object if necessary.
- func (p *TServerSocket) Open() error {
-	 p.mu.Lock()
-	 defer p.mu.Unlock()
-	 if p.IsListening() {
-		 return NewTTransportException(ALREADY_OPEN, "Server socket already open")
-	 }
-	 if l, err := net.Listen(p.addr.Network(), p.addr.String()); err != nil {
-		 return err
-	 } else {
-		 p.listener = l
-	 }
-	 return nil
- }
- 
- func (p *TServerSocket) Addr() net.Addr {
-	 p.mu.RLock()
-	 defer p.mu.RUnlock()
-	 if p.IsListening() {
-		 return p.listener.Addr()
-	 }
-	 return p.addr
- }
- 
- func (p *TServerSocket) Close() error {
-	 var err error
-	 p.mu.Lock()
-	 if p.IsListening() {
-		 err = p.listener.Close()
-		 p.listener = nil
-	 }
-	 p.mu.Unlock()
-	 return err
- }
- 
- func (p *TServerSocket) Interrupt() error {
-	 p.mu.Lock()
-	 p.interrupted = true
-	 p.mu.Unlock()
-	 p.Close()
- 
-	 return nil
- }
- 
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+type TServerSocket struct {
+	addr          net.Addr
+	clientTimeout time.Duration
+
+	// Protects the listener and interrupted fields to make them thread safe.
+	mu          sync.RWMutex
+	listener    net.Listener
+	interrupted bool
+}
+
+func NewTServerSocket(listenAddr string) (*TServerSocket, error) {
+	return NewTServerSocketTimeout(listenAddr, 0)
+}
+
+func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*TServerSocket, error) {
+	addr, err := net.ResolveTCPAddr("tcp", listenAddr)
+	if err != nil {
+		return nil, err
+	}
+	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
+}
+
+func (p *TServerSocket) Listen() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.IsListening() {
+		return nil
+	}
+	l, err := net.Listen(p.addr.Network(), p.addr.String())
+	if err != nil {
+		return err
+	}
+	p.listener = l
+	return nil
+}
+
+func (p *TServerSocket) Accept() (TTransport, error) {
+	p.mu.RLock()
+	interrupted := p.interrupted
+	p.mu.RUnlock()
+
+	if interrupted {
+		return nil, errTransportInterrupted
+	}
+
+	p.mu.Lock()
+	listener := p.listener
+	p.mu.Unlock()
+	if listener == nil {
+		return nil, NewTTransportException(NOT_OPEN, "No underlying server socket")
+	}
+	conn, err := listener.Accept()
+	if err != nil {
+		return nil, NewTTransportExceptionFromError(err)
+	}
+	return NewTSocketFromConnTimeout(conn, p.clientTimeout), nil
+}
+
+// Checks whether the socket is listening.
+func (p *TServerSocket) IsListening() bool {
+	return p.listener != nil
+}
+
+// Connects the socket, creating a new socket object if necessary.
+func (p *TServerSocket) Open() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.IsListening() {
+		return NewTTransportException(ALREADY_OPEN, "Server socket already open")
+	}
+	if l, err := net.Listen(p.addr.Network(), p.addr.String()); err != nil {
+		return err
+	} else {
+		p.listener = l
+	}
+	return nil
+}
+
+func (p *TServerSocket) Addr() net.Addr {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.IsListening() {
+		return p.listener.Addr()
+	}
+	return p.addr
+}
+
+func (p *TServerSocket) Close() error {
+	var err error
+	p.mu.Lock()
+	if p.IsListening() {
+		err = p.listener.Close()
+		p.listener = nil
+	}
+	p.mu.Unlock()
+	return err
+}
+
+func (p *TServerSocket) Interrupt() error {
+	p.mu.Lock()
+	p.interrupted = true
+	p.mu.Unlock()
+	p.Close()
+
+	return nil
+}

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
@@ -17,108 +17,124 @@
  * under the License.
  */
 
-package thrift
+ package thrift
 
-import (
-	"net"
-	"sync"
-	"time"
-)
-
-type TServerSocket struct {
-	addr          net.Addr
-	clientTimeout time.Duration
-
-	// Protects the listener and interrupted fields to make them thread safe.
-	mu          sync.RWMutex
-	listener    net.Listener
-	interrupted bool
-}
-
-func NewTServerSocket(listenAddr string) (*TServerSocket, error) {
-	return NewTServerSocketTimeout(listenAddr, 0)
-}
-
-func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*TServerSocket, error) {
-	addr, err := net.ResolveTCPAddr("tcp", listenAddr)
-	if err != nil {
-		return nil, err
-	}
-	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
-}
-
-func (p *TServerSocket) Listen() error {
-	if p.IsListening() {
-		return nil
-	}
-	l, err := net.Listen(p.addr.Network(), p.addr.String())
-	if err != nil {
-		return err
-	}
-	p.listener = l
-	return nil
-}
-
-func (p *TServerSocket) Accept() (TTransport, error) {
-	p.mu.RLock()
-	interrupted := p.interrupted
-	p.mu.RUnlock()
-
-	if interrupted {
-		return nil, errTransportInterrupted
-	}
-	if p.listener == nil {
-		return nil, NewTTransportException(NOT_OPEN, "No underlying server socket")
-	}
-	conn, err := p.listener.Accept()
-	if err != nil {
-		return nil, NewTTransportExceptionFromError(err)
-	}
-	return NewTSocketFromConnTimeout(conn, p.clientTimeout), nil
-}
-
-// Checks whether the socket is listening.
-func (p *TServerSocket) IsListening() bool {
-	return p.listener != nil
-}
-
-// Connects the socket, creating a new socket object if necessary.
-func (p *TServerSocket) Open() error {
-	if p.IsListening() {
-		return NewTTransportException(ALREADY_OPEN, "Server socket already open")
-	}
-	if l, err := net.Listen(p.addr.Network(), p.addr.String()); err != nil {
-		return err
-	} else {
-		p.listener = l
-	}
-	return nil
-}
-
-func (p *TServerSocket) Addr() net.Addr {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if p.IsListening() {
-		return p.listener.Addr()
-	}
-	return p.addr
-}
-
-func (p *TServerSocket) Close() error {
-	defer func() {
-		p.listener = nil
-	}()
-	if p.IsListening() {
-		return p.listener.Close()
-	}
-	return nil
-}
-
-func (p *TServerSocket) Interrupt() error {
-	p.mu.Lock()
-	p.interrupted = true
-	p.Close()
-	p.mu.Unlock()
-
-	return nil
-}
+ import (
+	 "net"
+	 "sync"
+	 "time"
+ )
+ 
+ type TServerSocket struct {
+	 addr          net.Addr
+	 clientTimeout time.Duration
+ 
+	 // Protects the listener and interrupted fields to make them thread safe.
+	 mu          sync.RWMutex
+	 listener    net.Listener
+	 interrupted bool
+ }
+ 
+ func NewTServerSocket(listenAddr string) (*TServerSocket, error) {
+	 return NewTServerSocketTimeout(listenAddr, 0)
+ }
+ 
+ func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*TServerSocket, error) {
+	 addr, err := net.ResolveTCPAddr("tcp", listenAddr)
+	 if err != nil {
+		 return nil, err
+	 }
+	 return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
+ }
+ 
+ // Creates a TServerSocket from a net.Addr
+ func NewTServerSocketFromAddrTimeout(addr net.Addr, clientTimeout time.Duration) *TServerSocket {
+	 return &TServerSocket{addr: addr, clientTimeout: clientTimeout}
+ }
+ 
+ func (p *TServerSocket) Listen() error {
+	 p.mu.Lock()
+	 defer p.mu.Unlock()
+	 if p.IsListening() {
+		 return nil
+	 }
+	 l, err := net.Listen(p.addr.Network(), p.addr.String())
+	 if err != nil {
+		 return err
+	 }
+	 p.listener = l
+	 return nil
+ }
+ 
+ func (p *TServerSocket) Accept() (TTransport, error) {
+	 p.mu.RLock()
+	 interrupted := p.interrupted
+	 p.mu.RUnlock()
+ 
+	 if interrupted {
+		 return nil, errTransportInterrupted
+	 }
+ 
+	 p.mu.Lock()
+	 listener := p.listener
+	 p.mu.Unlock()
+	 if listener == nil {
+		 return nil, NewTTransportException(NOT_OPEN, "No underlying server socket")
+	 }
+ 
+	 conn, err := listener.Accept()
+	 if err != nil {
+		 return nil, NewTTransportExceptionFromError(err)
+	 }
+	 return NewTSocketFromConnTimeout(conn, p.clientTimeout), nil
+ }
+ 
+ // Checks whether the socket is listening.
+ func (p *TServerSocket) IsListening() bool {
+	 return p.listener != nil
+ }
+ 
+ // Connects the socket, creating a new socket object if necessary.
+ func (p *TServerSocket) Open() error {
+	 p.mu.Lock()
+	 defer p.mu.Unlock()
+	 if p.IsListening() {
+		 return NewTTransportException(ALREADY_OPEN, "Server socket already open")
+	 }
+	 if l, err := net.Listen(p.addr.Network(), p.addr.String()); err != nil {
+		 return err
+	 } else {
+		 p.listener = l
+	 }
+	 return nil
+ }
+ 
+ func (p *TServerSocket) Addr() net.Addr {
+	 p.mu.RLock()
+	 defer p.mu.RUnlock()
+	 if p.IsListening() {
+		 return p.listener.Addr()
+	 }
+	 return p.addr
+ }
+ 
+ func (p *TServerSocket) Close() error {
+	 var err error
+	 p.mu.Lock()
+	 if p.IsListening() {
+		 err = p.listener.Close()
+		 p.listener = nil
+	 }
+	 p.mu.Unlock()
+	 return err
+ }
+ 
+ func (p *TServerSocket) Interrupt() error {
+	 p.mu.Lock()
+	 p.interrupted = true
+	 p.mu.Unlock()
+	 p.Close()
+ 
+	 return nil
+ }
+ 

--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/server_socket.go
@@ -47,6 +47,11 @@ func NewTServerSocketTimeout(listenAddr string, clientTimeout time.Duration) (*T
 	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}, nil
 }
 
+// Creates a TServerSocket from a net.Addr
+func NewTServerSocketFromAddrTimeout(addr net.Addr, clientTimeout time.Duration) *TServerSocket {
+	return &TServerSocket{addr: addr, clientTimeout: clientTimeout}
+}
+
 func (p *TServerSocket) Listen() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()


### PR DESCRIPTION
Problem
The Addr() method in server_socket.go was accessing the p.listener field without mutex protection, which could cause data races when multiple goroutines access it concurrently (e.g., one goroutine calling Addr() while another calls Close(), Open(), or Listen()).

Solution
Added RLock()/RUnlock() protection around listener access for thread-safety
Changed direct nil check to use IsListening() method for consistency with the codebase
Follows the same locking pattern used in other methods (Accept(), Close(), Listen(), Open())

Sync with upstream fix https://github.com/apache/thrift/commit/2620a12bfa92dfb808fb9668b3d84a2c56526fc3

Also, this PR includes all the necessary upstream fixes to ensure the file is up-to-date https://github.com/apache/thrift/blob/master/lib/go/thrift/server_socket.go