### PR TITLE
Fix and modernize CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,23 +28,18 @@ jobs:
           LINT: "yes"
 
     steps:
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
-
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
       with:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
 
-    - name: Load cache
-      uses: actions/cache@v1
+    - name: Setup Go
+      uses: actions/setup-go@v7
       with:
-        path: ~/.glide/cache
-        key: ${{ runner.os }}-go-${{ hashFiles('**/glide.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version: ${{ matrix.go }}
+        # Code is checked out into $GOPATH/src (above), not the workspace root,
+        # so point setup-go's module cache at the real go.sum location.
+        cache-dependency-path: '**/go.sum'
 
     - name: Install CI
       run: make install_ci

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test_relay_frame_leaks:
 	PATH=$(BIN):$$PATH go test -parallel=4 $(TEST_ARG) relay_test.go
 
 check_no_test_deps:
-	! go list -json $(PROD_PKGS) | jq -r '.Deps | select ((. | length) > 0) | .[]' | grep -e test -e mock | grep -v '^internal/testlog'
+	! go list -json $(PROD_PKGS) | jq -r '.Deps | select ((. | length) > 0) | .[]' | grep -e test -e mock | grep -vE '^internal/(testlog|synctest)'
 
 benchmark: clean setup $(BIN)/thrift
 	echo Running benchmarks:


### PR DESCRIPTION
Bump actions/checkout (v2 -> v7) and actions/setup-go (v5 -> v7), which drops the deprecated actions/cache@v1 that was auto-failing every run. Run checkout before setup-go and set cache-dependency-path so setup-go module caching finds go.sum (this repo checks out into $GOPATH/src). Remove the dead glide actions/cache step (no glide.lock or vendor dir in the repo).

Exclude the stdlib internal/synctest package from check_no_test_deps: Go 1.25+ pulls it into production deps via sync, and its name trips the test/mock grep -- the same false positive already handled for internal/testlog.