### PR TITLE
Fix compile error on Darwin platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 ## [1.34.7] - 2026-02-12
 ### Fixed
 
- * Fix compile issue on Darwin (#927)
+ * Fix compile issue on Darwin (#929)
 
 ## [1.34.6] - 2025-01-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 =========
+## [1.34.7] - 2026-02-12
+### Fixed
+
+ * Fix compile issue on Darwin (#927)
 
 ## [1.34.6] - 2025-01-07
 ### Fixed

--- a/sockio_bsd.go
+++ b/sockio_bsd.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd netbsd openbsd solaris
+//go:build aix || dragonfly || freebsd || netbsd || openbsd || solaris
+// +build aix dragonfly freebsd netbsd openbsd solaris
 
 package tchannel
 

--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ package tchannel
 // VersionInfo identifies the version of the TChannel library.
 // Due to lack of proper package management, this version string will
 // be maintained manually.
-const VersionInfo = "1.34.6-dev"
+const VersionInfo = "1.34.7-dev"


### PR DESCRIPTION
This is a fix to desolve build failure on macOS target due to duplicate getSendQueueLen definition after adding sockio_bsd.go

Description

After adding sockio_bsd.go, builds targeting macOS (darwin) fail with a duplicate symbol error:

sockio_darwin.go:28:6: getSendQueueLen redeclared in this block

Root Cause

sockio_bsd.go includes the following build constraint:

//go:build aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris
// +build aix darwin dragonfly freebsd netbsd openbsd solaris
Because darwin is included in this build tag, sockio_bsd.go is compiled when GOOS=darwin.

At the same time, sockio_darwin.go is also compiled (due to the _darwin.go filename suffix).

Both files define:

func getSendQueueLen(...) 

As a result, when building for macOS (including cross-compilation, e.g. arm64 Big Sur bottles), both files are included in the same package, causing a redeclaration error.

Reproduction

Build the package with:

GOOS=darwin GOARCH=arm64 go build ./... 

Expected Behavior

Only one platform-specific implementation of getSendQueueLen should be compiled per target OS.

Suggested Fix

If sockio_bsd.go is not intended to apply to macOS, remove darwin from its build constraint: