### PR TITLE
Remove Darwin tag from bsd file 

### DIFF
--- a/sockio_bsd.go
+++ b/sockio_bsd.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:build aix || darwin || dragonfly || freebsd || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd netbsd openbsd solaris
+//go:build aix || dragonfly || freebsd || netbsd || openbsd || solaris
+// +build aix dragonfly freebsd netbsd openbsd solaris
 
 package tchannel
 


### PR DESCRIPTION
This fix resolve build failure on macOS target due to duplicate getSendQueueLen definition after adding sockio_bsd.go

issue: https://github.com/uber/tchannel-go/issues/929

Fix:  sockio_bsd.go is not intended to apply to macOS, remove darwin from its build constraint: